### PR TITLE
Expose more of the keyring options

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -74,11 +74,11 @@ func run(args []string, exit func(int)) {
 		StringVar(&keyringPassDir)
 
 	app.Flag("keyring-pass-cmd", "Name of the pass executable").
-		OverrideDefaultFromEnvar("AWS_VAULT_PASS_CMD").
+		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_PASS_CMD").
 		StringVar(&keyringPassCmd)
 
 	app.Flag("keyring-pass-prefix", "Prefix to prepend to the item path stored in pass").
-		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PREFIX").
+		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_PASS_PREFIX").
 		StringVar(&keyringPassPrefix)
 
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildkite/cli"
 	"github.com/buildkite/cli/graphql"
 	"github.com/fatih/color"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/99designs/keyring"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -39,10 +40,15 @@ func run(args []string, exit func(int)) {
 	}
 
 	var (
-		debug          bool
-		debugGraphQL   bool
-		keyringBackend string
-		keyringImpl    keyring.Keyring
+		debug             bool
+		debugGraphQL      bool
+		keyringBackend    string
+		keyringFileDir    string
+		keyringKeychain   string
+		keyringPassDir    string
+		keyringPassCmd    string
+		keyringPassPrefix string
+		keyringImpl       keyring.Keyring
 	)
 
 	app.Flag("debug", "Show debugging output").
@@ -55,6 +61,26 @@ func run(args []string, exit func(int)) {
 		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_BACKEND").
 		EnumVar(&keyringBackend, backendsAvailable...)
 
+	app.Flag("keyring-file-dir", "Use the file keyring-backend with a specific directory").
+		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_FILE_DIR").
+		StringVar(&keyringFileDir)
+
+	app.Flag("keyring-keychain", "Use the macOS keychain keyring-backend with a specific keychain (defaults to login)").
+		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_KEYCHAIN").
+		StringVar(&keyringKeychain)
+
+	app.Flag("keyring-pass-dir", "Use the pass password manager with a specific directory").
+		OverrideDefaultFromEnvar("BUILDKITE_CLI_KEYRING_PASS_DIR").
+		StringVar(&keyringPassDir)
+
+	app.Flag("keyring-pass-cmd", "Name of the pass executable").
+		OverrideDefaultFromEnvar("AWS_VAULT_PASS_CMD").
+		StringVar(&keyringPassCmd)
+
+	app.Flag("keyring-pass-prefix", "Prefix to prepend to the item path stored in pass").
+		OverrideDefaultFromEnvar("AWS_VAULT_PASS_PREFIX").
+		StringVar(&keyringPassPrefix)
+
 	app.PreAction(func(c *kingpin.ParseContext) (err error) {
 		if debug {
 			keyring.Debug = true
@@ -63,8 +89,52 @@ func run(args []string, exit func(int)) {
 		if debugGraphQL {
 			graphql.DebugHTTP = true
 		}
+
+		// infer keyring backend types if we get certain config
+		if keyringFileDir != "" {
+			keyringBackend = `file`
+		} else if keyringKeychain != "" {
+			keyringBackend = `keychain`
+		} else if keyringPassDir != "" {
+			keyringBackend = `pass`
+		}
+
+		var allowedBackends []keyring.BackendType
+		if keyringBackend != `` {
+			allowedBackends = append(allowedBackends, keyring.BackendType(keyringBackend))
+		}
+
+		// otherwise use one of the defaults
+		if keyringBackend == `` {
+			for _, k := range backendsAvailable {
+				switch keyring.BackendType(k) {
+				// secret-service and kwallet are kind of the worst
+				case keyring.KWalletBackend, keyring.SecretServiceBackend:
+					continue
+				default:
+					allowedBackends = append(allowedBackends, keyring.BackendType(k))
+				}
+			}
+		}
+
+		// default keychain to the login keychain
+		if keyringBackend == `keyring` && keyringKeychain == `` {
+			keyringKeychain = `login`
+		}
+
 		keyringImpl, err = keyring.Open(keyring.Config{
-			ServiceName: "buildkite",
+			ServiceName:              "buildkite",
+			AllowedBackends:          allowedBackends,
+			KeychainName:             keyringKeychain,
+			FileDir:                  "~/.buildkite/keyring/",
+			FilePasswordFunc:         terminalPrompt,
+			PassDir:                  keyringPassDir,
+			PassCmd:                  keyringPassCmd,
+			PassPrefix:               keyringPassPrefix,
+			LibSecretCollectionName:  "buildkite",
+			KWalletAppID:             "buildkite",
+			KWalletFolder:            "buildkite",
+			KeychainTrustApplication: true,
 		})
 		if err != nil {
 			return err
@@ -274,5 +344,14 @@ func run(args []string, exit func(int)) {
 			os.Exit(1)
 		}
 	}
+}
 
+func terminalPrompt(prompt string) (string, error) {
+	fmt.Printf("%s: ", prompt)
+	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+	return string(b), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
-	golang.org/x/crypto v0.0.0-20180527072434-ab813273cd59
+	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
 	golang.org/x/net v0.0.0-20180530034148-89e543239a64 // indirect
 	golang.org/x/oauth2 v0.0.0-20180529203656-ec22f46f877b
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180527072434-ab813273cd59 h1:hk3yo72LXLapY9EXVttc3Z1rLOxT9IuAPPX3GpY2+jo=
 golang.org/x/crypto v0.0.0-20180527072434-ab813273cd59/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180530034148-89e543239a64 h1:otRUcJnCzmletog6NvNtimZZStU31VhmAuuno53i0Nk=
 golang.org/x/net v0.0.0-20180530034148-89e543239a64/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180529203656-ec22f46f877b h1:nCwwlzLoBQhkY/S3CJ2CGAU4pYfR8+5/TPGEHT+p5Nk=


### PR DESCRIPTION
This exposes configuration for setting the path to the `file` backend in keyring, as well as for `pass` and the keychain name for `keychain`. Closes #16.

This also removes `secret-service` and `kwallet` from the defaults. You can select them manually, but not by default. Closes #12.