### PR TITLE
Fix TestPipelineParsing flakiness

### DIFF
--- a/local/pipeline_test.go
+++ b/local/pipeline_test.go
@@ -209,12 +209,12 @@ func TestPipelineParsing(t *testing.T) {
 							"echo hello world",
 							"pwd"
 						],
-						"plugins": {
-							"blah-blah/blah#v0.0.1": null,
-							"blah-blah/another#v0.0.1": {
+						"plugins": [
+							{"blah-blah/blah#v0.0.1": null},
+							{"blah-blah/another#v0.0.1": {
 								"my_config":"totes"
-							}
-						}
+							}}
+						]
 					}
 				]
 			}`,


### PR DESCRIPTION
We apparently support three different kinds of plugin configuration in a pipeline (see the command step `UnmarshalJSON` method for details). This fixes the test data to use the form with stable ordering.