### PR TITLE
Remove end year in LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2019 Buildkite Pty Ltd
+Copyright (c) 2014 Buildkite Pty Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is licensed under MIT License since 2014.

fixes #127