### PR TITLE
SUP-1698: Keybind for viewing agent data within `bk agent list`

### DIFF
--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/pkg/style"
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -24,8 +25,18 @@ type AgentListModel struct {
 func NewAgentList(loader tea.Cmd) AgentListModel {
 	l := list.New(nil, NewDelegate(), 0, 0)
 	l.Title = "Buildkite Agents"
+	l.SetStatusBarItemName("agent", "agents")
+	l.SetFilteringEnabled(false)
 
 	v := viewport.New(80, 30)
+
+	l.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view")),
+		}
+	}
+
+	l.AdditionalFullHelpKeys = l.AdditionalShortHelpKeys
 
 	return AgentListModel{
 		agentList:     l,

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -69,14 +69,14 @@ func (m *AgentListModel) setComponentSizing(width, height int) {
 	h, v := agentListStyle.GetFrameSize()
 	// Set component size
 	m.agentList.SetSize(width-h, height-v)
-	m.agentViewPort.Height = height-v
-	m.agentViewPort.Width = width-h
+	m.agentViewPort.Height = height - v
+	m.agentViewPort.Width = width - h
 
 	// Set styles width
-	viewPortStyle.Width((width-h)/2)
- 	viewPortStyle.Height(height-v)
-	agentListStyle.Width((width-h)/2)
-	agentListStyle.Height(height-v)
+	viewPortStyle.Width((width - h) / 2)
+	viewPortStyle.Height(height - v)
+	agentListStyle.Width((width - h) / 2)
+	agentListStyle.Height(height - v)
 }
 
 func (m *AgentListModel) clearAgentViewPort() {
@@ -125,7 +125,7 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					setStatus := m.agentList.NewStatusMessage("No more agents to load!")
 					cmds = append(cmds, setStatus)
 				}
-			} 
+			}
 		case "w":
 			if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
 				if err := browser.OpenURL(*agent.WebURL); err != nil {

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -72,7 +72,7 @@ func (m *AgentListModel) setComponentSizing(width, height int) {
 	m.agentViewPort.Height = height - v
 	m.agentViewPort.Width = width - h
 
-	// Set styles width
+	// Set styles width/height for resizing upon a tea.WindowSizeMsg
 	viewPortStyle.Width((width - h) / 2)
 	viewPortStyle.Height(height - v)
 	agentListStyle.Width((width - h) / 2)
@@ -133,6 +133,7 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	// Custom messages
 	case AgentItemsMsg:
 		// When a new page of agents is received, append them to existing agents in the list and stop the loading
 		// spinner

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -1,29 +1,71 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 
+	"github.com/buildkite/cli/v3/pkg/style"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 )
 
 var agentListStyle = lipgloss.NewStyle().Margin(1, 2)
 
 type AgentListModel struct {
-	agentList   list.Model
-	agentLoader tea.Cmd
+	agentList     list.Model
+	agentViewPort viewport.Model
+	agentLoader   tea.Cmd
 }
 
 func NewAgentList(loader tea.Cmd) AgentListModel {
 	l := list.New(nil, NewDelegate(), 0, 0)
 	l.Title = "Buildkite Agents"
 
+	v := viewport.New(80, 30)
+
 	return AgentListModel{
-		agentList:   l,
-		agentLoader: loader,
+		agentList:     l,
+		agentViewPort: v,
+		agentLoader:   loader,
 	}
+}
+
+func getAgentTable(agentData AgentListItem) string {
+	// Parse metadata and queue name from returned REST API Metadata list
+	metadata, queue := ParseMetadata(agentData.Metadata)
+
+	tableOut := &bytes.Buffer{}
+	bold := lipgloss.NewStyle().Bold(true)
+	agentStateStyle := lipgloss.NewStyle().Bold(true).Foreground(MapStatusToColour(*agentData.ConnectedState))
+	queueStyle := lipgloss.NewStyle().Foreground(style.Teal)
+	versionStyle := lipgloss.NewStyle().Foreground(style.Grey)
+
+	fmt.Fprint(tableOut, bold.Render(*agentData.Name))
+
+	t := table.New().Border(lipgloss.HiddenBorder()).StyleFunc(func(row, col int) lipgloss.Style {
+		return lipgloss.NewStyle().PaddingRight(2)
+	})
+
+	// Construct table row data
+	t.Row("ID", *agentData.ID)
+	t.Row("State", agentStateStyle.Render(*agentData.ConnectedState))
+	t.Row("Queue", queueStyle.Render(queue))
+	t.Row("Version", versionStyle.Render(*agentData.Version))
+	t.Row("Hostname", *agentData.Hostname)
+	// t.Row("PID", *agent.)
+	t.Row("User Agent", *agentData.UserAgent)
+	t.Row("IP Address", *agentData.IPAddress)
+	// t.Row("OS", *agent.)
+	t.Row("Connected", agentData.CreatedAt.UTC().Format(time.RFC1123Z))
+	// t.Row("Stopped By", *agent.CreatedAt)
+	t.Row("Metadata", metadata)
+
+	fmt.Fprint(tableOut, t.Render())
+	return tableOut.String()
 }
 
 func (m AgentListModel) Init() tea.Cmd {
@@ -37,7 +79,16 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// when viewport size is reported, start a spinner and show a message to the user indicating agents are loading
 		h, v := agentListStyle.GetFrameSize()
 		m.agentList.SetSize(msg.Width-h, msg.Height-v)
+		m.agentViewPort.SetContent("")
 		return m, tea.Batch(m.agentList.StartSpinner(), m.agentList.NewStatusMessage("Loading agents"))
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "v":
+			if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
+				tableContext := getAgentTable(agent)
+				m.agentViewPort.SetContent(tableContext)
+			}
+		}
 	case NewAgentItemsMsg:
 		// when a new page of agents is received, append them to existing agents in the list and stop the loading
 		// spinner
