### PR TITLE
Update CODEOWNERS to reflect changes to Support team projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jradtilbrook @mcncl @james2791 @lizrabuya
+* @jradtilbrook @mcncl @lizrabuya


### PR DESCRIPTION
James is no in the migrations team and thus should not be in the list of people to be notified when changes occur on CLI.

This does not mean that James cannot contribute, but he need not be notified of changes nor feel obligated to review changes.
