### PR TITLE
Go module renamed with /v2 suffix

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/buildkite/cli"
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2"
+	"github.com/buildkite/cli/v2/graphql"
 	"github.com/fatih/color"
 	"golang.org/x/crypto/ssh/terminal"
 

--- a/cmd_artifact_download.go
+++ b/cmd_artifact_download.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/graphql"
 	zglob "github.com/mattn/go-zglob"
 )
 

--- a/cmd_browse.go
+++ b/cmd_browse.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"path/filepath"
 
-	"github.com/buildkite/cli/git"
+	"github.com/buildkite/cli/v2/git"
 	"github.com/skratchdot/open-golang/open"
 )
 

--- a/cmd_build_create.go
+++ b/cmd_build_create.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/buildkite/cli/git"
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/git"
+	"github.com/buildkite/cli/v2/graphql"
 	"github.com/fatih/color"
 )
 

--- a/cmd_configure.go
+++ b/cmd_configure.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/buildkite/cli/config"
-	"github.com/buildkite/cli/github"
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/config"
+	"github.com/buildkite/cli/v2/github"
+	"github.com/buildkite/cli/v2/graphql"
 	"github.com/fatih/color"
 )
 

--- a/cmd_init.go
+++ b/cmd_init.go
@@ -11,9 +11,9 @@ import (
 
 	githubclient "github.com/google/go-github/github"
 
-	"github.com/buildkite/cli/git"
-	"github.com/buildkite/cli/github"
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/git"
+	"github.com/buildkite/cli/v2/github"
+	"github.com/buildkite/cli/v2/graphql"
 	"github.com/fatih/color"
 )
 

--- a/cmd_local_run.go
+++ b/cmd_local_run.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/buildkite/cli/local"
+	"github.com/buildkite/cli/v2/local"
 )
 
 type LocalRunCommandContext struct {

--- a/context.go
+++ b/context.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/buildkite/cli/config"
-	"github.com/buildkite/cli/github"
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/config"
+	"github.com/buildkite/cli/v2/github"
+	"github.com/buildkite/cli/v2/graphql"
 
 	githubclient "github.com/google/go-github/github"
 

--- a/github/remote.go
+++ b/github/remote.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/buildkite/cli/git"
+	"github.com/buildkite/cli/v2/git"
 )
 
 func ParseRemote(gitRemote string) (string, string, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildkite/cli
+module github.com/buildkite/cli/v2
 
 go 1.16
 

--- a/pipelines.go
+++ b/pipelines.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/buildkite/cli/graphql"
+	"github.com/buildkite/cli/v2/graphql"
 )
 
 type pipeline struct {


### PR DESCRIPTION
Since this module is v2.0.0 now, https://go.dev/doc/modules/major-version says we need to reflect that in the module path. This pull request suffixes the module name with `/v2` and updates all internal references to that.

