### PR TITLE
Prefer /usr/bin/env bash

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 go mod tidy
 

--- a/.buildkite/steps/run-local.sh
+++ b/.buildkite/steps/run-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 bash -c "$(curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh)"
 export PATH="/root/.buildkite-agent/bin:$PATH"


### PR DESCRIPTION
Instead of `/bin/bash`, which may help this script support slightly more
systems (e.g. NixOS), where `/bin/bash` doesn't exist.