### PR TITLE
Initial framework for adding an OpenAI token to the base config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	APITokenConfigKey          = "api_token"
+	OpenAIAPITokenConfigKey    = "openai_api_token"
 	OrganizationsSlugConfigKey = "organizations"
 	SelectedOrgKey             = "selected_org"
 )
@@ -32,9 +33,10 @@ const (
 //	  buildkite-oss:
 //	    api_token: <token>
 type Config struct {
-	APIToken     string
-	Organization string
-	V            ViperConfig
+	APIToken       string
+	OpenAIAPIToken string
+	Organization   string
+	V              ViperConfig
 }
 
 type ProjectConfig struct {
@@ -57,11 +59,13 @@ func (conf *Config) merge() {
 		APITokenConfigKey: conf.APIToken,
 	}
 	conf.V.Set(OrganizationsSlugConfigKey, orgs)
+	conf.V.Set(OpenAIAPITokenConfigKey, conf.OpenAIAPIToken)
 }
 
 // Save sets the current config values into viper and writes the config file
 func (conf *Config) Save() error {
 	conf.V.Set(SelectedOrgKey, conf.Organization)
+	conf.V.Set(OpenAIAPITokenConfigKey, conf.OpenAIAPIToken)
 	conf.merge()
 
 	return conf.V.WriteConfig()


### PR DESCRIPTION
We don't need to have the functionality **yet**, but the initial field could be set on first config right now.

We'll need to check for its existence to replace the empty string in the future.

I can see a future where each org may have its own token, but at the moment a top level makes sense to me; we can always change it later.
