### PR TITLE
Add annotation outputting

### DIFF
--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -1,0 +1,33 @@
+package annotation
+
+import (
+	"regexp"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	STYLE_DEFAULT = lipgloss.Color("#DDD")
+	STYLE_INFO    = lipgloss.Color("#337AB7")
+	STYLE_WARNING = lipgloss.Color("#FF841C")
+	STYLE_ERROR   = lipgloss.Color("#F45756")
+	STYLE_SUCCESS = lipgloss.Color("#2ECC40")
+
+	// Max length for annotation body
+	ANNOTATION_MAX_LENGTH = 120
+)
+
+func StripTags(body string) string {
+	// Removing the tags separately allows us to maintian new lines in the output
+	// Remove closing tags first
+	re := regexp.MustCompile(`</[^>]+>`)
+	body = re.ReplaceAllString(body, "")
+	// Then rremove opening tags
+	re = regexp.MustCompile(`<[^>]*>`)
+	body = re.ReplaceAllString(body, "")
+
+	if len(body) > ANNOTATION_MAX_LENGTH {
+		return body[:ANNOTATION_MAX_LENGTH] + "...(more)"
+	}
+	return body
+}

--- a/internal/annotation/list.go
+++ b/internal/annotation/list.go
@@ -1,0 +1,50 @@
+package annotation
+
+import (
+	"fmt"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func AnnotationSummary(annotation *buildkite.Annotation) string {
+	summary := lipgloss.JoinVertical(lipgloss.Top,
+		lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
+		lipgloss.NewStyle().Padding(0, 1).Border(lipgloss.RoundedBorder()).BorderForeground(renderAnnotationState(*annotation.Style)).Render(fmt.Sprintf("%s\t%s", renderAnnotationIcon(*annotation.Style), StripTags(*annotation.BodyHTML))),
+	)
+	return summary
+}
+
+func renderAnnotationState(state string) lipgloss.Color {
+	var style lipgloss.Color
+	switch state {
+	case "success":
+		style = STYLE_SUCCESS
+	case "error":
+		style = STYLE_ERROR
+	case "warning":
+		style = STYLE_WARNING
+	case "info":
+		style = STYLE_INFO
+	default:
+		style = STYLE_DEFAULT
+	}
+	return style
+}
+
+func renderAnnotationIcon(state string) string {
+	var icon string
+	switch state {
+	case "success":
+		icon = "✔"
+	case "error":
+		icon = "✖"
+	case "warning":
+		icon = "⚠"
+	case "info":
+		icon = "ℹ"
+	default:
+		icon = "🗒️"
+	}
+	return icon
+}

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/annotation"
 	"github.com/buildkite/cli/v3/internal/artifact"
 	"github.com/buildkite/cli/v3/internal/build"
 	"github.com/buildkite/cli/v3/internal/io"
@@ -33,6 +34,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var buildArtifacts = make([]buildkite.Artifact, 0)
+			var buildAnnotations = make([]buildkite.Annotation, 0)
 			buildId := args[0]
 			resolvers := pipeline.NewAggregateResolver(pipelineResolverPositionArg(args[1:], f.Config))
 			pipeline, err := resolvers.Resolve()
@@ -42,13 +44,17 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 
 			l := io.NewPendingCommand(func() tea.Msg {
 				var buildUrl string
-
 				b, _, err := f.RestAPIClient.Builds.Get(pipeline.Org, pipeline.Name, buildId, &buildkite.BuildsListOptions{})
-
 				if err != nil {
 					return err
 				}
+
 				buildArtifacts, _, err = f.RestAPIClient.Artifacts.ListByBuild(pipeline.Org, pipeline.Name, buildId, &buildkite.ArtifactListOptions{})
+				if err != nil {
+					return err
+				}
+
+				buildAnnotations, _, err = f.RestAPIClient.Annotations.ListByBuild(pipeline.Org, pipeline.Name, buildId, &buildkite.AnnotationListOptions{})
 				if err != nil {
 					return err
 				}
@@ -69,6 +75,12 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nArtifacts")
 					for _, a := range buildArtifacts {
 						summary += artifact.ArtifactSummary(&a)
+					}
+				}
+				if len(buildAnnotations) > 0 {
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nAnnotations")
+					for _, a := range buildAnnotations {
+						summary += annotation.AnnotationSummary(&a)
 					}
 				}
 				return io.PendingOutput(summary)


### PR DESCRIPTION
## Changes
This allows annotations to be outputted with the `build view` command, the caveat with annotation output is that they are used in weird and wonderful ways;
* Test outputs
* Snyk results
* etc

Therefore it makes sense to set a limit on the body length of the annotations, displaying a hint (`...(more)`) that there is additional information not being shown.

![CleanShot 2024-04-29 at 10 29 48](https://github.com/buildkite/cli/assets/10952642/f944dc83-fa0e-45b4-a68f-c9788a264639)