@@ -59,5 +110,13 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m AgentListModel) View() string {
-	return agentListStyle.Render(m.agentList.View())
+	return lipgloss.JoinHorizontal(
+		lipgloss.Left,
+		agentListStyle.Render(m.agentList.View()),
+		lipgloss.JoinVertical(
+			lipgloss.Top,
+			//	m.agentStyle.Title.Render(m.agentList.SelectedItem().FilterValue()),
+			fmt.Sprintf("%4s", m.agentViewPort.View()),
+		),
+	)
 }

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -14,9 +14,10 @@ import (
 var agentListStyle = lipgloss.NewStyle().Margin(1, 2)
 
 type AgentListModel struct {
-	agentList     list.Model
-	agentViewPort viewport.Model
-	agentLoader   tea.Cmd
+	agentList          list.Model
+	agentViewPort      viewport.Model
+	agentDataDisplayed bool
+	agentLoader        tea.Cmd
 }
 
 func NewAgentList(loader tea.Cmd) AgentListModel {
@@ -35,9 +36,10 @@ func NewAgentList(loader tea.Cmd) AgentListModel {
 	l.AdditionalFullHelpKeys = l.AdditionalShortHelpKeys
 
 	return AgentListModel{
-		agentList:     l,
-		agentViewPort: v,
-		agentLoader:   loader,
+		agentList:          l,
+		agentViewPort:      v,
+		agentDataDisplayed: false,
+		agentLoader:        loader,
 	}
 }
 
@@ -57,16 +59,20 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "v":
-			if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
-				tableContext := AgentDataTable(agent.Agent)
-				m.agentViewPort.SetContent(tableContext)
+			if !m.agentDataDisplayed {
+				if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
+					tableContext := AgentDataTable(agent.Agent)
+					m.agentViewPort.SetContent(tableContext)
+					m.agentDataDisplayed = true
+				}
+			} else {
+				m.agentViewPort.SetContent("")
+				m.agentDataDisplayed = false
 			}
-		case "up":
+		case "up", "down":
 			// Clear the viewports' data
 			m.agentViewPort.SetContent("")
-		case "down":
-			// Clear the viewports' data
-			m.agentViewPort.SetContent("")
+			m.agentDataDisplayed = false
 		}
 	case NewAgentItemsMsg:
 		// when a new page of agents is received, append them to existing agents in the list and stop the loading

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -69,12 +69,14 @@ func (m *AgentListModel) setComponentSizing(width, height int) {
 	h, v := agentListStyle.GetFrameSize()
 	// Set component size
 	m.agentList.SetSize(width-h, height-v)
-	m.agentViewPort.Height = height - v
-	m.agentViewPort.Width = (width - h) / 2
+	m.agentViewPort.Height = height-v
+	m.agentViewPort.Width = width-h
 
 	// Set styles width
-	viewPortStyle.Width((width - h/2))
-	agentListStyle.Width((width - h) / 2)
+	viewPortStyle.Width((width-h)/2)
+ 	viewPortStyle.Height(height-v)
+	agentListStyle.Width((width-h)/2)
+	agentListStyle.Height(height-v)
 }
 
 func (m *AgentListModel) clearAgentViewPort() {
@@ -123,7 +125,7 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					setStatus := m.agentList.NewStatusMessage("No more agents to load!")
 					cmds = append(cmds, setStatus)
 				}
