### PR TITLE
Add fallback to XDG dirs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/buildkite/cli/v2
 go 1.16
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/ahmetb/go-cursor v0.0.0-20131010032410-8136607ea412
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
@@ -27,7 +28,6 @@ require (
 	github.com/sahilm/fuzzy v0.0.5
 	github.com/satori/go.uuid v1.2.0
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
-	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/oauth2 v0.0.0-20180529203656-ec22f46f877b
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/ahmetb/go-cursor v0.0.0-20131010032410-8136607ea412 h1:mjEdk5IWaOUyDfmIScVahVtW56YQ1gBv8RMyHl69Z30=
 github.com/ahmetb/go-cursor v0.0.0-20131010032410-8136607ea412/go.mod h1:6/fH+MoHXlGOc3iy8TSNB4eM1oaBDMs1oxPVN40M3h0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
@@ -69,6 +71,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/local/emoji.go
+++ b/local/emoji.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/adrg/xdg"
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -28,11 +29,16 @@ const (
 var emojiRegexp = regexp.MustCompile(`:\w+:`)
 
 func emojiCachePath() (string, error) {
-	home, err := homedir.Dir()
-	if err != nil {
-		return "", err
+	if home, err := homedir.Dir(); err == nil {
+		file := filepath.Join(home, ".buildkite", "emoji")
+		info, err := os.Stat(file)
+		if err == nil && info.Mode().IsRegular() {
+			return file, nil
+		}
 	}
-	return filepath.Join(home, ".buildkite", "emoji"), nil
+
+	// xdg.CacheFile will create buildkite/emoji dir if it doesn't exist but does not touch/create ignored
+	return xdg.CacheFile("buildkite/emoji/ignored")
 }
 
 type emojiLoader struct {


### PR DESCRIPTION
This PR adds the appropriate xdg base dir as the default/fallback for both config file and emoji cache paths. This uses adrg/xdg which has seemingly good choices for non-linux platforms. Either way though, its only a fallback so if a pre-existing directory is found its used. This will make buildkite/cli more respectful of the user's $HOME dir instead of just dumping yet another hidden directory with mixed config&data that needs to be thought about for backups/sync/ls purposes.