### PR TITLE
Enable async pipeline upload flow

### DIFF
--- a/local/server.go
+++ b/local/server.go
@@ -871,6 +871,7 @@ func (a *apiServer) handleArtifactDownload(w http.ResponseWriter, r *http.Reques
 	artifact, ok := a.artifacts.Load(artifactID)
 	if !ok {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
 	}
 
 	f, err := os.Open(artifact.(Artifact).localPath)

--- a/local/server.go
+++ b/local/server.go
@@ -196,7 +196,11 @@ func (a *apiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case `POST /jobs/:uuid/data/get`:
 		a.handleMetadataGet(w, r, uuidRegexp.FindStringSubmatch(r.URL.Path)[1])
 	case `POST /jobs/:uuid/pipelines`:
-		a.handlePipelineUpload(w, r, uuidRegexp.FindStringSubmatch(r.URL.Path)[1])
+		async, _ := strconv.ParseBool(r.URL.Query().Get("async"))
+		a.handlePipelineUpload(w, r, uuidRegexp.FindStringSubmatch(r.URL.Path)[1], async)
+	case `GET /jobs/:uuid/pipelines/:uuid`:
+		matches := uuidRegexp.FindAllString(r.URL.Path, 2)
+		a.handlePipelineUploadStatus(w, r, matches[0], matches[1])
 	case `POST /jobs/:uuid/annotations`:
 		a.handleAnnotations(w, r, uuidRegexp.FindStringSubmatch(r.URL.Path)[1])
 	case `POST /jobs/:uuid/artifacts`:
@@ -626,7 +630,12 @@ func (a *apiServer) handleLogChunks(w http.ResponseWriter, r *http.Request, jobI
 	})
 }
 
-func (a *apiServer) handlePipelineUpload(w http.ResponseWriter, r *http.Request, jobID string) {
+func (a *apiServer) handlePipelineUpload(
+	w http.ResponseWriter,
+	r *http.Request,
+	jobID string,
+	async bool,
+) {
 	var pur struct {
 		UUID string `json:"uuid"`
 		pipelineUpload
@@ -640,8 +649,32 @@ func (a *apiServer) handlePipelineUpload(w http.ResponseWriter, r *http.Request,
 
 	a.pipelineUploads <- pur.pipelineUpload
 
+	if async {
+		locationURL := r.URL
+		locationURL.RawQuery = ""
+		w.Header().Set("Location", locationURL.JoinPath(pur.UUID).String())
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusAccepted)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(&struct{}{})
+}
+
+type pipelineUploadStatus struct {
+	State   string `json:"state"`
+	Message string `json:"message"`
+}
+
+func (a *apiServer) handlePipelineUploadStatus(
+	w http.ResponseWriter,
+	r *http.Request,
+	jobID string,
+	uuid string,
+) {
+	json.NewEncoder(w).Encode(&pipelineUploadStatus{
+		State: "applied",
+	})
 }
 
 type uploadAction struct {


### PR DESCRIPTION
The API and agent will soon support a pipeline upload where retries will not require re-uploading the same pipeline.
However, the agent CI uses the buildkite cli, and was failing for that PR because the cli did not handle this new async pipeline upload method.

This PR adds the routes that the agent would call and responds in the appropriate way to allow the agent CI job to pass.

Here is the agent CI job that uses the bk cli passing while using the async pipeline upload:
![2023-02-02T23:26:55,935276163+11:00](https://user-images.githubusercontent.com/11096602/216325763-e2c476d2-ea57-43e0-afd6-1c00d37b0cd3.png)
