### PR TITLE
Artifact download

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -287,6 +287,27 @@ func run(args []string, exit func(int)) {
 		IntVar(&pipelineListCtx.Limit)
 
 	// --------------------------
+	// artifact commands
+
+	artifactCmd := app.Command("artifact", "Operate on artifacts")
+
+	artifactDownloadCtx := cli.ArtifactDownloadCommandContext{}
+	artifactDownloadCmd := artifactCmd.
+		Command("download", "Download buildkite artifacts").
+		Default().
+		Action(func(c *kingpin.ParseContext) error {
+			artifactDownloadCtx.Debug = debug
+			artifactDownloadCtx.Keyring = keyringImpl
+			artifactDownloadCtx.TerminalContext = &cli.Terminal{}
+			return cli.ArtifactDownloadCommand(artifactDownloadCtx)
+		})
+
+	artifactDownloadCmd.
+		Flag("job", "Job to search for artifacts").
+		Required().
+		StringVar(&artifactDownloadCtx.Job)
+
+	// --------------------------
 	// local command
 
 	localCmd := app.Command("local", "Operate on your local repositories")

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -303,8 +303,11 @@ func run(args []string, exit func(int)) {
 		})
 
 	artifactDownloadCmd.
+		Flag("build", "Build to search for artifacts").
+		StringVar(&artifactDownloadCtx.Build)
+
+	artifactDownloadCmd.
 		Flag("job", "Job to search for artifacts").
-		Required().
 		StringVar(&artifactDownloadCtx.Job)
 
 	// --------------------------

