### PR TITLE
Missing wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Add `--listen-port` to `bk local run`.
+
 ## [v1.0.0](https://github.com/buildkite/cli/tree/v1.0.0) (2019-06-21)
 [Full Changelog](https://github.com/buildkite/cli/compare/v0.5.0...v1.0.0)
 

--- a/cmd_local_run.go
+++ b/cmd_local_run.go
@@ -78,6 +78,7 @@ func LocalRunCommand(ctx LocalRunCommandContext) error {
 		Dir:        wd,
 		Prompt:     ctx.Prompt,
 		StepFilter: ctx.StepFilterRegex,
+		ListenPort: ctx.ListenPort,
 		JobTemplate: local.Job{
 			Commit:           commit,
 			Branch:           branch,


### PR DESCRIPTION
```
$ ~/src/github/cli/bk local run --debug --filter bake-build-capability --meta-data "source-image-family=macos_14.6.06" --listen-port 23456 .buildkite/bakery.steps.yaml
2019/11/28 12:00:13 [keyring] Considering backends: [keychain pass file]
2019/11/28 12:00:13 Serving API on http://127.0.0.1:23456
```

Fixes #70, sorry!