### PR TITLE
SUP-1658: `bk agent list`: appender, pagination and limiting

### DIFF
--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -33,7 +33,7 @@ func NewAgentList(loader tea.Cmd, appender func(page int) (tea.Msg, *buildkite.R
 
 func (m *AgentListModel) appendAgents(page int) tea.Cmd {
 	// Increment to next page
-	m.agentPage++ 
+	m.agentPage++
 	// Set a status message and start the agentList's spinner
 	startSpiner := m.agentList.StartSpinner()
 	setStatus := m.agentList.NewStatusMessage(("Fetching more agents..."))
@@ -63,7 +63,9 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "down":
-			if m.agentList.Index() == len(m.agentList.Items())-1 && m.agentList.FilterState() == list.Unfiltered {
+			lastListElement := m.agentList.Index() == len(m.agentList.Items())-1
+			unfilteredState := m.agentList.FilterState() == list.Unfiltered
+			if lastListElement && unfilteredState {
 				return m, m.appendAgents(m.agentPage)
 			}
 		}

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -37,7 +37,7 @@ func (m *AgentListModel) appendAgents() tea.Cmd {
 	m.agentsLoading = true
 	// Set a status message and start the agentList's spinner
 	startSpiner := m.agentList.StartSpinner()
-	setStatus := m.agentList.NewStatusMessage(("Fetching more agents..."))
+	setStatus := m.agentList.NewStatusMessage(("Fetching more agents"))
 	// Fetch and append more agents
 	appendAgents := m.agentLoader(m.agentCurrentPage, m.agentPerPage)
 	return tea.Sequence(appendAgents, tea.Batch(startSpiner, setStatus))

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -33,6 +33,7 @@ func NewAgentList(loader func(int, int) tea.Cmd, page, perpage int) AgentListMod
 }
 
 func (m *AgentListModel) appendAgents() tea.Cmd {
+	// Set agentsLoading
 	m.agentsLoading = true
 	// Set a status message and start the agentList's spinner
 	startSpiner := m.agentList.StartSpinner()
@@ -57,15 +58,17 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "down":
-			if !m.agentsLoading {
-				// Calculate last element, unfiltered and if the last agent page via the API has been reached
-				lastListElement := m.agentList.Index() == len(m.agentList.Items())-1
-				unfilteredState := m.agentList.FilterState() == list.Unfiltered
+			// Calculate last element, unfiltered and if the last agent page via the API has been reached
+			lastListItem := m.agentList.Index() == len(m.agentList.Items())-1
+			unfilteredState := m.agentList.FilterState() == list.Unfiltered
+			if !m.agentsLoading && lastListItem && unfilteredState {
 				lastPageReached := m.agentCurrentPage > m.agentLastPage
-				// If down is pressed on the last agent item, list state is unfiltered and more agents are available by the API
-				if lastListElement && unfilteredState && !lastPageReached {
+				// If down is pressed on the last agent item, list state is unfiltered and more agents are available
+				// to load the API
+				if !lastPageReached {
 					return m, m.appendAgents()
-				} else if lastListElement && unfilteredState && lastPageReached {
+				} else {
+					// Append a status message to alert that no more agents are available to load from the API
 					setStatus := m.agentList.NewStatusMessage("No more agents to load!")
 					cmds = append(cmds, setStatus)
 				}

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -40,7 +40,7 @@ func (m *AgentListModel) appendAgents() tea.Cmd {
 	setStatus := m.agentList.NewStatusMessage(("Fetching more agents"))
 	// Fetch and append more agents
 	appendAgents := m.agentLoader(m.agentCurrentPage, m.agentPerPage)
-	return tea.Sequence(appendAgents, tea.Batch(startSpiner, setStatus))
+	return tea.Sequence(tea.Batch(startSpiner, setStatus), appendAgents)
 }
 
 func (m AgentListModel) Init() tea.Cmd {
@@ -80,7 +80,6 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// spinner
 		allItems := append(m.agentList.Items(), msg.ListItems()...)
 		cmds = append(cmds, m.agentList.SetItems(allItems))
-		// Stop the loading spinner
 		m.agentList.StopSpinner()
 		// If the message from the initial agent load, set the last page
 		if m.agentCurrentPage == 1 {

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -4,21 +4,15 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 )
 
-type NewAgentItemsMsg []AgentListItem
-
-func (a NewAgentItemsMsg) Items() []list.Item {
-	agg := make([]list.Item, len(a))
-	for i, v := range a {
-		agg[i] = v
-	}
-	return agg
+type NewAgentItemsMsg struct {
+	Items    []AgentListItem
+	NextPage int
+	LastPage int
 }
 
-type NewAgentAppendItemsMsg []AgentListItem
-
-func (a NewAgentAppendItemsMsg) Items() []list.Item {
-	agg := make([]list.Item, len(a))
-	for i, v := range a {
+func (a NewAgentItemsMsg) ListItems() []list.Item {
+	agg := make([]list.Item, len(a.Items))
+	for i, v := range a.Items {
 		agg[i] = v
 	}
 	return agg

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -6,7 +6,6 @@ import (
 
 type NewAgentItemsMsg struct {
 	Items    []AgentListItem
-	NextPage int
 	LastPage int
 }
 

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -13,3 +13,13 @@ func (a NewAgentItemsMsg) Items() []list.Item {
 	}
 	return agg
 }
+
+type NewAgentAppendItemsMsg []AgentListItem
+
+func (a NewAgentAppendItemsMsg) Items() []list.Item {
+	agg := make([]list.Item, len(a))
+	for i, v := range a {
+		agg[i] = v
+	}
+	return agg
+}

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -4,14 +4,18 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 )
 
-type NewAgentItemsMsg struct {
-	Items    []AgentListItem
-	LastPage int
+type AgentItemsMsg struct {
+	items    []AgentListItem
+	lastPage int
 }
 
-func (a NewAgentItemsMsg) ListItems() []list.Item {
-	agg := make([]list.Item, len(a.Items))
-	for i, v := range a.Items {
+func NewAgentItemsMsg(items []AgentListItem, page int) AgentItemsMsg {
+	return AgentItemsMsg{items, page}
+}
+
+func (a AgentItemsMsg) ListItems() []list.Item {
+	agg := make([]list.Item, len(a.items))
+	for i, v := range a.items {
 		agg[i] = v
 	}
 	return agg

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -51,7 +51,6 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 						}
 					}
 
-					// If initial load, return agents with page info
 					return agent.NewAgentItemsMsg{
 						Items:    items,
 						LastPage: resp.LastPage,

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	//"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -31,7 +32,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 						Hostname: hostname,
 						Version:  version,
 						ListOptions: buildkite.ListOptions{
-							Page:    1,
+							Page:    page,
 							PerPage: perpage,
 						},
 					}
@@ -51,24 +52,16 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 					}
 
 					// If initial load, return agents with page info
-					if page == 1 {
-						return agent.NewAgentItemsMsg{
-							Items:    items,
-							NextPage: resp.NextPage,
-							LastPage: resp.LastPage,
-						}
-					} else {
-						return agent.NewAgentItemsMsg{
-							Items:    items,
-							NextPage: resp.NextPage,
-						}
+					return agent.NewAgentItemsMsg{
+						Items:    items,
+						LastPage: resp.LastPage,
 					}
 				}
 			}
 
 			model := agent.NewAgentList(loader, 1, perpage)
 
-			p := tea.NewProgram(model, tea.WithAltScreen())
+			p := tea.NewProgram(model)
 
 			if _, err := p.Run(); err != nil {
 				os.Exit(1)

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -59,7 +59,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 
 			model := agent.NewAgentList(loader, 1, perpage)
 
-			p := tea.NewProgram(model)
+			p := tea.NewProgram(model, tea.WithAltScreen())
 
 			if _, err := p.Run(); err != nil {
 				os.Exit(1)

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	//"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -24,7 +24,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 			List all connected agents for the current organization.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loader := func(page, perpage int) tea.Cmd {
+			loader := func(page int) tea.Cmd {
 				return func() tea.Msg {
 					opts := buildkite.AgentListOptions{
 						Name:     name,
@@ -50,10 +50,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 						}
 					}
 
-					return agent.NewAgentItemsMsg{
-						Items:    items,
-						LastPage: resp.LastPage,
-					}
+					return agent.NewAgentItemsMsg(items, resp.LastPage)
 				}
 			}
 

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -13,6 +13,7 @@ import (
 
 func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 	var name, version, hostname string
+	var perpage int
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
@@ -29,7 +30,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 				Version:  version,
 				ListOptions: buildkite.ListOptions{
 					Page:    1,
-					PerPage: 5,
+					PerPage: perpage,
 				},
 			}
 			loader := func() tea.Msg {
@@ -88,6 +89,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Filter agents by their name")
 	cmd.Flags().StringVar(&version, "version", "", "Filter agents by their agent version")
 	cmd.Flags().StringVar(&hostname, "hostname", "", "Filter agents by their hostname")
+	cmd.Flags().IntVar(&perpage, "per-page", 30, "Number of agents to fetch per API call")
 
 	return &cmd
 }


### PR DESCRIPTION
Added pagination and limiting for `bk agent list`. This PR includes various tweaks to the existing functionality, including:

- The `loader` model functions now serves dual purpose to initially load agents, as well as append agents to the `agentList` model.  It now returns the same (renamed) `(New)AgentItemsMsg`, with the addition of the last page (set in the model from the initial `Init`). It now requires the `page` to load (`AgentListOptions`)
- `tea.KeyMsg` handled for `down` keypresses on `Update`. When the end of the current `agentList` is reached from the selected item, a further press will call the agent models `loader` with the current API page, load and then append agents to the `agentList` model and increment the page count. The list shows a status message of `Loading more agents: page X of Y` when this is happening and starts/stops the spinner.
- If there are no more agents to load from the API, the list will show a status message of `No more agents to load!`
- `per-page` integer flag for `bk agent list`: which by default is set as 30 (default REST API limits).

The below pictures use a small tweak to the agent list delegate to show a purple `>` for easier viewing of the functionality

**Initial load** (`per-page 4`)

![image](https://github.com/buildkite/cli/assets/70425486/e7d5c4c2-9b1c-43fe-84bd-c350830796e6)

**Fetching Agents** (`per-page 4`)

![image](https://github.com/buildkite/cli/assets/70425486/217d2c4e-ae84-4c86-b919-57bba13854b5)

**Last page reached - agents exhausted** (`per-page 4`)

![image](https://github.com/buildkite/cli/assets/70425486/70bf2596-cf8f-454e-9e13-3823aa0f425b)

To decide

- [ ] Should this also be keybindable? i.e show more agents with `l` which works as another "option" with reaching the end item in `agentList`?