### PR TITLE
Init command with checks on existing file.

### DIFF
--- a/pkg/cmd/configure/configure.go
+++ b/pkg/cmd/configure/configure.go
@@ -18,7 +18,7 @@ func NewCmdConfigure(v *viper.Viper) *cobra.Command {
 		Short: "Configure Buildkite API token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// if the token already exists and --force is not used
-			if !force && viper.IsSet(config.APIToken) {
+			if !force && v.IsSet(config.APIToken) {
 				return errors.New("API token already configured. You must use --force.")
 			}
 

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -1,0 +1,55 @@
+package init
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"log"
+	"os"
+)
+
+var (
+	yamlContent = []byte(
+		`steps:
+  - label: "Hello, world! 👋"
+    command: echo "Hello, world!"`,
+	)
+
+	pipelineFile = ".buildkite/pipeline.yaml"
+)
+
+func NewCmdInit(v *viper.Viper) *cobra.Command {
+	if _, err := os.Stat(pipelineFile); err == nil {
+		fmt.Println("🕵️  pipeline.yaml found at .buildkite/pipeline.yaml. You're already good to go!")
+	} else {
+		file, err := os.Create(pipelineFile)
+
+		if err != nil {
+			log.Fatalf("failed creating file: %s", err)
+		}
+
+		defer file.Close()
+		_, err = file.Write(yamlContent)
+
+		if err != nil {
+			log.Fatalf("failed to write to file: %f", err)
+		}
+
+		fmt.Println("✨ Buildkite pipeline successfully initialized 🎉")
+	}
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Args:  cobra.ExactArgs(0),
+		Short: "Initialize Buildkite pipeline directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := os.MkdirAll(".buildkite", 0755)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"github.com/MakeNowJust/heredoc"
 	configureCmd "github.com/buildkite/cli/v3/pkg/cmd/configure"
+	initCmd "github.com/buildkite/cli/v3/pkg/cmd/init"
 	versionCmd "github.com/buildkite/cli/v3/pkg/cmd/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -21,8 +22,9 @@ func NewCmdRoot(viper *viper.Viper, version string) (*cobra.Command, error) {
 		},
 	}
 
-	cmd.AddCommand(versionCmd.NewCmdVersion())
 	cmd.AddCommand(configureCmd.NewCmdConfigure(viper))
+	cmd.AddCommand(initCmd.NewCmdInit(viper))
+	cmd.AddCommand(versionCmd.NewCmdVersion())
 
 	return cmd, nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func NewCmdRoot(viper *viper.Viper, version string) (*cobra.Command, error) {
+func NewCmdRoot(v *viper.Viper, version string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "bk <command> <subcommand> [flags]",
 		Short: "Buildkite CLI",
@@ -22,8 +22,8 @@ func NewCmdRoot(viper *viper.Viper, version string) (*cobra.Command, error) {
 		},
 	}
 
-	cmd.AddCommand(configureCmd.NewCmdConfigure(viper))
-	cmd.AddCommand(initCmd.NewCmdInit(viper))
+	cmd.AddCommand(configureCmd.NewCmdConfigure(v))
+	cmd.AddCommand(initCmd.NewCmdInit(v))
 	cmd.AddCommand(versionCmd.NewCmdVersion())
 
 	return cmd, nil


### PR DESCRIPTION
`init` will check to see if a pipeline.yaml file exists in the `.buildkite` directory of the current project. If it does then it won't initialise another one, if it doesn't then it will create the `.buildkite` dir and a stubbed `pipeline.yaml` file.

Happy for any changes to be made to this that are desired.