### PR TITLE
Add NFPM to goreleaser

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,0 +1,4 @@
+# This uses the upstream image without any changes intentionally.
+# This allows dependabot to keep this version up-to-date for us automatically, since it does not work with
+# docker-compose directly
+FROM goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,4 +1,4 @@
 # This uses the upstream image without any changes intentionally.
 # This allows dependabot to keep this version up-to-date for us automatically, since it does not work with
 # docker-compose directly
-FROM goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3
+FROM goreleaser/goreleaser-pro:v1.26.2-pro@sha256:e3c5989f459122528766ec55ebcd77d8abd970500fe219936278aac2da077d71

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,8 +1,4 @@
+# This uses the upstream image without any changes intentionally.
 # This allows dependabot to keep this version up-to-date for us automatically, since it does not work with
 # docker-compose directly
 FROM goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3
-
-# use bash for easier shell scripts
-RUN apk add --no-cache bash
-
-ENTRYPOINT ["/bin/bash"]

--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,4 +1,8 @@
-# This uses the upstream image without any changes intentionally.
 # This allows dependabot to keep this version up-to-date for us automatically, since it does not work with
 # docker-compose directly
 FROM goreleaser/goreleaser:v1.26.2@sha256:e69fcf552e8eb2ce0d4c4a9b080b5f82ad9f040bb039a203667db0b5274ebfc3
+
+# use bash for easier shell scripts
+RUN apk add --no-cache bash
+
+ENTRYPOINT ["/bin/bash"]

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -16,3 +16,4 @@ services:
     working_dir: /go/src/github.com/buildkite/cli
     volumes:
       - ..:/go/src/github.com/buildkite/cli
+      - ${BUILDKITE_AGENT_JOB_API_SOCKET}:${BUILDKITE_AGENT_JOB_API_SOCKET}

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
   goreleaser:
     build:
       context: .
-    image: goreleaser/goreleaser:v1.20.0
     working_dir: /go/src/github.com/buildkite/cli
     volumes:
       - ..:/go/src/github.com/buildkite/cli

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -10,6 +10,9 @@ services:
   goreleaser:
     build:
       context: .
+    environment:
+      - BUILDKITE_AGENT_JOB_API_SOCKET
+      - BUILDKITE_AGENT_JOB_API_TOKEN
     working_dir: /go/src/github.com/buildkite/cli
     volumes:
       - ..:/go/src/github.com/buildkite/cli

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
       - ..:/app
       - ~/.cache/golangci-lint/v1.54.1:/root/.cache
   goreleaser:
+    build:
+      context: .
     image: goreleaser/goreleaser:v1.20.0
     working_dir: /go/src/github.com/buildkite/cli
     volumes:

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -7,22 +7,8 @@ services:
     volumes:
       - ..:/app
       - ~/.cache/golangci-lint/v1.54.1:/root/.cache
-  build:
+  goreleaser:
     image: goreleaser/goreleaser:v1.20.0
     working_dir: /go/src/github.com/buildkite/cli
     volumes:
       - ..:/go/src/github.com/buildkite/cli
-    command:
-      - build
-      - --snapshot
-      - --clean
-  release:
-    image: goreleaser/goreleaser:v1.20.0
-    working_dir: /go/src/github.com/buildkite/cli
-    volumes:
-      - ..:/go/src/github.com/buildkite/cli
-    environment:
-      - GITHUB_TOKEN
-    command:
-      - release
-      - --clean

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,6 +1,5 @@
 steps:
   - label: release
-    command: release --clean
     artifact_paths:
       - dist/**/*
     plugins:
@@ -10,7 +9,10 @@ steps:
           parameters:
             GITHUB_TOKEN: /pipelines/buildkite/buildkite-cli-release/github-token
       - docker-compose#v5.2.0:
-          run: goreleaser
+          command:
+            - release
+            - --clean
           config: .buildkite/docker-compose.yaml
           env:
             - GITHUB_TOKEN
+          run: goreleaser

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,5 +1,6 @@
 steps:
   - label: release
+    command: release --clean
     artifact_paths:
       - dist/**/*
     plugins:
