### PR TITLE
Update the URLs for emoji data [FDN-548]

### DIFF
--- a/local/emoji.go
+++ b/local/emoji.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	appleEmojiMapping     = `https://github.com/buildkite/emojis/raw/master/img-apple-64.json`
-	buildkiteEmojiMapping = `https://github.com/buildkite/emojis/raw/master/img-buildkite-64.json`
-	emojiCachePrefix      = `https://github.com/buildkite/emojis/raw/master/`
+	appleEmojiMapping     = `https://github.com/buildkite/emojis/raw/main/img-apple-64.json`
+	buildkiteEmojiMapping = `https://github.com/buildkite/emojis/raw/main/img-buildkite-64.json`
+	emojiCachePrefix      = `https://github.com/buildkite/emojis/raw/main/`
 )
 
 var emojiRegexp = regexp.MustCompile(`:\w+:`)


### PR DESCRIPTION
In August 2021 we renamed the development branch in the emojis repo from master to main.

That was relatively smooth from an emojis development perspective, but we didn't realise the cli had master hard coded.

As a quick 'fix' I've re-pushed a master branch to the emojis repo, based on current main. It won't stay up to date though, so this changes the cli to check the main branch instead.

See also: https://github.com/buildkite/emojis/issues/386