### PR TITLE
Resolve project pipeline

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -1,0 +1,1 @@
+pipeline: cli

--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -1,1 +1,0 @@
-pipeline: cli

--- a/go.mod
+++ b/go.mod
@@ -53,5 +53,6 @@ require (
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	V            ViperConfig
 }
 
+type ProjectConfig struct {
+	Pipeline string `yaml:"pipeline"`
+}
+
 type ViperConfig interface {
 	Set(string, interface{})
 	GetStringMap(string) map[string]interface{}
@@ -69,4 +73,29 @@ func ConfigFile() string {
 		path = filepath.Join(c, ".config", configFilePath)
 	}
 	return path
+}
+
+func LoadProjectConfig() (*ProjectConfig, error) {
+	var configFile string
+	// Check for both .yaml and .yml extensions
+	if _, err := os.Stat("bk.yaml"); err == nil {
+		configFile = "bk.yaml"
+	} else if _, err := os.Stat("bk.yml"); err == nil {
+		configFile = "bk.yml"
+	} else {
+		return nil, err
+	}
+
+	yamlFile, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,10 +82,10 @@ func LoadProjectConfig() (*ProjectConfig, error) {
 	projectConfig := &ProjectConfig{}
 
 	// Check for both .yaml and .yml extensions
-	if _, err := os.Stat("bk.yaml"); err == nil {
-		configFile = "bk.yaml"
-	} else if _, err := os.Stat("bk.yml"); err == nil {
-		configFile = "bk.yml"
+	if _, err := os.Stat("buildkite.yaml"); err == nil {
+		configFile = "buildkite.yaml"
+	} else if _, err := os.Stat("buildkite.yml"); err == nil {
+		configFile = "buildkite.yml"
 	}
 
 	if configFile != "" {
@@ -112,7 +112,34 @@ func LoadProjectConfig() (*ProjectConfig, error) {
 		}
 
 		projectConfig.Pipeline = filepath.Base(dir)
+
+		return writePipelineToBuildkiteYAML(projectConfig)
 	}
+
+	return projectConfig, nil
+}
+
+func writePipelineToBuildkiteYAML(projectConfig *ProjectConfig) (*ProjectConfig, error) {
+	configFilePath := "buildkite.yaml"
+
+	// Check if buildkite.yaml already exists
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		// The file does not exist; proceed to create and write to it
+		configData := map[string]interface{}{
+			"pipeline": projectConfig.Pipeline,
+		}
+
+		data, err := yaml.Marshal(&configData)
+		if err != nil {
+			return projectConfig, err
+		}
+
+		err = os.WriteFile(configFilePath, data, 0644)
+		if err != nil {
+			return projectConfig, err
+		}
+	}
+	// If the file exists, do nothing
 
 	return projectConfig, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,7 +143,7 @@ func writePipelineToBuildkiteYAML(projectConfig *ProjectConfig) (*ProjectConfig,
 	}
 
 	// Write or overwrite the buildkite.yaml file with the updated content
-	err = os.WriteFile(configFilePath, data, 0644)
+	err = os.WriteFile(configFilePath, data, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -22,12 +22,14 @@ type Factory struct {
 func New(version string) *Factory {
 	factoryConfig := loadFromViper()
 	client := httpClient(version, factoryConfig)
+	projectConfig, _ := config.LoadProjectConfig()
+
 	return &Factory{
 		Config:        factoryConfig,
 		HttpClient:    client,
 		RestAPIClient: buildkite.NewClient(client),
 		Version:       version,
-		ProjectConfig: config.LoadProjectConfig(),
+		ProjectConfig: projectConfig,
 	}
 }
 

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -22,7 +22,11 @@ type Factory struct {
 func New(version string) *Factory {
 	factoryConfig := loadFromViper()
 	client := httpClient(version, factoryConfig)
-	projectConfig, _ := config.LoadProjectConfig()
+	projectConfig, err := config.LoadProjectConfig()
+	
+	if err != nil {
+		fmt.Printf("Error loading project config: %s", err)
+	}
 
 	return &Factory{
 		Config:        factoryConfig,

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -23,7 +23,6 @@ func New(version string) *Factory {
 	factoryConfig := loadFromViper()
 	client := httpClient(version, factoryConfig)
 	projectConfig, err := config.LoadProjectConfig()
-	
 	if err != nil {
 		fmt.Printf("Error loading project config: %s", err)
 	}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -13,19 +13,21 @@ import (
 
 type Factory struct {
 	Config        *config.Config
+	ProjectConfig *config.ProjectConfig
 	HttpClient    *http.Client
 	RestAPIClient *buildkite.Client
 	Version       string
 }
 
 func New(version string) *Factory {
-	config := loadFromViper()
-	client := httpClient(version, config)
+	factoryConfig := loadFromViper()
+	client := httpClient(version, factoryConfig)
 	return &Factory{
-		Config:        config,
+		Config:        factoryConfig,
 		HttpClient:    client,
 		RestAPIClient: buildkite.NewClient(client),
 		Version:       version,
+		ProjectConfig: config.LoadProjectConfig(),
 	}
 }
 

--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -27,12 +27,12 @@ func NewCmdInit(f *factory.Factory) *cobra.Command {
 			}
 
 			pipelineFile := filepath.Join(".buildkite", "pipeline.yaml")
-			err := os.MkdirAll(filepath.Dir(pipelineFile), 0755)
+			err := os.MkdirAll(filepath.Dir(pipelineFile), 0o755)
 			if err != nil {
 				return err
 			}
 
-			err = os.WriteFile(pipelineFile, []byte(defaultPipelineYAML), 0660)
+			err = os.WriteFile(pipelineFile, []byte(defaultPipelineYAML), 0o660)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/init/init_test.go
+++ b/pkg/cmd/init/init_test.go
@@ -24,7 +24,7 @@ func TestFindExistingPipelineFile(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.RemoveAll(dir)
-	_ = os.MkdirAll(filepath.Join(dir, ".buildkite"), 0755)
+	_ = os.MkdirAll(filepath.Join(dir, ".buildkite"), 0o755)
 	f, _ := os.Create(filepath.Join(dir, ".buildkite", "pipeline.yml"))
 	defer f.Close()
 

--- a/pkg/cmd/use/use_test.go
+++ b/pkg/cmd/use/use_test.go
@@ -18,6 +18,7 @@ func (v viperMock) Set(k string, val interface{}) {
 func (v viperMock) GetStringMap(k string) map[string]interface{} {
 	return v.v.GetStringMap(k)
 }
+
 func (viperMock) WriteConfig() error {
 	return nil
 }

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -17,7 +17,6 @@ func TestCheckValidConfiguration(t *testing.T) {
 
 		f := CheckValidConfiguration(&c)
 		err := f(nil, nil)
-
 		if err != nil {
 			t.Error("expected no error returned")
 		}


### PR DESCRIPTION
In [SUP-1452](https://linear.app/buildkite/issue/SUP-1452/resolve-pipeline-from-working-dir) we discuss resolving the pipeline from either the current `dir` or allowing the user to configure it.

- [x] Check if the `buildkite.yaml` config file exists in the project root
- [x] If it exists, check that it has a `pipeline: <value>` config; if so then use that
- [x] If the config exists but doesn't define a `pipeline` then use the `dir` for that value
- [x] If the file contains anything other than `pipeline` then append the `pipeline` value as the `dir`