### PR TITLE
Add PipelinePicker to ResolveFromRepository

### DIFF
--- a/internal/pipeline/resolver/config.go
+++ b/internal/pipeline/resolver/config.go
@@ -7,14 +7,14 @@ import (
 	"github.com/buildkite/cli/v3/internal/pipeline"
 )
 
-func ResolveFromConfig(conf *config.Config) PipelineResolverFn {
+func ResolveFromConfig(conf *config.Config, picker PipelinePicker) PipelineResolverFn {
 	return func(context.Context) (*pipeline.Pipeline, error) {
-		preferredPipelines := conf.PreferredPipelines()
+		pipelines := conf.PreferredPipelines()
 
-		if len(preferredPipelines) == 0 {
+		if len(pipelines) == 0 {
 			return nil, nil
 		}
 
-		return &preferredPipelines[0], nil
+		return picker(pipelines), nil
 	}
 }

--- a/internal/pipeline/resolver/config_test.go
+++ b/internal/pipeline/resolver/config_test.go
@@ -16,7 +16,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 		t.Parallel()
 
 		conf := config.New(afero.NewMemMapFs(), nil)
-		resolve := ResolveFromConfig(conf)
+		resolve := ResolveFromConfig(conf, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
 			t.Errorf("failed to resolve from config")
@@ -33,7 +33,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
 		conf.SetPreferredPipelines(pipelines)
-		resolve := ResolveFromConfig(conf)
+		resolve := ResolveFromConfig(conf, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
 			t.Errorf("failed to resolve from config")
@@ -54,7 +54,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}, {Name: "pipeline2"}, {Name: "pipeline3"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
 		conf.SetPreferredPipelines(pipelines)
-		resolve := ResolveFromConfig(conf)
+		resolve := ResolveFromConfig(conf, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
 			t.Errorf("failed to resolve from config")

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -7,6 +7,9 @@ import (
 	"github.com/buildkite/cli/v3/internal/pipeline"
 )
 
+// PipelinePicker is a function used to pick a pipeline from a list.
+//
+// It is indended to be used from pipeline resolvers that resolve multiple pipelines.
 type PipelinePicker func([]pipeline.Pipeline) *pipeline.Pipeline
 
 func PassthruPicker(p []pipeline.Pipeline) *pipeline.Pipeline {

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -11,6 +11,10 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
+// ResolveFromRepository finds pipelines based on the current repository.
+//
+// It queries the API for all pipelines in the organization that match the repository's URL.
+// It delegates picking one from the list of matches to the `picker`.
 func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineResolverFn {
 	return func(context.Context) (*pipeline.Pipeline, error) {
 		pipelines, err := resolveFromRepository(f)

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -21,14 +21,13 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 			return nil, nil
 		}
 
-		return &pipeline.Pipeline{
-			Name: pipelines[0],
-			Org:  f.Config.OrganizationSlug(),
-		}, nil
+		choice := picker(pipelines)
+
+		return choice, nil
 	}
 }
 
-func resolveFromRepository(f *factory.Factory) ([]string, error) {
+func resolveFromRepository(f *factory.Factory) ([]pipeline.Pipeline, error) {
 	repos, err := getRepoURLs(f.GitRepository)
 	if err != nil {
 		return nil, err
@@ -36,8 +35,8 @@ func resolveFromRepository(f *factory.Factory) ([]string, error) {
 	return filterPipelines(repos, f.Config.OrganizationSlug(), f.RestAPIClient)
 }
 
-func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([]string, error) {
-	var currentPipelines []string
+func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([]pipeline.Pipeline, error) {
+	var currentPipelines []pipeline.Pipeline
 	page := 1
 	per_page := 30
 	for more_pipelines := true; more_pipelines; {
@@ -56,7 +55,7 @@ func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([
 			for _, u := range repoURLs {
 				gitUrl := u[strings.LastIndex(u, "/")+1:]
 				if strings.Contains(*p.Repository, gitUrl) {
-					currentPipelines = append(currentPipelines, *p.Slug)
+					currentPipelines = append(currentPipelines, pipeline.Pipeline{Name: *p.Slug, Org: org})
 				}
 			}
 		}

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
-func ResolveFromRepository(f *factory.Factory) PipelineResolverFn {
+func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineResolverFn {
 	return func(context.Context) (*pipeline.Pipeline, error) {
 		pipelines, err := resolveFromRepository(f)
 		if err != nil {

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -25,9 +25,7 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 			return nil, nil
 		}
 
-		choice := picker(pipelines)
-
-		return choice, nil
+		return picker(pipelines), nil
 	}
 }
 

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -32,7 +32,7 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 			buildId := args[0]
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.Config),
+				resolver.ResolveFromConfig(f.Config, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -33,7 +33,7 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
 				resolver.ResolveFromConfig(f.Config),
-				resolver.ResolveFromRepository(f),
+				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline
 			r := io.NewPendingCommand(func() tea.Msg {

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -36,7 +36,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 0, f.Config),
 				resolver.ResolveFromConfig(f.Config),
-				resolver.ResolveFromRepository(f),
+				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline
 			r := io.NewPendingCommand(func() tea.Msg {

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -35,7 +35,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 0, f.Config),
-				resolver.ResolveFromConfig(f.Config),
+				resolver.ResolveFromConfig(f.Config, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -32,7 +32,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 			buildId := args[0]
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.Config),
+				resolver.ResolveFromConfig(f.Config, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -33,7 +33,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
 				resolver.ResolveFromConfig(f.Config),
-				resolver.ResolveFromRepository(f),
+				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 			var pipeline pipeline.Pipeline
 			r := io.NewPendingCommand(func() tea.Msg {

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -42,7 +42,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.Config),
+				resolver.ResolveFromConfig(f.Config, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -43,7 +43,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
 				resolver.ResolveFromConfig(f.Config),
-				resolver.ResolveFromRepository(f),
+				resolver.ResolveFromRepository(f, resolver.PassthruPicker),
 			)
 
 			var pipeline pipeline.Pipeline


### PR DESCRIPTION
This introduces a PipelinePicker to the ResolveFromRepository resolver to allow picking a pipeline from the multiple returned from the API. It doesn't implement a PipelinePicker at the moment and just uses a simple one that hardcodes the first entry. Other picker logic/implementations will be added in subsequent PRs