### PR TITLE
Add XDG path for artifacts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,9 @@ func Path() (string, error) {
 		}
 	}
 
-	// xdg.CacheFile will create buildkite dir if it doesn't exist but does not touch/create config.json
-	return xdg.ConfigFile("buildkite/config.json")
+	// xdg.ConfigFile will create buildkite dir if it doesn't exist but does not touch/create config.json
+	return xdg.ConfigFile(filepath.Join("buildkite", "config.json"))
+}
 }
 
 func EmojiCachePath() (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,22 @@ func Path() (string, error) {
 	// xdg.ConfigFile will create buildkite dir if it doesn't exist but does not touch/create config.json
 	return xdg.ConfigFile(filepath.Join("buildkite", "config.json"))
 }
+
+func ArifactStoragePath() (string, error) {
+	if home, err := homedir.Dir(); err == nil {
+		dir := filepath.Join(home, ".buildkite", "local")
+		if info, err := os.Stat(dir); err == nil && info.Mode().IsDir() {
+			return dir, nil
+		}
+	}
+
+	relPath := filepath.Join("buildkite", "artifacts")
+	// artifacts paths should be 700 to prevent access to other users
+	if err := os.MkdirAll(relPath, 0700); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(xdg.DataHome, relPath), nil
 }
 
 func EmojiCachePath() (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ func Path() (string, error) {
 	return xdg.ConfigFile(filepath.Join("buildkite", "config.json"))
 }
 
-func ArifactStoragePath() (string, error) {
+func ArtifactStoragePath() (string, error) {
 	if home, err := homedir.Dir(); err == nil {
 		dir := filepath.Join(home, ".buildkite", "local")
 		if info, err := os.Stat(dir); err == nil && info.Mode().IsDir() {

--- a/config/config.go
+++ b/config/config.go
@@ -24,16 +24,13 @@ type Config struct {
 
 // Path returns either $BUILDKITE_CLI_CONFIG_FILE, ~/.buildkite/config.json or $XDG_CONFIG_HOME/buildkite/config.json in that order.
 func Path() (string, error) {
-	file := os.Getenv("BUILDKITE_CLI_CONFIG_FILE")
-	if file != "" {
+	if file := os.Getenv("BUILDKITE_CLI_CONFIG_FILE"); file != "" {
 		return file, nil
-
 	}
 
 	if home, err := homedir.Dir(); err == nil {
-		file = filepath.Join(home, ".buildkite", "config.json")
-		info, err := os.Stat(file)
-		if err == nil && info.Mode().IsRegular() {
+		file := filepath.Join(home, ".buildkite", "config.json")
+		if info, err := os.Stat(file); err == nil && info.Mode().IsRegular() {
 			return file, nil
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,22 @@ func Path() (string, error) {
 	return xdg.ConfigFile("buildkite/config.json")
 }
 
+func EmojiCachePath() (string, error) {
+	if home, err := homedir.Dir(); err == nil {
+		dir := filepath.Join(home, ".buildkite", "emoji")
+		if info, err := os.Stat(dir); err == nil && info.Mode().IsDir() {
+			return dir, nil
+		}
+	}
+
+	relPath := filepath.Join("buildkite", "emoji")
+	if err := os.MkdirAll(relPath, 0755); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(xdg.CacheHome, relPath), nil
+}
+
 // Open opens and parses the Config, returns a empty Config if one doesn't exist
 func Open() (*Config, error) {
 	path, err := Path()

--- a/local/emoji.go
+++ b/local/emoji.go
@@ -16,8 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/adrg/xdg"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/buildkite/cli/v2/config"
 )
 
 const (
@@ -28,25 +27,12 @@ const (
 
 var emojiRegexp = regexp.MustCompile(`:\w+:`)
 
-func emojiCachePath() (string, error) {
-	if home, err := homedir.Dir(); err == nil {
-		file := filepath.Join(home, ".buildkite", "emoji")
-		info, err := os.Stat(file)
-		if err == nil && info.Mode().IsRegular() {
-			return file, nil
-		}
-	}
-
-	// xdg.CacheFile will create buildkite/emoji dir if it doesn't exist but does not touch/create ignored
-	return xdg.CacheFile("buildkite/emoji/ignored")
-}
-
 type emojiLoader struct {
 	cache *emojiCache
 }
 
 func newEmojiLoader() (*emojiLoader, error) {
-	cachePath, err := emojiCachePath()
+	cachePath, err := config.EmojiCachePath()
 	if err != nil {
 		return nil, err
 	}

--- a/local/server.go
+++ b/local/server.go
@@ -723,7 +723,7 @@ func (a *apiServer) handleArtifactsUpload(w http.ResponseWriter, r *http.Request
 	}
 	filename := matches[1]
 
-	cacheDir, err := config.ArifactStoragePath()
+	cacheDir, err := config.ArtifactStoragePath()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/local/server.go
+++ b/local/server.go
@@ -18,8 +18,8 @@ import (
 	"sync"
 
 	"github.com/bmatcuk/doublestar"
+	"github.com/buildkite/cli/v2/config"
 	"github.com/fatih/color"
-	homedir "github.com/mitchellh/go-homedir"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -723,7 +723,7 @@ func (a *apiServer) handleArtifactsUpload(w http.ResponseWriter, r *http.Request
 	}
 	filename := matches[1]
 
-	cacheDir, err := artifactCachePath()
+	cacheDir, err := config.ArifactStoragePath()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -881,14 +881,6 @@ func (a *apiServer) ListenAndServe() (string, error) {
 func (a *apiServer) authenticateAgentFromHeader(h http.Header) (string, error) {
 	authToken := strings.TrimPrefix(h.Get(`Authorization`), `Token `)
 	return a.agents.Authenticate(authToken)
-}
-
-func artifactCachePath() (string, error) {
-	home, err := homedir.Dir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".buildkite", "local", "artifacts"), nil
 }
 
 type orderedMapValue struct {


### PR DESCRIPTION
Fallback [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) paths for the config and the emoji cache were introduced in https://github.com/buildkite/cli/pull/135. This extends this to the artifact storage path. So if the path `.buildkite/local` does not exist, artifacts will be stored in `$XDG_DATA_HOME/buildkite/artifacts` instead. This will fall back to `~/.local/share/buildkite/artifacts`.

There is also some code cleanup, and the removal of "ignored" from the emoji cache path.