-			}
+			} 
 		case "w":
 			if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
 				if err := browser.OpenURL(*agent.WebURL); err != nil {

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -23,7 +23,6 @@ func NewAgentList(loader tea.Cmd) AgentListModel {
 	l := list.New(nil, NewDelegate(), 0, 0)
 	l.Title = "Buildkite Agents"
 	l.SetStatusBarItemName("agent", "agents")
-	l.SetFilteringEnabled(false)
 
 	v := viewport.New(80, 30)
 

--- a/internal/agent/view.go
+++ b/internal/agent/view.go
@@ -1,9 +1,50 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/buildkite/cli/v3/pkg/style"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 )
+
+func AgentDataTable(agent *buildkite.Agent) string {
+	// Parse metadata and queue name from returned REST API Metadata list
+	metadata, queue := ParseMetadata(agent.Metadata)
+
+	tableOut := &bytes.Buffer{}
+	bold := lipgloss.NewStyle().Bold(true)
+	agentStateStyle := lipgloss.NewStyle().Bold(true).Foreground(MapStatusToColour(*agent.ConnectedState))
+	queueStyle := lipgloss.NewStyle().Foreground(style.Teal)
+	versionStyle := lipgloss.NewStyle().Foreground(style.Grey)
+
+	fmt.Fprint(tableOut, bold.Render(*agent.Name))
+
+	t := table.New().Border(lipgloss.HiddenBorder()).StyleFunc(func(row, col int) lipgloss.Style {
+		return lipgloss.NewStyle().PaddingRight(2)
+	})
+
+	// Construct table row data
+	t.Row("ID", *agent.ID)
+	t.Row("State", agentStateStyle.Render(*agent.ConnectedState))
+	t.Row("Queue", queueStyle.Render(queue))
+	t.Row("Version", versionStyle.Render(*agent.Version))
+	t.Row("Hostname", *agent.Hostname)
+	// t.Row("PID", *agent.)
+	t.Row("User Agent", *agent.UserAgent)
+	t.Row("IP Address", *agent.IPAddress)
+	// t.Row("OS", *agent.)
+	t.Row("Connected", agent.CreatedAt.UTC().Format(time.RFC1123Z))
+	// t.Row("Stopped By", *agent.CreatedAt)
+	t.Row("Metadata", metadata)
+
+	fmt.Fprint(tableOut, t.Render())
+	return tableOut.String()
+}
 
 func ParseMetadata(metadataList []string) (string, string) {
 	var metadata, queue string

--- a/pkg/cmd/agent/list.go
+++ b/pkg/cmd/agent/list.go
@@ -37,6 +37,7 @@ func NewCmdAgentList(f *factory.Factory) *cobra.Command {
 				}
 
 				for i, a := range agents {
+					a := a
 					items[i] = agent.AgentListItem{
 						Agent: &a,
 					}


### PR DESCRIPTION
Added shared functionality for viewing an agents finer details within `bk agent list`. This PR includes various tweaks to existing `list` and `view` functionality, including:

- A shared (exported) `AgentDataTable` function that constructs a Lipgloss table and is called by both `bk agent view` (as before) and now within `bk agent list` with a `v` keybind
- A half-page viewport component for the `bk agent list` model: set initially and from every `tea.WindowSizeMsg`. Split 50-50 with the agent list, and upon terminal resizing via `setComponentSizing` (both height/width of the agent list and viewport components are set)
- `v` keybind - agent data is cleared upon navigating through to other agents with an `up`/`down` keypress
- Works with filtered data (agent data loaded from the currently selected `Item`: for which `m.VisibleItems()` is polled and thus obtained from either the filtered item list or the list model's items.

**`bk agent list` with `v` keybind** (IP/UUID redacted)

![image](https://github.com/buildkite/cli/assets/70425486/8d3b4bac-dad5-4c4b-8a47-a07ceabb5dda)

**Helper Keys addendum**

![image](https://github.com/buildkite/cli/assets/70425486/fe536738-9086-4d02-8b1d-cb37f1ec6d96)
