### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bk configure
 bk browse
 
 # List the pipelines that you have access to
-bk pipelines list
+bk pipeline list
 
 # Triggers a build for the current directory's commit and branch
 bk build create


### PR DESCRIPTION
There is no `bk pipelines`, it should be `bk pipeline`.