### PR TITLE
SUP-2009 | Fix `build` commands

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -29,7 +29,6 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 				A pipeline is passed as an argument. It can be supplied in any of the following formats:
 				- "PIPELINE_SLUG"
 				- "ORGANIZATION_SLUG/PIPELINE_SLUG" 
-				- by URL, e.g. "https://buildkite.com/buildkite/buildkite-cli"
 			`),
 		},
 	}

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -23,7 +23,7 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 			Cancels the specified build.
 
 			It accepts a build number and a pipeline slug  as an argument.
-			The pipeline can be a {pipeline_slug}, {org_slug}/{pipeline_slug} or a full URL to the pipeline.
+			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -27,7 +27,7 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]
-			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args, f.Config))
+			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args[1:], f.Config))
 			pipeline, err := resolvers.Resolve()
 			if err != nil {
 				return err

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -23,7 +23,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 			Runs a new build from the specified build number and pipeline and outputs the URL to the new build.
 
 			It accepts a build number and a pipeline slug  as an argument.
-			The pipeline can be a {pipeline_slug}, {org_slug}/{pipeline_slug} or a full URL to the pipeline.
+			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -27,7 +27,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]
-			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args, f.Config))
+			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args[1:], f.Config))
 			pipeline, err := resolvers.Resolve()
 			if err != nil {
 				return err

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -27,7 +27,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			View a build's information.
 
 			It accepts a build number and a pipeline slug  as an argument.
-			The pipeline can be a {pipeline_slug}, {org_slug}/{pipeline_slug} or a full URL to the pipeline.
+			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -31,7 +31,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildId := args[0]
-			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args, f.Config))
+			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args[1:], f.Config))
 			pipeline, err := resolvers.Resolve()
 			if err != nil {
 				return err


### PR DESCRIPTION
## Change
The build view command is currently broken because it passes **all** `args` in to the resolver, it should ignore the first `arg` as that will be the build number.

I've also removed any reference to using the full `URL` for looking up a pipeline in the `build` commands as that doesn't parse correctly right now and we want to get a working binary up.

### Fix
![CleanShot 2024-04-17 at 20 48 08](https://github.com/buildkite/cli/assets/10952642/87c25a30-dd15-4470-b898-bbcf8b98d144)

### Edit
It turns out all `build` commands were broken, except `new` so I've fixed them too.
