### PR TITLE
SUP-1652: Filterable `bk agent list` via REST API query parameters

### DIFF
--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -94,7 +94,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "", "Filter agents by their name")
 	cmd.Flags().StringVar(&version, "version", "", "Filter agents by their agent version")
-	cmd.Flags().StringVar(&version, "hostname", "", "Filter agents by their hostname")
+	cmd.Flags().StringVar(&hostname, "hostname", "", "Filter agents by their hostname")
 
 	return &cmd
 }

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -13,6 +14,8 @@ import (
 )
 
 func NewCmdAgentList(f *factory.Factory) *cobra.Command {
+	var name, version, hostname string
+
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "list",
@@ -23,7 +26,17 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := io.NewPendingCommand(func() tea.Msg {
-				agents, _, err := f.RestAPIClient.Agents.List(f.Config.Organization, nil)
+				var alo buildkite.AgentListOptions
+
+				if name != "" || version != "" || hostname != "" {
+					alo = buildkite.AgentListOptions{
+						Name:     name,
+						Version:  version,
+						Hostname: hostname,
+					}
+				}
+
+				agents, _, err := f.RestAPIClient.Agents.List(f.Config.Organization, &alo)
 				if err != nil {
 					return err
 				}
@@ -72,6 +85,10 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 			return err
 		},
 	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Filter agents by their name")
+	cmd.Flags().StringVar(&version, "version", "", "Filter agents by their agent version")
+	cmd.Flags().StringVar(&version, "hostname", "", "Filter agents by their hostname")
 
 	return &cmd
 }


### PR DESCRIPTION
This change adds three optional flags (`name`, `hostname` and `version`) that are passed through to the REST API client in the CLI as `AgentListOptions` (query parameters) when performing the `List` function to obtain a list of respective agents server-side. 

I've also added the hostname/version to the outputted table for easier viewing of the agents that matched the filtering, and adjusted the column width calculation for the table for easier maintaining.