### PR TITLE
SUP-1911 Convert build command pipeline resolution

### DIFF
--- a/internal/pipeline/resolver.go
+++ b/internal/pipeline/resolver.go
@@ -1,19 +1,24 @@
 package pipeline
 
-// TODO temporary type for resolvers to return. this should be amended in future work
-type Pipeline any
+import "errors"
+
+// Pipeline is a struct containing information about a pipeline for a resolver to return
+type Pipeline struct {
+	Name string
+	Org  string
+}
 
 // PipelineResolverFn is a function for the purpose of finding a pipeline. It returns an error if an irrecoverable
 // scenario happens and should halt execution. Otherwise if the resolver does not find a pipeline, it should return
 // (nil, nil) to indicate this. ie. no error occurred, but no pipeline was found either.
-type PipelineResolverFn func() (Pipeline, error)
+type PipelineResolverFn func() (*Pipeline, error)
 
 type AggregateResolver []PipelineResolverFn
 
 // Resolve is a PipelineResolverFn that wraps up a list of resolvers to loop through to try find a pipeline. The first
 // pipeline that is found will be returned, if none are found if won't return an error to match the expectation of a
 // PipelineResolveFn
-func (pr AggregateResolver) Resolve() (Pipeline, error) {
+func (pr AggregateResolver) Resolve() (*Pipeline, error) {
 	for _, resolve := range pr {
 		p, err := resolve()
 		if err != nil {
@@ -25,4 +30,15 @@ func (pr AggregateResolver) Resolve() (Pipeline, error) {
 	}
 
 	return nil, nil
+}
+
+// NewAggregateResolver creates an AggregregateResolver from a list of PipelineResolverFn, appending a final resolver
+// for capturing the case that no resolvers find a pipeline
+func NewAggregateResolver(resolvers ...PipelineResolverFn) AggregateResolver {
+	// add a final error resolver to the chain in case no other resolvers find a pipeline
+	return append(resolvers, errorResolver)
+}
+
+func errorResolver() (*Pipeline, error) {
+	return nil, errors.New("Failed to resolve a pipeline.")
 }

--- a/internal/pipeline/resolver_test.go
+++ b/internal/pipeline/resolver_test.go
@@ -13,14 +13,14 @@ func TestAggregateResolver(t *testing.T) {
 		t.Parallel()
 
 		agg := pipeline.AggregateResolver{
-			func() (pipeline.Pipeline, error) { return nil, nil },
-			func() (pipeline.Pipeline, error) { return 42, nil },
+			func() (*pipeline.Pipeline, error) { return nil, nil },
+			func() (*pipeline.Pipeline, error) { return &pipeline.Pipeline{Name: "test"}, nil },
 		}
 
 		p, err := agg.Resolve()
 
-		if p.(int) != 42 {
-			t.Fatalf("Resolve function did not return expected value: %d", p.(int))
+		if p.Name != "test" {
+			t.Fatalf("Resolve function did not return expected value: %s", p.Name)
 		}
 		if err != nil {
 			t.Fatal("Resolve returned an error")

--- a/internal/pipelines/resolver.go
+++ b/internal/pipelines/resolver.go
@@ -9,7 +9,6 @@ import (
 )
 
 func ResolveFromPath(path string, org string, client *buildkite.Client) ([]string, error) {
-
 	repos, err := getRepoURLs(path)
 	if err != nil {
 		return nil, err
@@ -18,7 +17,6 @@ func ResolveFromPath(path string, org string, client *buildkite.Client) ([]strin
 }
 
 func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([]string, error) {
-
 	var currentPipelines []string
 	page := 1
 	per_page := 30

--- a/internal/pipelines/resolver_test.go
+++ b/internal/pipelines/resolver_test.go
@@ -12,7 +12,6 @@ func TestResolvePipelines(t *testing.T) {
 	t.Parallel()
 
 	t.Run("path has no repo URL", func(t *testing.T) {
-
 		defer gock.Off()
 
 		gock.New("https://api.buildkite.com/v2/organizations/testOrg").

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -15,9 +16,9 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "cancel <number> <pipeline> [flags]",
+		Use:                   "cancel <number> [pipeline] [flags]",
 		Short:                 "Cancels a build.",
-		Args:                  cobra.ExactArgs(2),
+		Args:                  cobra.MinimumNArgs(1),
 		Long: heredoc.Doc(`
 			Cancels the specified build.
 
@@ -26,8 +27,12 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]
-			org, pipeline := parsePipelineArg(args[1], f.Config)
-			return cancelBuild(org, pipeline, buildId, web, f)
+			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args, f.Config))
+			pipeline, err := resolvers.Resolve()
+			if err != nil {
+				return err
+			}
+			return cancelBuild(pipeline.Org, pipeline.Name, buildId, web, f)
 		},
 	}
 


### PR DESCRIPTION
This converts current build commands to an `AggregateResolver` implementation. Currently it only resolves using the existing positional argument but we can append to the resolver as we implement them
