### PR TITLE
Pass PipelinePicker to ResolveFromConfig

### DIFF
--- a/internal/pipeline/resolver/config_test.go
+++ b/internal/pipeline/resolver/config_test.go
@@ -14,7 +14,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 		l := config.LocalConfig{ // empty local config
 		}
 
-		resolve := ResolveFromConfig(&l)
+		resolve := ResolveFromConfig(&l, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
 			t.Errorf("failed to resolve from config")
@@ -33,7 +33,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 			Pipelines:       []string{"bk-1"},
 		}
 
-		resolve := ResolveFromConfig(&l)
+		resolve := ResolveFromConfig(&l, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
 			t.Errorf("failed to resolve from config")

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -5,3 +5,7 @@ import (
 )
 
 type PipelinePicker func([]pipeline.Pipeline) *pipeline.Pipeline
+
+func PassthruPicker(p []pipeline.Pipeline) *pipeline.Pipeline {
+	return &p[0]
+}

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -32,7 +32,7 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 			buildId := args[0]
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.LocalConfig),
+				resolver.ResolveFromConfig(f.LocalConfig, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -35,7 +35,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 0, f.Config),
-				resolver.ResolveFromConfig(f.LocalConfig),
+				resolver.ResolveFromConfig(f.LocalConfig, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -32,7 +32,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 			buildId := args[0]
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.LocalConfig),
+				resolver.ResolveFromConfig(f.LocalConfig, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f),
 			)
 			var pipeline pipeline.Pipeline

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -41,7 +41,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			buildId := args[0]
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromPositionalArgument(args, 1, f.Config),
-				resolver.ResolveFromConfig(f.LocalConfig),
+				resolver.ResolveFromConfig(f.LocalConfig, resolver.PassthruPicker),
 				resolver.ResolveFromRepository(f),
 			)
 


### PR DESCRIPTION
This passes a PipelinePicker to ResolveFromConfig to support reducing a list of saved pipelines in config to just one for use with the current command invocation.
There are no useful PipelinePickers just yet - to be added in future PRs
