### PR TITLE
SUP-1751 bk build rebuild implementation

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -33,6 +33,7 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 
 	cmd.AddCommand(NewCmdBuildNew(f))
 	cmd.AddCommand(NewCmdBuildView(f))
+	cmd.AddCommand(NewCmdBuildRebuild(f))
 
 	return &cmd
 }

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -1,0 +1,66 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
+	var web bool
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "rebuild <number> <pipeline> [flags]",
+		Short:                 "Reruns a build.",
+		Args:                  cobra.ExactArgs(2),
+		Long: heredoc.Doc(`
+			Runs a new build from the specified build number and pipeline and outputs the URL to the new build.
+
+			It accepts {pipeline_slug}, {org_slug}/{pipeline_slug} or a full URL to the pipeline as an argument.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			buildId := args[0]
+			org, pipeline := parsePipelineArg(args[1], f.Config)
+			return rebuild(org, pipeline, buildId, web, f)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+	cmd.Flags().SortFlags = false
+	return &cmd
+}
+
+func rebuild(org string, pipeline string, buildId string, web bool, f *factory.Factory) error {
+	l := io.NewPendingCommand(func() tea.Msg {
+		build, err := f.RestAPIClient.Builds.Rebuild(org, pipeline, buildId)
+		if err != nil {
+			return err
+		}
+
+		buildUrl := fmt.Sprintf("https://buildkite.com/%s/%s/builds/%d", org, pipeline, *build.Number)
+
+		if web {
+			fmt.Printf("Opening %s in your browser\n", buildUrl)
+			err = browser.OpenURL(buildUrl)
+			if err != nil {
+				fmt.Println("Error opening browser: ", err)
+			}
+		}
+
+		return io.PendingOutput(lipgloss.JoinVertical(lipgloss.Top,
+			lipgloss.NewStyle().Padding(1, 1).Render(fmt.Sprintf("Build created: %s\n", buildUrl))))
+
+	}, fmt.Sprintf("Rerunning build #%s for pipeline %s", buildId, pipeline))
+
+	p := tea.NewProgram(l)
+	_, err := p.Run()
+
+	return err
+}

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -1,16 +1,21 @@
 package build
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/build"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdBuildView(f *factory.Factory) *cobra.Command {
+	var web bool
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
@@ -28,9 +33,21 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			org, pipeline := parsePipelineArg(args[1], f.Config)
 
 			l := io.NewPendingCommand(func() tea.Msg {
+				var buildUrl string
+
 				b, _, err := f.RestAPIClient.Builds.Get(org, pipeline, buildId, &buildkite.BuildsListOptions{})
 				if err != nil {
 					return err
+				}
+
+				if web {
+					buildUrl = fmt.Sprintf("https://buildkite.com/%s/%s/builds/%d", org, pipeline, *b.Number)
+					fmt.Printf("Opening %s in your browser\n\n", buildUrl)
+					time.Sleep(1 * time.Second)
+					err = browser.OpenURL(buildUrl)
+					if err != nil {
+						fmt.Println("Error opening browser: ", err)
+					}
 				}
 
 				// Obtain build summary and return
@@ -44,5 +61,8 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			return err
 		},
 	}
+
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+
 	return &cmd
 }

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -62,7 +62,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser.")
 
 	return &cmd
 }


### PR DESCRIPTION
This PR implements the command `bk build rebuild <number> <pipeline> -w`, calling the [rebuild a build api ](https://buildkite.com/docs/apis/rest-api/builds#rebuild-a-build) from the specified build number of a pipeline and returns the url of the newly created build. 

The -w flag is also implemented together with this PR where a browser is opened for the created build.