### PR TITLE
Go 1.14; previously a mix 1.11, 1.12 and 1.13

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   agent:
-    image: golang:1.12
+    image: golang:1.14
     volumes:
       - go-module-cache:/go/pkg/mod
       - ../:/cli:cached

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
         build: ./cmd/bk
         import: github.com/buildkite/cli
         targets:
-          - version: "1.11"
+          - version: "1.14"
             goos: linux
             goarch: amd64
             gomodule: "on"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/buildkite/cli
 
+go 1.14
+
 require (
 	github.com/99designs/keyring v1.1.3
 	github.com/ahmetb/go-cursor v0.0.0-20131010032410-8136607ea412
@@ -38,5 +40,3 @@ require (
 	google.golang.org/appengine v1.0.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
-
-go 1.13


### PR DESCRIPTION
Use Go 1.14 in CI, and update `go.mod` to match.