### PR TITLE
Output build artifacts when build is viewed

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -1,0 +1,24 @@
+package artifact
+
+import "fmt"
+
+func FormatBytes(bytes int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+		TB = 1024 * GB
+	)
+	switch {
+	case bytes >= TB:
+		return fmt.Sprintf("%.1fTB", float64(bytes)/TB)
+	case bytes >= GB:
+		return fmt.Sprintf("%.1fGB", float64(bytes)/GB)
+	case bytes >= MB:
+		return fmt.Sprintf("%.1fMB", float64(bytes)/MB)
+	case bytes >= KB:
+		return fmt.Sprintf("%.1fKB", float64(bytes)/KB)
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}

--- a/internal/artifact/view.go
+++ b/internal/artifact/view.go
@@ -1,0 +1,18 @@
+package artifact
+
+import (
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func ArtifactSummary(artifact *buildkite.Artifact) string {
+	artifactSummary := lipgloss.JoinVertical(lipgloss.Top,
+		lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			lipgloss.NewStyle().Width(30).Align(lipgloss.Left).Padding(0, 1).Render(*artifact.Filename),
+			lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(FormatBytes(*artifact.FileSize)),
+		),
+	)
+
+	return artifactSummary
+}

--- a/internal/build/resolver.go
+++ b/internal/build/resolver.go
@@ -1,0 +1,9 @@
+package build
+
+type Build struct {
+	Organization string `json:"organization"`
+	Pipeline     string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+}
+
+type BuildResolverFn func() (*Build, error)

--- a/internal/build/resolvers/resolvefromurl.go
+++ b/internal/build/resolvers/resolvefromurl.go
@@ -1,0 +1,32 @@
+package build
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/buildkite/cli/v3/internal/build"
+)
+
+func ResolveFromURL(args []string) build.BuildResolverFn {
+	return func() (*build.Build, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("Incorrect number of arguments, expected 1, got %d", len(args))
+		}
+		resolvedURL := splitBuildURL(args[0])
+
+		org, name, buildNumber := resolvedURL.Organization, resolvedURL.Pipeline, resolvedURL.BuildNumber
+
+		return &build.Build{Pipeline: name, Organization: org, BuildNumber: buildNumber}, nil
+	}
+}
+
+func splitBuildURL(url string) build.Build {
+	re := regexp.MustCompile(`https://buildkite.com/([^/]+)/([^/]+)/builds/(\d+)$`)
+	matches := re.FindStringSubmatch(url)
+
+	return build.Build{
+		Organization: matches[1],
+		Pipeline:     matches[2],
+		BuildNumber:  matches[3],
+	}
+}

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -44,6 +44,10 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				var buildUrl string
 
 				b, _, err := f.RestAPIClient.Builds.Get(pipeline.Org, pipeline.Name, buildId, &buildkite.BuildsListOptions{})
+
+				if err != nil {
+					return err
+				}
 				buildArtifacts, _, err = f.RestAPIClient.Artifacts.ListByBuild(pipeline.Org, pipeline.Name, buildId, &buildkite.ArtifactListOptions{})
 				if err != nil {
 					return err

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -5,12 +5,14 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/artifact"
 	"github.com/buildkite/cli/v3/internal/build"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +32,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var buildArtifacts = make([]buildkite.Artifact, 0)
 			buildId := args[0]
 			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args[1:], f.Config))
 			pipeline, err := resolvers.Resolve()
@@ -41,6 +44,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				var buildUrl string
 
 				b, _, err := f.RestAPIClient.Builds.Get(pipeline.Org, pipeline.Name, buildId, &buildkite.BuildsListOptions{})
+				buildArtifacts, _, err = f.RestAPIClient.Artifacts.ListByBuild(pipeline.Org, pipeline.Name, buildId, &buildkite.ArtifactListOptions{})
 				if err != nil {
 					return err
 				}
@@ -57,6 +61,12 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 
 				// Obtain build summary and return
 				summary := build.BuildSummary(b)
+				if len(buildArtifacts) > 0 {
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nArtifacts")
+					for _, a := range buildArtifacts {
+						summary += artifact.ArtifactSummary(&a)
+					}
+				}
 				return io.PendingOutput(summary)
 			}, "Loading build information")
 


### PR DESCRIPTION
## Changes
When a user `view`s a build, that build will now output the artifacts and their respective sizes, if artifacts are found.

### Has Artifacts
![CleanShot 2024-04-26 at 15 02 32](https://github.com/buildkite/cli/assets/10952642/9be2e93c-489c-4dd4-b443-e38634ca6ad5)

### Doesn't Have Artifacts
![CleanShot 2024-04-26 at 15 04 03](https://github.com/buildkite/cli/assets/10952642/a3dca6ee-4992-422f-9707-887d3619f3e6)
