### PR TITLE
Pass through Windows env vars in local run

### DIFF
--- a/local/run.go
+++ b/local/run.go
@@ -416,6 +416,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	// Windows requires certain env variables to be present
 	if runtime.GOOS == "windows" {
 		cmd.Env = append(cmd.Env,
+			"APPDATA="+os.Getenv("APPDATA"),
+			"LOCALAPPDATA="+os.Getenv("LOCALAPPDATA"),
+			"HOMEPATH="+os.Getenv("HOMEPATH"),
+			"USERPROFILE="+os.Getenv("USERPROFILE"),
 			"PATH="+os.Getenv("PATH"),
 			"SystemRoot="+os.Getenv("SystemRoot"),
 			"WINDIR="+os.Getenv("WINDIR"),


### PR DESCRIPTION
For all systems `bk local run` already passes through the `HOME` environment variable so that things such as configurations (in `$HOME/.config`), caches (`$HOME/.cache`), etc can be appropriately resolved by processes that run under the local `buildkite-agent`.

On Windows however `HOME` is not used (unless you are in WSL or other Unix-like emulator like `git-bash`). Instead there are a few environment variables that should be used instead:
- `HOMEPATH` / `USERPROFILE` which point to the real "home" directory where documents, etc are stored.
- `APPDATA` where machine-global configurations and app data is stored.
- `LOCALAPPDATA` where user-specific configurations and app data is stored.

We should pass these along as well to the `buildkite-agent` on start.