### PR TITLE
Bump golang to v1.20

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   agent:
-    image: golang:1.16
+    image: golang:1.20
     volumes:
       - go-module-cache:/go/pkg/mod
       - ../:/cli:cached

--- a/.buildkite/local.yml
+++ b/.buildkite/local.yml
@@ -33,18 +33,55 @@ steps:
       [[ \${keys} == "family,size," ]]
 
   - wait
-  - label: "upload artifact"
+
+  - label: upload relative artifact
     command: |
-      echo "hello world" > llamas.txt
+      set -Eeufo pipefail
+
+      trap "rm llamas.txt" EXIT
+
+      echo "relative llamas" > llamas.txt
       buildkite-agent artifact upload llamas.txt
-      rm llamas.txt
+
+      shasum=$(buildkite-agent artifact shasum llamas.txt)
+      expected_shasum=fb60f84c2bd316e18a2f11e4da13684e41a16f31
+      if [[ \$shasum != \$expected_shasum ]]; then
+        echo expected: \$expected_shasum received: \$shasum
+        exit 1
+      fi
+
+  - label: upload absolute artifact
+    command: |
+      set -Eeufo pipefail
+
+      trap "rm /tmp/llamas.txt" EXIT
+
+      echo "absolute llamas" > /tmp/llamas.txt
+      buildkite-agent artifact upload /tmp/llamas.txt
+
+      shasum=$(buildkite-agent artifact shasum tmp/llamas.txt)
+      expected_shasum=9ce999892fbca0da31b2a781b2730ac11a2fc8a2
+      if [[ \$shasum != \$expected_shasum ]]; then
+        echo expected: \$expected_shasum received: \$shasum
+        exit 1
+      fi
 
   - wait
-  - label: "download artifact"
+
+  - label: download relative artifact
     command: |
-      shasum=$(buildkite-agent artifact shasum llamas.txt)
-      [[ \$shasum == "22596363b3de40b06f981fb85d82312e8c0ed511" ]]
+      set -Eeufo pipefail
+
+      trap "rm llamas.txt" EXIT
+
       buildkite-agent artifact download llamas.txt .
-      cat llamas.txt
-      grep "hello world" llamas.txt
-      rm llamas.txt
+      echo "ee756d1e307dc245b0df42f81845a4ff559531bc4cb287e35b15e4115844e903 llamas.txt" | sha256sum --check
+
+  - label: download absolute artifact
+    command: |
+      set -Eeufo pipefail
+
+      trap "rm tmp/llamas.txt" EXIT
+
+      buildkite-agent artifact download tmp/llamas.txt .
+      echo "e14227c78a206decdf9e869aaa2c44f3ff546a8324874e7442ef02b1f41a0099 tmp/llamas.txt" | sha256sum --check

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
     plugins:
       golang-cross-compile#v1.3.0:
         build: ./cmd/bk
-        import: github.com/buildkite/cli
+        import: github.com/buildkite/cli/v2
         targets:
           - version: "1.20.0"
             goos: darwin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: ".buildkite/steps/lint.sh"
     plugins:
       docker#v3.5.0:
-        image: "golang:1.16"
+        image: "golang:1.20"
 
   - name: "Test"
     command: "go test -v -failfast ./..."
@@ -27,18 +27,18 @@ steps:
         build: ./cmd/bk
         import: github.com/buildkite/cli
         targets:
-          - version: "1.16"
+          - version: "1.20.0"
             goos: darwin
             goarch: amd64
-          - version: "1.16"
+          - version: "1.20.0"
             goos: darwin
             goarch: arm64
-          - version: "1.16"
+          - version: "1.20.0"
             goos: linux
             goarch: amd64
-          - version: "1.16"
+          - version: "1.20.0"
             goos: linux
             goarch: arm64
-          - version: "1.16"
+          - version: "1.20.0"
             goos: windows
             goarch: amd64

--- a/go.mod
+++ b/go.mod
@@ -1,28 +1,16 @@
 module github.com/buildkite/cli/v2
 
-go 1.16
+go 1.20
 
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/ahmetb/go-cursor v0.0.0-20131010032410-8136607ea412
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/briandowns/spinner v0.0.0-20170614154858-48dbb65d7bd5
-	github.com/chzyer/logex v1.1.10 // indirect
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
-	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/go-test/deep v1.0.1
-	github.com/golang/protobuf v1.1.0 // indirect
 	github.com/google/go-github v15.0.0+incompatible
