### PR TITLE
SUP-1691:  `bk agent list` interactivity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
@@ -39,6 +40,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/buildkite/go-buildkite/v3 v3.10.0 h1:m4eD3iOqyTpRHN4DqalzJK63WZATml524jJar7o4CEY=
@@ -83,6 +85,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f h1:MvTmaQdww/z0Q4wrYjDSCcZ78NoftLQyHBSLW/Cx79Y=
+github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -71,7 +71,7 @@ func (m agentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc":
+		case "ctrl+c":
 			m.quitting = true
 			return m, tea.Quit
 		}

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -26,15 +26,15 @@ type agentListModel struct {
 	quitting  bool
 }
 
-func ObtainAgents(f *factory.Factory, args ...string) (*agentListModel, error) {
+func ObtainAgents(f *factory.Factory, name, version, hostname string) (*agentListModel, error) {
 	var alo buildkite.AgentListOptions
 	var items []list.Item
 
-	if args[0] != "" || args[1] != "" || args[2] != "" {
+	if name != "" || version != "" || hostname != "" {
 		alo = buildkite.AgentListOptions{
-			Name:     args[0],
-			Version:  args[1],
-			Hostname: args[2],
+			Name:     name,
+			Version:  version,
+			Hostname: hostname,
 		}
 	}
 

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var agentListStyle = lipgloss.NewStyle().Margin(1, 2)
+
+type agentListItem struct {
+	title, metadata string
+}
+
+func (ali agentListItem) Title() string       { return ali.title }
+func (ali agentListItem) Description() string { return ali.metadata }
+func (ali agentListItem) FilterValue() string { return ali.title }
+
+type AgentListModel struct {
+	agentList list.Model
+	agents    []buildkite.Agent
+	quitting  bool
+}
+
+func ObtainAgents(f *factory.Factory, args ...string) (*AgentListModel, error) {
+	var alo buildkite.AgentListOptions
+	var items []list.Item
+
+	if args[0] != "" || args[1] != "" || args[2] != "" {
+		alo = buildkite.AgentListOptions{
+			Name:     args[0],
+			Version:  args[1],
+			Hostname: args[2],
+		}
+	}
+
+	// Obtain agent list
+	agents, _, err := f.RestAPIClient.Agents.List(f.Config.Organization, &alo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, agent := range agents {
+		items = append(items, agentListItem{
+			title:    *agent.Name,
+			metadata: fmt.Sprintf("%s | v%s | %s", *agent.ID, *agent.Version, *agent.ConnectedState),
+		})
+	}
+
+	m := AgentListModel{
+		agentList: list.New(items, list.NewDefaultDelegate(), 20, 0),
+		agents:    agents,
+	}
+
+	// Set Title
+	m.agentList.Title = "Buildkite Agents"
+
+	return &m, nil
+}
+
+func (m AgentListModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		h, v := agentListStyle.GetFrameSize()
+		m.agentList.SetSize(msg.Width-h, msg.Height-v)
+	}
+
+	var cmd tea.Cmd
+	m.agentList, cmd = m.agentList.Update(msg)
+	return m, cmd
+}
+
+func (m AgentListModel) View() string {
+	if m.quitting {
+		return ""
+	} else {
+		return agentListStyle.Render(m.agentList.View())
+	}
+}

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -20,13 +20,13 @@ func (ali agentListItem) Title() string       { return ali.title }
 func (ali agentListItem) Description() string { return ali.metadata }
 func (ali agentListItem) FilterValue() string { return ali.title }
 
-type AgentListModel struct {
+type agentListModel struct {
 	agentList list.Model
 	agents    []buildkite.Agent
 	quitting  bool
 }
 
-func ObtainAgents(f *factory.Factory, args ...string) (*AgentListModel, error) {
+func ObtainAgents(f *factory.Factory, args ...string) (*agentListModel, error) {
 	var alo buildkite.AgentListOptions
 	var items []list.Item
 
@@ -52,7 +52,7 @@ func ObtainAgents(f *factory.Factory, args ...string) (*AgentListModel, error) {
 		})
 	}
 
-	m := AgentListModel{
+	m := agentListModel{
 		agentList: list.New(items, list.NewDefaultDelegate(), 20, 0),
 		agents:    agents,
 	}
@@ -63,11 +63,11 @@ func ObtainAgents(f *factory.Factory, args ...string) (*AgentListModel, error) {
 	return &m, nil
 }
 
-func (m AgentListModel) Init() tea.Cmd {
+func (m agentListModel) Init() tea.Cmd {
 	return nil
 }
 
-func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m agentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -85,7 +85,7 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m AgentListModel) View() string {
+func (m agentListModel) View() string {
 	if m.quitting {
 		return ""
 	} else {

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -1,15 +1,12 @@
 package agent
 
 import (
-	"strings"
+	"os"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/internal/agent"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	"github.com/buildkite/go-buildkite/v3/buildkite"
-	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -25,70 +22,19 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 			List all connected agents for the current organization.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			l := io.NewPendingCommand(func() tea.Msg {
-				var alo buildkite.AgentListOptions
+			model, err := agent.ObtainAgents(f, name, version, hostname)
 
-				if name != "" || version != "" || hostname != "" {
-					alo = buildkite.AgentListOptions{
-						Name:     name,
-						Version:  version,
-						Hostname: hostname,
-					}
-				}
+			if err != nil {
+				return err
+			}
 
-				// Obtain agent list
-				agents, _, err := f.RestAPIClient.Agents.List(f.Config.Organization, &alo)
-				if err != nil {
-					return err
-				}
+			p := tea.NewProgram(model)
 
-				if len(agents) == 0 {
-					return io.PendingOutput("No connected agents")
-				}
+			if _, err := p.Run(); err != nil {
+				os.Exit(1)
+			}
 
-				var rows []table.Row
-				maxLengths := map[string]int{"ID": 0, "Name": 0, "Hostname": 0, "Status": 0, "Tags": 0, "Version": 0}
-
-				for _, agent := range agents {
-					agentRowData := map[string]string{
-						"ID":       *agent.ID,
-						"Name":     *agent.Name,
-						"Hostname": *agent.Hostname,
-						"Status":   *agent.ConnectedState,
-						"Tags":     strings.Join(agent.Metadata, ", "),
-						"Version":  *agent.Version,
-					}
-
-					// If any length of an agents values are longer than its current maximum length, update it
-					for key, value := range agentRowData {
-						if len(value) > maxLengths[key] {
-							maxLengths[key] = len(value)
-						}
-					}
-
-					// Append row to table.Row list
-					rows = append(rows, []string{agentRowData["ID"], agentRowData["Name"], agentRowData["Hostname"], agentRowData["Status"], agentRowData["Tags"], agentRowData["Version"]})
-				}
-
-				columns := []table.Column{
-					{Title: "ID", Width: maxLengths["ID"]},
-					{Title: "Name", Width: maxLengths["Name"]},
-					{Title: "Hostname", Width: maxLengths["Hostname"]},
-					{Title: "Status", Width: maxLengths["Status"]},
-					{Title: "Tags", Width: maxLengths["Tags"]},
-					{Title: "Version", Width: maxLengths["Version"] + 1},
-				}
-
-				// Set the selected style to default
-				styles := table.DefaultStyles()
-				styles.Selected = lipgloss.NewStyle()
-				table := table.New(table.WithColumns(columns), table.WithRows(rows), table.WithHeight(len(rows)), table.WithStyles(styles))
-
-				return io.PendingOutput(table.View())
-			}, "Loading agents")
-
-			_, err := tea.NewProgram(l).Run()
-			return err
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Added a default Bubble Tea list component for `bk agent list` - which shows the agent list output in a filterable, navigable list that has default actions for sorting, clearing, exiting etc.

The model for the list component includes the list model itself, the list of Buildkite agents from Go-Buildkite, and a quitting `bool` (the latter is used for clearing the user's stdout with a `ctrl+c` when viewing the list). Pressing `esc` while filtering will clear it and return to the results given from the API.

Each row of the list (for now) includes the agents name (primary), with the secondary row showing the UUID, version and connectivity state