### PR TITLE
Fix default keychain selection

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -119,7 +119,7 @@ func run(args []string, exit func(int)) {
 		}
 
 		// default keychain to the login keychain
-		if keyringBackend == `keyring` && keyringKeychain == `` {
+		if keyringBackend == `keychain` && keyringKeychain == `` {
 			keyringKeychain = `login`
 		}
 


### PR DESCRIPTION
This fixes a typo; `keyring` is not a valid keyringBackend.