### PR TITLE
local: replace "master" with "main"

### DIFF
--- a/local/emoji.go
+++ b/local/emoji.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	appleEmojiMapping     = `https://github.com/buildkite/emojis/raw/master/img-apple-64.json`
-	buildkiteEmojiMapping = `https://github.com/buildkite/emojis/raw/master/img-buildkite-64.json`
-	emojiCachePrefix      = `https://github.com/buildkite/emojis/raw/master/`
+	appleEmojiMapping     = `https://github.com/buildkite/emojis/raw/main/img-apple-64.json`
+	buildkiteEmojiMapping = `https://github.com/buildkite/emojis/raw/main/img-buildkite-64.json`
+	emojiCachePrefix      = `https://github.com/buildkite/emojis/raw/main/`
 )
 
 var emojiRegexp = regexp.MustCompile(`:\w+:`)


### PR DESCRIPTION
The 'master' branch no longer exists so Github returns a 404 for this
URL.

We can fix it here, but any deployments in the field will likely run
into issues, because they will continue to hit the old URL.