### PR TITLE
Add --env flag to `bk build create`

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -232,6 +232,10 @@ func run(args []string, exit func(int)) {
 		Flag("branch", "The branch to use for the build").
 		StringVar(&buildCreateCtx.Branch)
 
+	buildCreateCmd.
+		Flag("env", "Environment to pass to the build").
+		StringsVar(&buildCreateCtx.Env)
+
 	// --------------------------
 	// browse command
 

--- a/cmd_build_create.go
+++ b/cmd_build_create.go
@@ -21,6 +21,7 @@ type BuildCreateCommandContext struct {
 	Branch  string
 	Commit  string
 	Message string
+	Env     []string
 }
 
 func BuildCreateCommand(ctx BuildCreateCommandContext) error {
@@ -28,6 +29,7 @@ func BuildCreateCommand(ctx BuildCreateCommandContext) error {
 		Branch:  ctx.Branch,
 		Commit:  ctx.Commit,
 		Message: ctx.Message,
+		Env:     ctx.Env,
 	}
 
 	bk, err := ctx.BuildkiteGraphQLClient()
@@ -164,6 +166,7 @@ type buildkiteBuildParams struct {
 	Commit     string
 	Branch     string
 	Message    string
+	Env        []string
 }
 
 func createBuildkiteBuild(client *graphql.Client, params buildkiteBuildParams) (buildkiteBuildDetails, error) {
@@ -182,6 +185,7 @@ func createBuildkiteBuild(client *graphql.Client, params buildkiteBuildParams) (
 			"message":    params.Message,
 			"commit":     params.Commit,
 			"branch":     params.Branch,
+			"env":        params.Env,
 		}})
 	if err != nil {
 		return buildkiteBuildDetails{}, err


### PR DESCRIPTION
For example,

$ bk build create --env ENV1=VAR1 --env ENV2=VAR2