### PR TITLE
Amend homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ We'd love to hear any feedback and questions you might have. Please [file an iss
 On macOS, you can install with [Homebrew](https://brew.sh):
 
 ```bash
-brew tap buildkite/cli
-brew install bk
+brew install buildkite/cli/bk
 ````
 
 On all other platforms, download a binary from the [latest GitHub releases](https://github.com/buildkite/cli/releases/latest).


### PR DESCRIPTION
**What?**
🍡   Amends the readme install command from `brew install bk` -> `brew install buildkite/cli/bk` 

**Why?**
🍏   There is now a homebrew/core formula called `bk` - so this is what brew will install without the full path specified in the command. 