### PR TITLE
Update README.md to add Apple M-series chip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ On macOS, you can install with [Homebrew](https://brew.sh):
 brew install buildkite/cli/bk
 ````
 
+With Apple Silicon, you will need to use the following command:
+
+```bash
+arch -x86_64 brew install buildkite/cli/bk
+```
+
 On all other platforms, download a binary from the [latest GitHub releases](https://github.com/buildkite/cli/releases/latest).
 
 ## 📄 Usage


### PR DESCRIPTION
Ran into this issue trying to install, I always forget you need to do this on the new M-series macs so adding for clarity.