### PR TITLE
Fix spelling of GitHub for configure command

### DIFF
--- a/cmd_configure.go
+++ b/cmd_configure.go
@@ -26,7 +26,7 @@ func ConfigureDefaultCommand(ctx ConfigureCommandContext) error {
 	}
 
 	ctx.Println()
-	ctx.Printf("For now, we will assume you are using Github. " +
+	ctx.Printf("For now, we will assume you are using GitHub. " +
 		"Support for others is coming soon! 😓\n\n")
 
 	if err := ConfigureGithubCommand(ctx); err != nil {
@@ -69,7 +69,7 @@ func ConfigureGithubCommand(ctx ConfigureCommandContext) error {
 		return NewExitError(err, 1)
 	}
 
-	ctx.Printf(color.GreenString("Securely stored Github token! 💪\n"))
+	ctx.Printf(color.GreenString("Securely stored GitHub token! 💪\n"))
 	return nil
 }
 


### PR DESCRIPTION
Noticed while doing `bk configure`:

<img width="1017" alt="Screenshot 2019-04-25 14 16 56" src="https://user-images.githubusercontent.com/1000669/56711216-ce79f380-6764-11e9-83be-598da3b8c228.png">

Background: https://twitter.com/willmanduffy/status/1067614575061856257

Cheers.