@@ -9,5 +10,7 @@ steps:
           parameters:
             GITHUB_TOKEN: /pipelines/buildkite/buildkite-cli-release/github-token
       - docker-compose#v5.2.0:
-          run: release
+          run: goreleaser
           config: .buildkite/docker-compose.yaml
+          env:
+            - GITHUB_TOKEN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
           - buildkite
           - --registry
           - cli-deb
-          - -- package
+          - --package
           - deb
         config: .buildkite/docker-compose.yaml
         mount-buildkite-agent: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,10 +27,11 @@ steps:
   - wait
 
   - label: ":buildkite: build"
+    command: build --snapshot --clean
     artifact_paths:
       - dist/**/*
     plugins:
       docker-compose#v5.1.0:
         config: .buildkite/docker-compose.yaml
-        run: build
+        run: goreleaser
         tty: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,11 @@ steps:
 
   - wait
 
-  - label: ":buildkite: build"
+  - label: ":buildkite: build ({{matrix}})"
+    matrix:
+      - "darwin"
+      - "linux"
+      - "windows"
     artifact_paths:
       - dist/**/*
     plugins:
@@ -37,6 +41,7 @@ steps:
         entrypoint: /bin/sh
         env:
           - GORELEASER_ARGS=--snapshot
+          - GOOS={{matrix}}
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,6 @@ steps:
           - -- package
           - deb
         config: .buildkite/docker-compose.yaml
-        entrypoint: /bin/sh
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,16 +33,10 @@ steps:
       docker-compose#v5.1.0:
         command:
           - .buildkite/release.sh
-          - --snapshot
-          - --publish
-          - --org
-          - buildkite
-          - --registry
-          - cli-deb
-          - --package
-          - deb
         config: .buildkite/docker-compose.yaml
         entrypoint: /bin/sh
+        env:
+          - GORELEASER_ARGS="--snapshot"
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
         config: .buildkite/docker-compose.yaml
         entrypoint: /bin/sh
         env:
-          - GORELEASER_ARGS="--snapshot"
+          - GORELEASER_ARGS=--snapshot
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,6 +42,7 @@ steps:
           - --package
           - deb
         config: .buildkite/docker-compose.yaml
+        entrypoint: /bin/sh
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,23 +32,15 @@ steps:
     plugins:
       docker-compose#v5.1.0:
         command:
-          - build
-          - --snapshot
-          - --clean
-        config: .buildkite/docker-compose.yaml
-        run: goreleaser
-        tty: true
-
-  - label: ":buildkite: release"
-    artifact_paths:
-      - dist/**/*
-    plugins:
-      docker-compose#v5.1.0:
-        build:
-          context: .
-        command:
           - .buildkite/release.sh
-          - https://packages.buildkite.com/organizations/jradtilbrook/packages/registries/cli-rpm
+          - --snapshot
+          - --publish
+          - --org
+          - buildkite
+          - --registry
+          - cli-deb
+          - -- package
+          - deb
         config: .buildkite/docker-compose.yaml
         entrypoint: /bin/sh
         mount-buildkite-agent: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,11 +26,31 @@ steps:
 
   - wait
 
-  - label: ":buildkite: build ({{matrix}})"
+  - label: ":buildkite: build ({{matrix.os}}/{{matrix.arch}})"
     matrix:
-      - "darwin"
-      - "linux"
-      - "windows"
+      setup:
+        os:
+          - "darwin"
+          - "linux"
+          - "windows"
+        arch:
+          - amd64
+          - arm64
+          - '386'
+          - arm
+      adjustments:
+        - with:
+            os: windows
+            arch: arm
+          skip: true
+        - with:
+            os: darwin
+            arch: arm
+          skip: true
+        - with:
+            os: darwin
+            arch: '386'
+          skip: true
     artifact_paths:
       - dist/**/*
     plugins:
@@ -41,7 +61,8 @@ steps:
         entrypoint: /bin/sh
         env:
           - GORELEASER_ARGS=--snapshot --split
-          - GOOS={{matrix}}
+          - GOOS={{matrix.os}}
+          - GOARCH={{matrix.arch}}
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
         config: .buildkite/docker-compose.yaml
         entrypoint: /bin/sh
         env:
