### PR TITLE
SUP-1596 Configure goreleaser to create github releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,9 @@ release:
   make_latest: false
   mode: replace
 
+changelog:
+  use: github
+
 builds:
   - id: macos
     goos: [darwin]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,11 @@ project_name: bk
 
 release:
   name_template: Buildkite CLI {{.Version}}
+  draft: true
+  replace_existing_draft: true
+  prerelease: auto
+  make_latest: false
+  mode: replace
 
 builds:
   - id: macos


### PR DESCRIPTION
This updates the goreleaser config to allow it to create github releases.
