### PR TITLE
Add checks if a remote URL exists, or if repo exists

### DIFF
--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -82,12 +81,16 @@ func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([
 
 func getRepoURLs(r *git.Repository) ([]string, error) {
 	if r == nil {
-		return nil, fmt.Errorf("could not determine current repository")
+		return nil, nil // could not resolve to any repository, proceed to another resolver
 	}
 
 	c, err := r.Config()
 	if err != nil {
 		return nil, err
+	}
+
+	if _, ok := c.Remotes["origin"]; !ok {
+		return nil, nil // repo's "origin" remote does not exist, proceed to another resolver
 	}
 	return c.Remotes["origin"].URLs, nil
 }

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -25,24 +25,9 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	t.Run("no pipelines found", func(t *testing.T) {
 		t.Parallel()
 		// mock a response that doesn't match the current repository url
-		transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)),
-			}, nil
-		})
-		client := &http.Client{Transport: transport}
-
-		bkClient := buildkite.NewClient(client)
-		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SelectOrganization("testOrg")
-		f := factory.Factory{
-			Config:        conf,
-			RestAPIClient: bkClient,
-			HttpClient:    client,
-			GitRepository: testRepository(),
-		}
-		pipelines, err := resolveFromRepository(&f)
+		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
+		f := testFactory(client, "testOrg", testRepository())
+		pipelines, err := resolveFromRepository(f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -54,25 +39,10 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("one pipeline", func(t *testing.T) {
 		t.Parallel()
-		// mock a response with a single pipeline matching the current repo url
-		transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)),
-			}, nil
-		})
-		client := &http.Client{Transport: transport}
-
-		bkClient := buildkite.NewClient(client)
-		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SelectOrganization("testOrg")
-		f := factory.Factory{
-			Config:        conf,
-			RestAPIClient: bkClient,
-			HttpClient:    client,
-			GitRepository: testRepository(),
-		}
-		pipelines, err := resolveFromRepository(&f)
+		// mock an http client response with a single pipeline matching the current repo url
+		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)
+		f := testFactory(client, "testOrg", testRepository())
+		pipelines, err := resolveFromRepository(f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -83,25 +53,11 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("multiple pipelines", func(t *testing.T) {
 		t.Parallel()
-		// mock a response with 2 pipelines matching the current repo url
-		transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body: io.NopCloser(strings.NewReader(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"},
-						{"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)),
-			}, nil
-		})
-		client := &http.Client{Transport: transport}
-		bkClient := buildkite.NewClient(client)
-		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SelectOrganization("testOrg")
-		f := factory.Factory{
-			Config:        conf,
-			RestAPIClient: bkClient,
-			HttpClient:    client,
-			GitRepository: testRepository(),
-		}
-		pipelines, err := resolveFromRepository(&f)
+		// mock an http client response with 2 pipelines matching the current repo url
+		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"},
+		{"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)
+		f := testFactory(client, "testOrg", testRepository())
+		pipelines, err := resolveFromRepository(f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -109,9 +65,55 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 			t.Errorf("Expected 2 pipeline, got %d", len(pipelines))
 		}
 	})
+
+	t.Run("no repository found", func(t *testing.T) {
+		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
+		f := testFactory(client, "testOrg", nil)
+		pipelines, err := resolveFromRepository(f)
+		if pipelines != nil {
+			t.Errorf("Expected nil, got %v", pipelines)
+		}
+		if err != nil {
+			t.Errorf("Expected nil, got error: %s", err)
+		}
+	})
+
+	t.Run("no remote repository found", func(t *testing.T) {
+		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
+		f := testFactory(client, "testOrg", testRepository())
+		pipelines, err := resolveFromRepository(f)
+		if pipelines != nil {
+			t.Errorf("Expected nil, got %v", pipelines)
+		}
+		if err != nil {
+			t.Errorf("Expected nil, got error: %s", err)
+		}
+	})
 }
 
 func testRepository() *git.Repository {
 	repo, _ := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
 	return repo
+}
+
+func testFactory(client *http.Client, org string, repo *git.Repository) *factory.Factory {
+	bkClient := buildkite.NewClient(client)
+	conf := config.New(afero.NewMemMapFs(), nil)
+	conf.SelectOrganization(org)
+	return &factory.Factory{
+		Config:        conf,
+		RestAPIClient: bkClient,
+		HttpClient:    client,
+		GitRepository: repo,
+	}
+}
+
+func mockHttpClient(response string) *http.Client {
+	transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(response)),
+		}, nil
+	})
+	return &http.Client{Transport: transport}
 }


### PR DESCRIPTION
This PR resolves the segfault issue reported by @patrobinson when running the cli in a directory without a remote set. 

Two scenarios are addressed here:

- we should check if in a repository within the ResolveFromRepository resolver prior to making API requests
_if not in a repo, we can pass through (returning nil, nil)_

- we need to also check the repo's "origin" remote exists in the Remotes map prior to retrieving the URLs field. if origin _does not exist, we can passthrough (nil, nil)_

Updated/refactored the tests for Repository Resolver function 