-	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
-	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
-	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
-	github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626 // indirect
 	github.com/manifoldco/promptui v0.3.0
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mattn/go-zglob v0.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sahilm/fuzzy v0.0.5
@@ -30,9 +18,25 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/oauth2 v0.0.0-20180529203656-ec22f46f877b
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
+	github.com/golang/protobuf v1.1.0 // indirect
+	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
+	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
+	github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.3 // indirect
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	google.golang.org/appengine v1.0.0 // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/local/server.go
+++ b/local/server.go
@@ -716,7 +716,12 @@ func (a *apiServer) handleArtifactsUpload(w http.ResponseWriter, r *http.Request
 	defer file.Close()
 
 	contentDisposition := header.Header.Get("Content-Disposition")
-	filename := filenameRegexp.FindStringSubmatch(contentDisposition)[1]
+	matches := filenameRegexp.FindStringSubmatch(contentDisposition)
+	if len(matches) < 2 {
+		http.Error(w, "filename missing from Content-Disposition header", http.StatusBadRequest)
+		return
+	}
+	filename := matches[1]
 
 	cacheDir, err := artifactCachePath()
 	if err != nil {

--- a/local/server.go
+++ b/local/server.go
@@ -74,8 +74,8 @@ type jobEnvelope struct {
 }
 
 var (
-	uuidRegexp = regexp.MustCompile(
-		"([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})")
+	uuidRegexp     = regexp.MustCompile("([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})")
+	filenameRegexp = regexp.MustCompile(`filename="(.*?)"`)
 )
 
 type apiServer struct {
@@ -715,14 +715,16 @@ func (a *apiServer) handleArtifactsUpload(w http.ResponseWriter, r *http.Request
 	}
 	defer file.Close()
 
+	contentDisposition := header.Header.Get("Content-Disposition")
+	filename := filenameRegexp.FindStringSubmatch(contentDisposition)[1]
+
 	cacheDir, err := artifactCachePath()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	path := filepath.Join(cacheDir, jobID, header.Filename)
-
+	path := filepath.Join(cacheDir, jobID, filename)
 	if err = os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -752,13 +754,13 @@ func (a *apiServer) handleArtifactsUpload(w http.ResponseWriter, r *http.Request
 	}
 
 	for idx := range job.Artifacts {
-		if header.Filename == job.Artifacts[idx].Path {
+		if filename == job.Artifacts[idx].Path {
 			job.Artifacts[idx].uploaded = true
 			job.Artifacts[idx].localPath = path
 		}
 	}
 
-	fmt.Fprintf(w, "File uploaded successfully: %s", header.Filename)
+	fmt.Fprintf(w, "File uploaded successfully: %s", filename)
 }
 
 func (a *apiServer) handleArtifactsUpdate(w http.ResponseWriter, r *http.Request, jobID string) {


### PR DESCRIPTION
Upgrading to golang 1.20 was not straightforward, as there was a change in how the golang standard library's `"net/http"` package reports an uploaded file's filename in a request. Previously `header.Filename` returned the absolute filename, but now it returns the base of the filename. This is due to a security fix introduced in go 1.17: https://go.dev/doc/go1.17#mime/multipart

Unfortunately, the Buildkite API preserved most of the filename of that was uploaded using its absolute filename, so we have to preserve this behaviour. Fortunately, I manged to recover the absolute filename from the `Content-Disposition` header.

This was not picked up in the tests, as there are no absolute artifact uploads in the test pipeline. This is why the initial commit to bump the versions, [8ad27de](https://github.com/buildkite/cli/pull/141/commits/8ad27de2717202d27a6d6c49b95e547bbad4f512) builds [successfully](https://buildkite.com/buildkite/buildkite-cli/builds/90). However, introducing an absolute upload in [592f4de](https://github.com/buildkite/cli/pull/141/commits/592f4de11be65335ad9977ee277a2dc4564238ef) breaks the [build](https://buildkite.com/buildkite/buildkite-cli/builds/101). This is fixed in the final commit in the manner mentioned in the previous paragraph.