### PR TITLE
SUP-1743 Implement -w flag to open build in url on build view cmd

### DIFF
--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -1,16 +1,21 @@
 package build
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/build"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdBuildView(f *factory.Factory) *cobra.Command {
+	var web bool
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
@@ -28,9 +33,21 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			org, pipeline := parsePipelineArg(args[1], f.Config)
 
 			l := io.NewPendingCommand(func() tea.Msg {
+				var buildUrl string
+
 				b, _, err := f.RestAPIClient.Builds.Get(org, pipeline, buildId, &buildkite.BuildsListOptions{})
 				if err != nil {
 					return err
+				}
+
+				if web {
+					buildUrl = fmt.Sprintf("https://buildkite.com/%s/%s/builds/%d", org, pipeline, *b.Number)
+					fmt.Printf("Opening %s in your browser\n\n", buildUrl)
+					time.Sleep(1 * time.Second)
+					err = browser.OpenURL(buildUrl)
+					if err != nil {
+						fmt.Println("Error opening browser: ", err)
+					}
 				}
 
 				// Obtain build summary and return
@@ -44,5 +61,8 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			return err
 		},
 	}
+
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+
 	return &cmd
 }

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -62,7 +62,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser.")
 
 	return &cmd
 }


### PR DESCRIPTION
This PR implements `-w | --web` flag to the `bk build view <number> <pipeline>`  command to open a browser and load the build url.