### PR TITLE
Rename commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ bk configure
 bk init
 
 # Triggers a build via the cli
-bk create build
+bk build create
 
 # Opens the current pipeline in your browse
 bk browse
 
 # Lists pipelines that you have access to
-bk list pipelines
+bk pipelines list
 
 # Runs a build entirely locally for development
-bk run local
+bk local run
 ```
 
 ## Development

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -223,14 +223,17 @@ func run(args []string, exit func(int)) {
 	// --------------------------
 	// run command
 
-	runCmdCtx := cli.RunCommandContext{}
-	runCmd := app.Command("run", "Run a pipeline locally").
+	localCmd := app.Command("local", "Operate your local repositories")
+
+	runCmdCtx := cli.LocalRunCommandContext{}
+	runCmd := localCmd.
+		Command("run", "Run a pipeline locally").
 		Default().
 		Action(func(c *kingpin.ParseContext) error {
 			runCmdCtx.Debug = debug
 			runCmdCtx.Keyring = keyringImpl
 			runCmdCtx.TerminalContext = &cli.Terminal{}
-			return cli.RunCommand(runCmdCtx)
+			return cli.LocalRunCommand(runCmdCtx)
 		})
 
 	runCmd.

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -193,32 +193,32 @@ func run(args []string, exit func(int)) {
 		StringVar(&browseCtx.Branch)
 
 	// --------------------------
-	// list command
+	// pipeline commands
 
-	listCmd := app.Command("list", "List various things")
+	pipelineCmd := app.Command("pipeline", "Operate on pipeline")
 
-	listPipelinesCtx := cli.ListPipelinesCommandContext{}
-	listPipelinesCmd := listCmd.
-		Command("pipelines", "List buildkite pipelines").
+	pipelineListCtx := cli.PipelineListCommandContext{}
+	pipelineListCmd := pipelineCmd.
+		Command("list", "List buildkite pipelines").
 		Default().
 		Action(func(c *kingpin.ParseContext) error {
-			listPipelinesCtx.Debug = debug
-			listPipelinesCtx.Keyring = keyringImpl
-			listPipelinesCtx.TerminalContext = &cli.Terminal{}
-			return cli.ListPipelinesCommand(listPipelinesCtx)
+			pipelineListCtx.Debug = debug
+			pipelineListCtx.Keyring = keyringImpl
+			pipelineListCtx.TerminalContext = &cli.Terminal{}
+			return cli.PipelineListCommand(pipelineListCtx)
 		})
 
-	listPipelinesCmd.
+	pipelineListCmd.
 		Flag("fuzzy", "Fuzzy filter pipelines based on org and slug").
-		StringVar(&listPipelinesCtx.Fuzzy)
+		StringVar(&pipelineListCtx.Fuzzy)
 
-	listPipelinesCmd.
+	pipelineListCmd.
 		Flag("url", "Show buildkite.com urls for pipelines").
-		BoolVar(&listPipelinesCtx.ShowURL)
+		BoolVar(&pipelineListCtx.ShowURL)
 
-	listPipelinesCmd.
+	pipelineListCmd.
 		Flag("limit", "How many pipelines to output").
-		IntVar(&listPipelinesCtx.Limit)
+		IntVar(&pipelineListCtx.Limit)
 
 	// --------------------------
 	// run command

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -130,45 +130,45 @@ func run(args []string, exit func(int)) {
 		StringVar(&initCtx.PipelineSlug)
 
 	// --------------------------
-	// create commands
+	// build commands
 
-	createCmd := app.Command("create", "Create various things")
+	buildCmd := app.Command("build", "Operate on builds")
 
-	createBuildCtx := cli.CreateBuildCommandContext{}
-	createBuildCmd := createCmd.
-		Command("build", "Create a new build in a pipeline").
+	buildCreateCtx := cli.BuildCreateCommandContext{}
+	buildCreateCmd := buildCmd.
+		Command("create", "Create a new build in a pipeline").
 		Action(func(c *kingpin.ParseContext) error {
-			createBuildCtx.Debug = debug
-			createBuildCtx.Keyring = keyringImpl
-			createBuildCtx.TerminalContext = &cli.Terminal{}
+			buildCreateCtx.Debug = debug
+			buildCreateCtx.Keyring = keyringImpl
+			buildCreateCtx.TerminalContext = &cli.Terminal{}
 
 			// Default to the current directory
-			if createBuildCtx.PipelineSlug == "" && createBuildCtx.Dir == "" {
-				createBuildCtx.Dir = "."
+			if buildCreateCtx.PipelineSlug == "" && buildCreateCtx.Dir == "" {
+				buildCreateCtx.Dir = "."
 			}
 
-			return cli.CreateBuildCommand(createBuildCtx)
+			return cli.BuildCreateCommand(buildCreateCtx)
 		})
 
-	createBuildCmd.
+	buildCreateCmd.
 		Flag("dir", "Build a specific directory, defaults to the current").
-		ExistingDirVar(&createBuildCtx.Dir)
+		ExistingDirVar(&buildCreateCtx.Dir)
 
-	createBuildCmd.
+	buildCreateCmd.
 		Flag("pipeline", "Build a specific pipeline rather than a directory").
-		StringVar(&createBuildCtx.PipelineSlug)
+		StringVar(&buildCreateCtx.PipelineSlug)
 
-	createBuildCmd.
+	buildCreateCmd.
 		Flag("message", "The message to use for the build").
-		StringVar(&createBuildCtx.Message)
+		StringVar(&buildCreateCtx.Message)
 
-	createBuildCmd.
+	buildCreateCmd.
 		Flag("commit", "The commit to use for the build").
-		StringVar(&createBuildCtx.Commit)
+		StringVar(&buildCreateCtx.Commit)
 
-	createBuildCmd.
+	buildCreateCmd.
 		Flag("branch", "The branch to use for the build").
-		StringVar(&createBuildCtx.Branch)
+		StringVar(&buildCreateCtx.Branch)
 
 	// --------------------------
 	// browse command

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -223,45 +223,41 @@ func run(args []string, exit func(int)) {
 	// --------------------------
 	// run command
 
-	runCmd := app.Command("run", "Run builds")
-
-	runLocalCmdCtx := cli.RunLocalCommandContext{}
-	runLocalCmd := runCmd.
-		Command("local", "Run a pipeline locally").
+	runCmdCtx := cli.RunCommandContext{}
+	runCmd := app.Command("run", "Run a pipeline locally").
 		Default().
 		Action(func(c *kingpin.ParseContext) error {
-			runLocalCmdCtx.Debug = debug
-			runLocalCmdCtx.Keyring = keyringImpl
-			runLocalCmdCtx.TerminalContext = &cli.Terminal{}
-			return cli.RunLocalCommand(runLocalCmdCtx)
+			runCmdCtx.Debug = debug
+			runCmdCtx.Keyring = keyringImpl
+			runCmdCtx.TerminalContext = &cli.Terminal{}
+			return cli.RunCommand(runCmdCtx)
 		})
 
-	runLocalCmd.
+	runCmd.
 		Flag("command", "The initial command to execute").
 		Default("buildkite-agent pipeline upload").
-		StringVar(&runLocalCmdCtx.Command)
+		StringVar(&runCmdCtx.Command)
 
-	runLocalCmd.
+	runCmd.
 		Flag("filter", "A regex to filter step labels with").
-		RegexpVar(&runLocalCmdCtx.StepFilterRegex)
+		RegexpVar(&runCmdCtx.StepFilterRegex)
 
-	runLocalCmd.
+	runCmd.
 		Flag("dry-run", "Show what steps will be executed").
-		BoolVar(&runLocalCmdCtx.DryRun)
+		BoolVar(&runCmdCtx.DryRun)
 
-	runLocalCmd.
+	runCmd.
 		Flag("prompt", "Prompt for each step before executing").
-		BoolVar(&runLocalCmdCtx.Prompt)
+		BoolVar(&runCmdCtx.Prompt)
 
-	runLocalCmd.
+	runCmd.
 		Flag("env", "Environment to pass to the agent").
 		Short('E').
-		StringsVar(&runLocalCmdCtx.Env)
+		StringsVar(&runCmdCtx.Env)
 
-	runLocalCmd.
+	runCmd.
 		Arg("file", "A specific pipeline file to upload").
-		FileVar(&runLocalCmdCtx.File)
-
+		FileVar(&runCmdCtx.File)
 
 	// --------------------------
 	// run the app, parse args

--- a/cmd_build_create.go
+++ b/cmd_build_create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fatih/color"
 )
 
-type CreateBuildCommandContext struct {
+type BuildCreateCommandContext struct {
 	TerminalContext
 	KeyringContext
 
@@ -23,7 +23,7 @@ type CreateBuildCommandContext struct {
 	Message string
 }
 
-func CreateBuildCommand(ctx CreateBuildCommandContext) error {
+func BuildCreateCommand(ctx BuildCreateCommandContext) error {
 	params := buildkiteBuildParams{
 		Branch:  ctx.Branch,
 		Commit:  ctx.Commit,

--- a/cmd_local_run.go
+++ b/cmd_local_run.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/local"
 )
 
-type RunCommandContext struct {
+type LocalRunCommandContext struct {
 	TerminalContext
 	KeyringContext
 
@@ -29,7 +29,7 @@ type RunCommandContext struct {
 	DryRun          bool
 }
 
-func RunCommand(ctx RunCommandContext) error {
+func LocalRunCommand(ctx LocalRunCommandContext) error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 

--- a/cmd_pipeline_list.go
+++ b/cmd_pipeline_list.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sahilm/fuzzy"
 )
 
-type ListPipelinesCommandContext struct {
+type PipelineListCommandContext struct {
 	TerminalContext
 	KeyringContext
 
@@ -18,7 +18,7 @@ type ListPipelinesCommandContext struct {
 	ShowURL bool
 }
 
-func ListPipelinesCommand(ctx ListPipelinesCommandContext) error {
+func PipelineListCommand(ctx PipelineListCommandContext) error {
 	bk, err := ctx.BuildkiteGraphQLClient()
 	if err != nil {
 		return NewExitError(err, 1)

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/local"
 )
 
-type RunLocalCommandContext struct {
+type RunCommandContext struct {
 	TerminalContext
 	KeyringContext
 
@@ -29,7 +29,7 @@ type RunLocalCommandContext struct {
 	DryRun          bool
 }
 
-func RunLocalCommand(ctx RunLocalCommandContext) error {
+func RunCommand(ctx RunCommandContext) error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 

--- a/local/emoji.go
+++ b/local/emoji.go
@@ -2,8 +2,6 @@ package local
 
 // This tool implements the iterm2 image support as described here:
 // http://iterm2.com/images.html
-//
-// Be sure to install iterm2 nightly.
 
 import (
 	"encoding/base64"

--- a/local/server.go
+++ b/local/server.go
@@ -817,7 +817,7 @@ func readRequestInto(r *http.Request, into interface{}) error {
 		panic(err)
 	}
 	defer r.Body.Close()
-	
+
 	return json.Unmarshal(body, &into)
 }
 


### PR DESCRIPTION
I tried a slightly unusual command / sub-command ordering initially, with `<action> <subject>`, but I don't think it works well. Before we hit 1.0 I'm going to revert this to be inline with our other tools:

* `bk create build` to `bk build create`
* `bk list pipelines` to `bk pipeline list`
* `bk local run` to `bk run`