### PR TITLE
Add CachedPicker to save pipelines to config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ linters:
   enable:
   - gofmt
   - nolintlint
+  - tparallel
 
 issues:
   max-issues-per-linter: 0

--- a/internal/agent/stoppable_test.go
+++ b/internal/agent/stoppable_test.go
@@ -15,6 +15,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	t.Parallel()
 
 	t.Run("starts in waiting state", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{tea.Quit, nil, "123", Waiting} })
 		testModel := teatest.NewTestModel(t, model)
@@ -28,6 +30,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	})
 
 	t.Run("stopping state", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{tea.Quit, nil, "123", Stopping} })
 		testModel := teatest.NewTestModel(t, model)
@@ -41,6 +45,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	})
 
 	t.Run("success state", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{tea.Quit, nil, "123", Succeeded} })
 		testModel := teatest.NewTestModel(t, model)
@@ -54,6 +60,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	})
 
 	t.Run("failed state", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{tea.Quit, errors.New("error"), "123", Failed} })
 		testModel := teatest.NewTestModel(t, model)
@@ -67,6 +75,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	})
 
 	t.Run("transitions through waiting-stopping-succeeded", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{nil, nil, "123", Waiting} })
 		testModel := teatest.NewTestModel(t, model)
@@ -94,6 +104,8 @@ func TestStoppableAgentOutput(t *testing.T) {
 	})
 
 	t.Run("shows error state", func(t *testing.T) {
+		t.Parallel()
+
 		// use a StopFn that quits straight away
 		model := NewStoppableAgent("123", func() StatusUpdate { return StatusUpdate{nil, nil, "123", Waiting} })
 		testModel := teatest.NewTestModel(t, model)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,10 +40,9 @@ const (
 //	    api_token: <token>
 //	  buildkite-oss:
 //	    api_token: <token>
-//	preferences:
-//	   pipelines:
-//	     - first-pipeline
-//	     - second-pipeline
+//	pipelines: # (only in local config)
+//	  - first-pipeline
+//	  - second-pipeline
 type Config struct {
 	// localConfig is the configuration stored in the current directory or any directory above that, stopping at the git
 	// root. This file should never contain the `organizations` property because that will include the API token and it

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ func (conf *Config) HasConfiguredOrganization(slug string) bool {
 	return ok
 }
 
+// PreferredPipelines will retrieve the list of pipelines from local configuration
 func (conf *Config) PreferredPipelines() []pipeline.Pipeline {
 	names := conf.localConfig.GetStringSlice("pipelines")
 
@@ -149,7 +150,13 @@ func (conf *Config) PreferredPipelines() []pipeline.Pipeline {
 	return pipelines
 }
 
+// SetPreferredPipelines will write the provided list of pipelines to local configuration
 func (conf *Config) SetPreferredPipelines(pipelines []pipeline.Pipeline) error {
+	// only save pipelines if they are present
+	if len(pipelines) == 0 {
+		return nil
+	}
+
 	names := make([]string, len(pipelines))
 	for i, p := range pipelines {
 		names[i] = p.Name

--- a/internal/pipeline/resolver/config.go
+++ b/internal/pipeline/resolver/config.go
@@ -2,28 +2,19 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 )
 
-func ResolveFromConfig(c *config.Config) PipelineResolverFn {
+func ResolveFromConfig(conf *config.Config) PipelineResolverFn {
 	return func(context.Context) (*pipeline.Pipeline, error) {
-
-		if c == nil {
-			return nil, fmt.Errorf("could not determine config to use for pipeline resolution")
-		}
-
-		preferredPipelines := c.PreferredPipelines()
+		preferredPipelines := conf.PreferredPipelines()
 
 		if len(preferredPipelines) == 0 {
 			return nil, nil
 		}
 
-		return &pipeline.Pipeline{
-			Name: preferredPipelines[0],
-			Org:  c.OrganizationSlug(),
-		}, nil
+		return &preferredPipelines[0], nil
 	}
 }

--- a/internal/pipeline/resolver/config_test.go
+++ b/internal/pipeline/resolver/config_test.go
@@ -5,25 +5,12 @@ import (
 	"testing"
 
 	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/spf13/afero"
 )
 
 func TestResolvePipelineFromConfig(t *testing.T) {
-
-	t.Run("missing config", func(t *testing.T) {
-		t.Parallel()
-
-		resolve := ResolveFromConfig(nil)
-		selected, err := resolve(context.Background())
-
-		if err != nil && err.Error() != "could not determine config to use for pipeline resolution" {
-			t.Errorf("unknown error encountered")
-		}
-
-		if selected != nil {
-			t.Errorf("pipeline must be nil")
-		}
-	})
+	t.Parallel()
 
 	t.Run("no pipelines from config", func(t *testing.T) {
 		t.Parallel()
@@ -43,9 +30,9 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 	t.Run("Resolve to one pipeline", func(t *testing.T) {
 		t.Parallel()
 
-		pipelines := []string{"pipeline1"}
+		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.AddPreferredPipeline(pipelines)
+		conf.SetPreferredPipelines(pipelines)
 		resolve := ResolveFromConfig(conf)
 		selected, err := resolve(context.Background())
 		if err != nil {
@@ -56,7 +43,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 			t.Errorf("pipeline must not be nil")
 		}
 
-		if selected != nil && selected.Name != pipelines[0] {
+		if selected != nil && selected.Name != pipelines[0].Name {
 			t.Errorf("pipeline name must be pipeline1")
 		}
 	})
@@ -64,9 +51,9 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 	t.Run("Resolve to many pipelines", func(t *testing.T) {
 		t.Parallel()
 
-		pipelines := []string{"pipeline1", "pipeline2", "pipeline3"}
+		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}, {Name: "pipeline2"}, {Name: "pipeline3"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.AddPreferredPipeline(pipelines)
+		conf.SetPreferredPipelines(pipelines)
 		resolve := ResolveFromConfig(conf)
 		selected, err := resolve(context.Background())
 		if err != nil {
@@ -77,7 +64,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 			t.Errorf("pipeline must not be nil")
 		}
 
-		if selected != nil && selected.Name != pipelines[0] {
+		if selected != nil && selected.Name != pipelines[0].Name {
 			t.Errorf("pipeline name should resolve temporarily to pipeline1")
 		}
 	})

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"sort"
+
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 )
@@ -15,12 +17,26 @@ func PassthruPicker(p []pipeline.Pipeline) *pipeline.Pipeline {
 // picker.
 func CachedPicker(conf *config.Config, picker PipelinePicker) PipelinePicker {
 	return func(pipelines []pipeline.Pipeline) *pipeline.Pipeline {
+		// run the picker first because we want to put the chosen on at the top of the saved list
+		chosen := picker(pipelines)
+		// if chosen is nil, either there were no pipelines to begin with, or the user cancelled the picker, so we
+		// probably shouldnt save them to config
+		if chosen == nil {
+			return nil
+		}
+
+		// swap the chosen pipeline with the first element
+		index := sort.Search(len(pipelines), func(i int) bool {
+			return chosen == &pipelines[i]
+		})
+		pipelines[0], pipelines[index] = *chosen, pipelines[0]
+
 		// save the pipelines to local config before passing to the picker
 		err := conf.SetPreferredPipelines(pipelines)
 		if err != nil {
 			return nil
 		}
 
-		return picker(pipelines)
+		return chosen
 	}
 }

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -1,7 +1,26 @@
 package resolver
 
 import (
+	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 )
 
 type PipelinePicker func([]pipeline.Pipeline) *pipeline.Pipeline
+
+func PassthruPicker(p []pipeline.Pipeline) *pipeline.Pipeline {
+	return &p[0]
+}
+
+// CachedPicker returns a PipelinePicker that saves the given pipelines to local config as well as running the provider
+// picker.
+func CachedPicker(conf *config.Config, picker PipelinePicker) PipelinePicker {
+	return func(pipelines []pipeline.Pipeline) *pipeline.Pipeline {
+		// save the pipelines to local config before passing to the picker
+		err := conf.SetPreferredPipelines(pipelines)
+		if err != nil {
+			return nil
+		}
+
+		return picker(pipelines)
+	}
+}

--- a/internal/pipeline/resolver/picker_test.go
+++ b/internal/pipeline/resolver/picker_test.go
@@ -1,0 +1,52 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/pipeline"
+	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/spf13/afero"
+)
+
+func TestPickers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cached picker will save to local config", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		conf := config.New(fs, nil)
+
+		pipelines := []pipeline.Pipeline{
+			{Name: "pipeline", Org: "org"},
+		}
+		picked := resolver.CachedPicker(conf, resolver.PassthruPicker)(pipelines)
+
+		if picked == nil {
+			t.Fatal("Should not have received nil from picker")
+		}
+
+		b, _ := afero.ReadFile(fs, ".bk.yaml")
+		expected := "pipelines:\n    - pipeline\n"
+		if string(b) != expected {
+			t.Fatalf("Local config file does not match expected: %s", string(b))
+		}
+	})
+
+	t.Run("cached picker handles empty list", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		conf := config.New(fs, nil)
+
+		pipelines := []pipeline.Pipeline{}
+		resolver.CachedPicker(conf, func(p []pipeline.Pipeline) *pipeline.Pipeline { return nil })(pipelines)
+
+		b, _ := afero.ReadFile(fs, ".bk.yaml")
+		expected := "pipelines: []\n"
+		if string(b) != expected {
+			t.Fatalf("Local config file does not match expected: %s", string(b))
+		}
+	})
+}

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -11,6 +11,8 @@ func TestCheckValidConfiguration(t *testing.T) {
 	t.Parallel()
 
 	t.Run("API token is configured", func(t *testing.T) {
+		t.Parallel()
+
 		conf := config.New(afero.NewMemMapFs(), nil)
 		_ = conf.SetTokenForOrg("testing", "testing")
 		_ = conf.SelectOrganization("testing")
@@ -23,6 +25,8 @@ func TestCheckValidConfiguration(t *testing.T) {
 	})
 
 	t.Run("API token is not configured", func(t *testing.T) {
+		t.Parallel()
+
 		conf := config.New(afero.NewMemMapFs(), nil)
 
 		f := CheckValidConfiguration(conf)


### PR DESCRIPTION
Add a picker that will save resolved pipelines to local config and run a picker to choose one for the current invocation

I've also come across various places where we are trying to run tests in parallel but not configuring it quite correctly. Good news is I found a linter that will tell us when this happens. I've enabled that linter and also fixed up some of the errors it found for us