### PR TITLE
Use .bk.yaml universally for config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ const (
 
 const (
 	appData        = "AppData"
-	configFilePath = ".bk.yaml"
+	configFilePath = "bk.yaml"
 	xdgConfigHome  = "XDG_CONFIG_HOME"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ const (
 
 const (
 	appData        = "AppData"
-	configFilePath = "bk.yaml"
+	configFilePath = ".bk.yaml"
 	xdgConfigHome  = "XDG_CONFIG_HOME"
 )
 
@@ -32,8 +32,8 @@ const (
 //	  buildkite-oss:
 //	    api_token: <token>
 type Config struct {
-	Organization string
 	APIToken     string
+	Organization string
 	V            ViperConfig
 }
 
@@ -92,10 +92,10 @@ func LoadProjectConfig() (*ProjectConfig, error) {
 	currentDirName := filepath.Base(dir)
 
 	var configFile string
-	if _, err := os.Stat("buildkite.yaml"); err == nil {
-		configFile = "buildkite.yaml"
-	} else if _, err := os.Stat("buildkite.yml"); err == nil {
-		configFile = "buildkite.yml"
+	if _, err := os.Stat(".bk.yaml"); err == nil {
+		configFile = ".bk.yaml"
+	} else if _, err := os.Stat(".bk.yml"); err == nil {
+		configFile = ".bk.yml"
 	}
 
 	// If a configuration file is found, try to read and parse it
@@ -121,7 +121,7 @@ func LoadProjectConfig() (*ProjectConfig, error) {
 }
 
 func writePipelineToBuildkiteYAML(projectConfig *ProjectConfig) (*ProjectConfig, error) {
-	configFilePath := "buildkite.yaml"
+	configFilePath := ".bk.yaml"
 
 	configData := make(map[string]interface{})
 	// Attempt to read the existing buildkite.yaml file


### PR DESCRIPTION
Currently we use either `.bk.yaml` in `~/.config` or `buildkite.yaml` in the repository, but the latter would clash with a pipeline file.

We should use a consistent name for the configuration file.