-          - GORELEASER_ARGS=--snapshot
+          - GORELEASER_ARGS=--snapshot --split
           - GOOS={{matrix}}
         mount-buildkite-agent: true
         run: goreleaser

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,11 +27,14 @@ steps:
   - wait
 
   - label: ":buildkite: build"
-    command: build --snapshot --clean
     artifact_paths:
       - dist/**/*
     plugins:
       docker-compose#v5.1.0:
+        command:
+          - build
+          - --snapshot
+          - --clean
         config: .buildkite/docker-compose.yaml
         run: goreleaser
         tty: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,8 @@ steps:
       - dist/**/*
     plugins:
       docker-compose#v5.1.0:
-        shell: false
+        build:
+          context: .
         command:
           - .buildkite/release.sh
           - https://packages.buildkite.com/organizations/jradtilbrook/packages/registries/cli-rpm
@@ -52,4 +53,5 @@ steps:
         entrypoint: /bin/sh
         mount-buildkite-agent: true
         run: goreleaser
+        shell: false
         tty: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,3 +38,18 @@ steps:
         config: .buildkite/docker-compose.yaml
         run: goreleaser
         tty: true
+
+  - label: ":buildkite: release"
+    artifact_paths:
+      - dist/**/*
+    plugins:
+      docker-compose#v5.1.0:
+        shell: false
+        command:
+          - .buildkite/release.sh
+          - https://packages.buildkite.com/organizations/jradtilbrook/packages/registries/cli-rpm
+        config: .buildkite/docker-compose.yaml
+        entrypoint: /bin/sh
+        mount-buildkite-agent: true
+        run: goreleaser
+        tty: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,31 +26,11 @@ steps:
 
   - wait
 
-  - label: ":buildkite: build ({{matrix.os}}/{{matrix.arch}})"
+  - label: ":buildkite: build ({{matrix}})"
     matrix:
-      setup:
-        os:
           - "darwin"
           - "linux"
           - "windows"
-        arch:
-          - amd64
-          - arm64
-          - '386'
-          - arm
-      adjustments:
-        - with:
-            os: windows
-            arch: arm
-          skip: true
-        - with:
-            os: darwin
-            arch: arm
-          skip: true
-        - with:
-            os: darwin
-            arch: '386'
-          skip: true
     artifact_paths:
       - dist/**/*
     plugins:
@@ -61,8 +41,7 @@ steps:
         entrypoint: /bin/sh
         env:
           - GORELEASER_ARGS=--snapshot --split
