### PR TITLE
Fix runtime error introduced in SUP-1695

### DIFF
--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -86,8 +86,9 @@ func (m AgentListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "w":
 			if agent, ok := m.agentList.SelectedItem().(AgentListItem); ok {
-				err := browser.OpenURL(*agent.WebURL)
-				return m, m.agentList.NewStatusMessage(fmt.Sprintf("Failed opening agent web url: %s", err.Error()))
+				if err := browser.OpenURL(*agent.WebURL); err != nil {
+					return m, m.agentList.NewStatusMessage(fmt.Sprintf("Failed opening agent web url: %s", err.Error()))
+				}
 			}
 		}
 	// Custom messages


### PR DESCRIPTION
In a rush to fix a linting error, I didn't immediately realise that the following code block introduced a runtime error:

```
err := browser.OpenURL(*agent.WebURL)
return m, m.agentList.NewStatusMessage(fmt.Sprintf("Failed opening agent web url: %s", err.Error()))
```

If `browser.OpenURL()` does not fail, then `err.Error()` results to a runtime error.  This PR aims to fix that. 
 