### PR TITLE
CI: compile for macOS and Windows, not just Linux

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,5 +28,11 @@ steps:
         import: github.com/buildkite/cli
         targets:
           - version: "1.14"
+            goos: darwin
+            goarch: amd64
+          - version: "1.14"
             goos: linux
+            goarch: amd64
+          - version: "1.14"
+            goos: windows
             goarch: amd64

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,4 +30,3 @@ steps:
           - version: "1.14"
             goos: linux
             goarch: amd64
-            gomodule: "on"


### PR DESCRIPTION
Compile for macOS and Windows, not just Linux, by adding `darwin` and `windows` GOOS targets.
Also, drop the `gomodule` flag, it's on by default in newer Go.

![image](https://user-images.githubusercontent.com/15759/86564469-a19caf80-bfa9-11ea-9ea4-9526aef8e16a.png)