-          - GOOS={{matrix.os}}
-          - GOARCH={{matrix.arch}}
+          - GOOS={{matrix}}
         mount-buildkite-agent: true
         run: goreleaser
         shell: false

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -1,0 +1,31 @@
+#!/bin/env bash
+
+# NOTE: do not exit on non-zero returns codes
+set -uo pipefail
+
+AUDIENCE=$1
+
+# grab a token for pushing packages to buildkite with an expiry of 3 mins
+TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
+
+if [ ! $? ]; then
+    echo "Failed to retrieve OIDC token"
+    exit 1
+fi
+
+goreleaser release --clean --auto-snapshot --skip publish
+
+if [ ! $? ]; then
+    echo "Failed to build a release"
+    exit 1
+fi
+
+for FILE in dist/*.rpm; do
+    echo curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
+         -H "Authorization: Bearer ${TOKEN}" \
+         -F "file=@$FILE"
+    if [ ! $? ]; then
+        echo "Failed to push RPM package"
+        exit 1
+    fi
+done

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -5,7 +5,7 @@ set -uo pipefail
 
 AUDIENCE=$1
 
-goreleaser release --clean --auto-snapshot --skip publish
+goreleaser release --clean --snapshot
 
 if [ ! $? ]; then
     echo "Failed to build a release"

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -22,9 +22,7 @@ upload_url() {
     echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"
 }
 
-goreleaser release --clean ${GORELEASER_ARGS}
-
-if [[ ! $? ]]; then
+if ! goreleaser release --clean ${GORELEASER_ARGS}; then
     echo "Failed to build a release"
     exit 1
 fi

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -1,16 +1,71 @@
 #!/bin/env bash
 
+#
+# This script is used to build a release of the CLI and publish it to multiple registries on Buildkite
+#
+
 # NOTE: do not exit on non-zero returns codes
 set -uo pipefail
 
-AUDIENCE=$1
+GORELEASER_ARGS=""
+ORGANIZATION=""
+REGISTRY=""
+PUBLISH=false
+PACKAGE=""
 
-goreleaser release --clean --snapshot
+function audience() {
+    ORG=$1
+    REGISTRY=$2
+    echo "https://packages.buildkite.com/organizations/${ORG}/packages/registries/${REGISTRY}"
+}
+function upload_url() {
+    ORG=$1
+    REGISTRY=$2
+    echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"
+}
+
+# Parse flags and their arguments
+while shopt -s nullglob; do
+    case "$1" in
+    --snapshot)
+        GORELEASER_ARGS="${GORELEASER_ARGS} --snapshot"
+        shift
+        ;;
+    --org)
+        ORGANIZATION=$2
+        shift 2
+        ;;
+    --registry)
+        REGISTRY=$2
+        shift 2
+        ;;
+    --package)
+        PACKAGE=$2
+        shift 2
+        ;;
+    --publish)
+        PUBLISH=true
+        shift
+        ;;
+    *)
+        break
+        ;;
+    esac
+done
+
+goreleaser release --clean ${GORELEASER_ARGS}
 
 if [ ! $? ]; then
     echo "Failed to build a release"
     exit 1
 fi
+
+if [ ! $PUBLISH ]; then
+    echo "Not publishing package to registries"
+    exit 0
+fi
+
+AUDIENCE=$(audience $ORGANIZATION $REGISTRY)
 
 # grab a token for pushing packages to buildkite with an expiry of 3 mins
 TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
@@ -20,10 +75,8 @@ if [ ! $? ]; then
     exit 1
 fi
 
-echo $TOKEN
-
-for FILE in dist/*.rpm; do
-    curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
+for FILE in dist/*.${PACKAGE}; do
+    curl -X POST $(upload_url $ORGANIZATION $REGISTRY) \
          -H "Authorization: Bearer ${TOKEN}" \
          -F "file=@${FILE}" \
         --fail-with-body

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -22,6 +22,13 @@ upload_url() {
     echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"
 }
 
+GORELEASER_KEY=$(buildkite-agent secret get goreleaser_key)
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to retrieve GoReleaser Pro key"
+    exit 1
+fi
+
 if ! goreleaser release --clean ${GORELEASER_ARGS}; then
     echo "Failed to build a release"
     exit 1

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -24,8 +24,10 @@ for FILE in dist/*.rpm; do
     curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
          -H "Authorization: Bearer ${TOKEN}" \
          -F "file=@${FILE}"
+        --fail-with-body
+
     if [ ! $? ]; then
-        echo "Failed to push RPM package"
+        echo "Failed to push RPM package $file"
         exit 1
     fi
 done

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -37,7 +37,7 @@ AUDIENCE=$(audience $ORGANIZATION $REGISTRY)
 # grab a token for pushing packages to buildkite with an expiry of 3 mins
 TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
 
-if [[ ! $? ]]; then
+if [[ $? -ne 0 ]]; then
     echo "Failed to retrieve OIDC token"
     exit 1
 fi
@@ -48,7 +48,7 @@ for FILE in dist/*.${PACKAGE}; do
          -F "file=@${FILE}" \
         --fail-with-body
 
-    if [ ! $? ]; then
+    if [[ $? -ne 0 ]]; then
         echo "Failed to push RPM package $file"
         exit 1
     fi

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -20,6 +20,8 @@ if [ ! $? ]; then
     exit 1
 fi
 
+echo $TOKEN
+
 for FILE in dist/*.rpm; do
     curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
          -H "Authorization: Bearer ${TOKEN}" \

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -13,12 +13,12 @@ REGISTRY=""
 PUBLISH=false
 PACKAGE=""
 
-function audience() {
+audience() {
     ORG=$1
     REGISTRY=$2
     echo "https://packages.buildkite.com/organizations/${ORG}/packages/registries/${REGISTRY}"
 }
-function upload_url() {
+upload_url() {
     ORG=$1
     REGISTRY=$2
     echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -21,7 +21,7 @@ if [ ! $? ]; then
 fi
 
 for FILE in dist/*.rpm; do
-    echo curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
+    curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
          -H "Authorization: Bearer ${TOKEN}" \
          -F "file=@${FILE}"
     if [ ! $? ]; then

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -25,7 +25,7 @@ echo $TOKEN
 for FILE in dist/*.rpm; do
     curl -X POST https://api.buildkite.com/v2/packages/organizations/jradtilbrook/registries/cli-rpm/packages \
          -H "Authorization: Bearer ${TOKEN}" \
-         -F "file=@${FILE}"
+         -F "file=@${FILE}" \
         --fail-with-body
 
     if [ ! $? ]; then

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
+  - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 2
-    reviewers:
-      - "jradtilbrook"
+  - package-ecosystem: docker
+    directory: .buildkite
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,4 +66,24 @@ archives:
       - LICENSE.md
       - README.md
 
+nfpms:
+  - builds:
+      - linux
+    vendor: Buildkite
+    homepage: https://buildkite.com
+    maintainer: Buildkite <support@buildkite.com>
+    description: A command line interface for Buildkite.
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+    provides:
+      - bk
+    recommends:
+      - jq
+    contents:
+      - dst: /usr/bin/bk
+        src: bin/bk
+
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
 project_name: bk
 
-partial:
-  by: target
-
 release:
   name_template: Buildkite CLI {{.Version}}
   draft: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 project_name: bk
 
+partial:
+  by: target
+
 release:
   name_template: Buildkite CLI {{.Version}}
   draft: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,10 +80,8 @@ nfpms:
       - rpm
     provides:
       - bk
-    # bindir: /usr
-    # TODO bindir/contents seems wrong
-    contents:
-      - dst: /usr/bin/bk
-        src: dist/linux_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/bk
+    # contents:
+    #   - dst: /usr/bin/bk
+    #     src: dist/linux_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/bk
 
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,10 +80,10 @@ nfpms:
       - rpm
     provides:
       - bk
-    recommends:
-      - jq
+    # bindir: /usr
+    # TODO bindir/contents seems wrong
     contents:
       - dst: /usr/bin/bk
-        src: bin/bk
+        src: dist/linux_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/bk
 
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,8 +80,5 @@ nfpms:
       - rpm
     provides:
       - bk
-    # contents:
-    #   - dst: /usr/bin/bk
-    #     src: dist/linux_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/bk
 
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
   - id: macos
     goos: [darwin]
     goarch: [amd64, arm64]
-    binary: bin/bk
+    binary: bk
     main: ./cmd/bk
     ldflags:
       - -s -w -X github.com/buildkite/cli/v3/internal/version.Version={{.Version}}
@@ -25,7 +25,7 @@ builds:
     goarch: ['386', arm, amd64, arm64]
     env:
       - CGO_ENABLED=0
-    binary: bin/bk
+    binary: bk
     main: ./cmd/bk
     ldflags:
       - -s -w -X github.com/buildkite/cli/v3/internal/version.Version={{.Version}}
@@ -33,7 +33,7 @@ builds:
   - id: windows
     goos: [windows]
     goarch: ['386', amd64, arm64]
-    binary: bin/bk
+    binary: bk
     main: ./cmd/bk
     ldflags:
       - -s -w -X github.com/buildkite/cli/v3/internal/version.Version={{.Version}}


### PR DESCRIPTION
Changes:

- introduced a Dockerfile that pulls from goreleaser
  - this allows dependabot to keep our goreleaser version up to date for us so we are always using the newest version
- consolidated the build/release portions of docker-compose to use the Dockerfile
  - both services were using the same image with different config, that config has moved to pipeline.yaml now instead
- the build step now produces packages and pushes them to artifacts. we might push them to the registry in a future PR, or leave it for only 3.x builds
- added a release.sh script for housing the building and pushing of packages
- updated .goreleaser.yaml to create linux packages
- use goreleaser pro and split the build so it runs faster