--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -310,6 +310,10 @@ func run(args []string, exit func(int)) {
 		Flag("job", "Job to search for artifacts").
 		StringVar(&artifactDownloadCtx.Job)
 
+	artifactDownloadCmd.
+		Arg("pattern", "Download only artifacts matching the glob patterm").
+		StringVar(&artifactDownloadCtx.Pattern)
+
 	// --------------------------
 	// local command
 

--- a/cmd_artifact_download.go
+++ b/cmd_artifact_download.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/buildkite/cli/graphql"
+)
+
+type ArtifactDownloadCommandContext struct {
+	TerminalContext
+	KeyringContext
+
+	Debug     bool
+	DebugHTTP bool
+
+	Job string
+}
+
+func ArtifactDownloadCommand(ctx ArtifactDownloadCommandContext) error {
+	bk, err := ctx.BuildkiteGraphQLClient()
+	if err != nil {
+		return NewExitError(err, 1)
+	}
+
+	try := ctx.Try()
+	try.Start("Downloading artifacts")
+
+	artifacts, err := findBuildkiteJobArtifacts(bk, ctx.Job)
+	if err != nil {
+		try.Failure(err.Error())
+		return NewExitError(err, 1)
+	}
+
+	total := len(artifacts)
+
+	for _, artifact := range artifacts {
+		err := downloadArtifact(artifact)
+		if err != nil {
+			try.Failure(err.Error())
+			return NewExitError(err, 1)
+		}
+
+		try.Println(fmt.Sprintf("%s (%d bytes)", artifact.Path, artifact.Size))
+	}
+
+	try.Success(fmt.Sprintf("Downloaded %d artifacts", total))
+
+	return nil
+}
+
+const artifactDownloadLimit = 100
+
+type artifact struct {
+	ID          string
+	Path        string
+	Size        int
+	DownloadURL string
+}
+
+func findBuildkiteJobArtifacts(client *graphql.Client, jobID string) ([]artifact, error) {
+	resp, err := client.Do(`
+		query($jobID: ID!, $limit: Int!) {
+			job(uuid: $jobID) {
+				...on JobTypeCommand {
+					artifacts(first: $limit) {
+						count
+						edges {
+							node {
+								id
+								path
+								size
+								downloadURL
+							}
+						}
+					}
+				}
+			}
+		}
+	`, map[string]interface{}{
+		"jobID": jobID,
+		"limit": artifactDownloadLimit,
+	})
+	if err != nil {
+		return []artifact{}, fmt.Errorf("Failed perform GraphQL query: %v", err)
+	}
+
+	var parsedResp struct {
+		Data struct {
+			Job struct {
+				Artifacts struct {
+					Count int `json:"count"`
+					Edges []struct {
+						Node struct {
+							ID          string `json:"id"`
+							Path        string `json:"path"`
+							Size        int    `json:"size"`
+							DownloadURL string `json:"downloadURL"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"artifacts"`
+			} `json:"job"`
+		} `json:"data"`
+	}
+
+	if err = resp.DecodeInto(&parsedResp); err != nil {
+		return []artifact{}, fmt.Errorf("Failed to parse GraphQL response: %v", err)
+	}
+
+	if parsedResp.Data.Job.Artifacts.Count > artifactDownloadLimit {
+		// GraphQL CommandJob.artifacts only supports `first` so cannot paginate
+		return []artifact{}, fmt.Errorf("Too many artifacts\n\nJob has %d artifacts but this tool can only download %d",
+			parsedResp.Data.Job.Artifacts.Count, artifactDownloadLimit)
+	}
+
+	var artifacts []artifact
+
+	for _, artifactEdge := range parsedResp.Data.Job.Artifacts.Edges {
+		artifacts = append(artifacts, artifact{
+			ID:          artifactEdge.Node.ID,
+			Path:        artifactEdge.Node.Path,
+			Size:        artifactEdge.Node.Size,
+			DownloadURL: artifactEdge.Node.DownloadURL,
+		})
+	}
+
+	return artifacts, nil
+}
+
+func downloadArtifact(artifact artifact) error {
+	path := artifact.Path
+
+	dir := filepath.Dir(artifact.Path)
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Get(artifact.DownloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd_artifact_download.go
+++ b/cmd_artifact_download.go
@@ -87,7 +87,7 @@ func ArtifactDownloadCommand(ctx ArtifactDownloadCommandContext) error {
 	return nil
 }
 
-const artifactDownloadLimit = 100
+const artifactDownloadLimit = 500
 
 type artifact struct {
 	ID          string

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
-	github.com/keybase/go-keychain v0.0.0-20180801170200-15d3657f24fc // indirect
+	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/manifoldco/promptui v0.3.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/mattn/go-zglob v0.0.1
 	github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-zglob v0.0.1 h1:xsEx/XUoVlI6yXjqBK062zYhRTZltCNmYPx6v+8DNaY=
+github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9 h1:Y94YB7jrsihrbGSqRNMwRWJ2/dCxr0hdC2oPRohkx0A=
 github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/keybase/go-keychain v0.0.0-20180801170200-15d3657f24fc h1:hsMxTKUbDWam6afrf6TFFBUCCGejgYQzIpwSe14WI4c=
 github.com/keybase/go-keychain v0.0.0-20180801170200-15d3657f24fc/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
+github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d h1:Z+RDyXzjKE0i2sTjZ/b1uxiGtPhFy34Ou/Tk0qwN0kM=
+github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=

--- a/terminal.go
+++ b/terminal.go
@@ -75,6 +75,7 @@ func (t *Terminal) Spinner() Spinner {
 
 type Tryer interface {
 	Start(msg string)
+	Println(msg string)
 	Success(msg string)
 	Failure(msg string)
 }
@@ -85,11 +86,22 @@ func (t *Terminal) Try() Tryer {
 
 type tryPrompt struct {
 	terminal *Terminal
+	message  string
 	spinner  Spinner
 }
 
 func (t *tryPrompt) Start(msg string) {
-	t.terminal.Printf(color.WhiteString("%s: "), msg)
+	t.message = msg
+	t.terminal.Printf(color.WhiteString("%s: ", t.message))
+	t.spinner.Start()
+}
+
+func (t *tryPrompt) Println(msg string) {
+	t.spinner.Stop()
+	fmt.Printf("\r")
+	fmt.Printf(cursor.ClearEntireLine())
+	t.terminal.Println(msg)
+	t.terminal.Printf(color.WhiteString("%s: ", t.message))
 	t.spinner.Start()
 }
 


### PR DESCRIPTION
Adds a `bk artifact download` command which can download artifacts from a job, or a whole build of jobs, and accepts a glob for filtering downloaded artifacts. It has some caveats — I haven't added pagination because it's impossible to paginate the artifacts connection — and globbing is done client-side for the same reason so may not be the same syntax as `buildkite-agent artifact download`. It also needs tests. But it works well enough. Fixes #15.