### PR TITLE
`bk build download --logs` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 buildkite.yaml
 .bk.yaml
+build-logs-*

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -30,10 +30,11 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(NewCmdBuildNew(f))
-	cmd.AddCommand(NewCmdBuildView(f))
-	cmd.AddCommand(NewCmdBuildRebuild(f))
 	cmd.AddCommand(NewCmdBuildCancel(f))
+	cmd.AddCommand(NewCmdBuildDownload(f))
+	cmd.AddCommand(NewCmdBuildNew(f))
+	cmd.AddCommand(NewCmdBuildRebuild(f))
+	cmd.AddCommand(NewCmdBuildView(f))
 
 	return &cmd
 }

--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -1,0 +1,51 @@
+package build
+
+import (
+	"fmt"
+
+	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
+	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
+	var logs bool
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "download [number [pipeline]] [flags]",
+		Short:                 "Download resources of a build",
+		Long:                  "Download allows you to download resources from a build.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pipelineRes := pipelineResolver.NewAggregateResolver(
+				pipelineResolver.ResolveFromPositionalArgument(args, 1, f.Config),
+				pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
+				pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOne)),
+			)
+
+			buildRes := buildResolver.NewAggregateResolver(
+				buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),
+				// buildResolver.ResolveBuildFromCurrentBranch(f.GitRepository, pipelineRes.Resolve, f),
+			)
+
+			bld, err := buildRes.Resolve(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if bld == nil {
+				return fmt.Errorf("could not resolve a build")
+			}
+
+			return download()
+		},
+	}
+
+	cmd.Flags().BoolVar(&logs, "logs", false, "Download all job logs for the build")
+
+	return &cmd
+}
+
+func download() error {
+	return nil
+}

--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/buildkite/cli/v3/internal/build"
 	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/charmbracelet/huh/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -40,11 +39,15 @@ func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a build")
 			}
 
-			s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-			s.Suffix = " Downloading logs"
-			s.Start()
-			defer s.Stop()
-			err = download(*bld, f)
+			spinErr := spinner.New().
+				Title("Downloading logs").
+				Action(func() {
+					err = download(*bld, f)
+				}).
+				Run()
+			if spinErr != nil {
+				return spinErr
+			}
 
 			return err
 		},

--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -15,18 +15,12 @@ import (
 )
 
 func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
-	var logs bool
-
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "download [number [pipeline]] [flags]",
-		Short:                 "Download resources of a build",
-		Long:                  "Download allows you to download resources from a build.",
+		Short:                 "Download job logs for a build",
+		Long:                  "Download allows you to download resources for a build.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !logs {
-				fmt.Println("Nothing to download")
-				return nil
-			}
 			pipelineRes := pipelineResolver.NewAggregateResolver(
 				pipelineResolver.ResolveFromPositionalArgument(args, 1, f.Config),
 				pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
@@ -55,8 +49,6 @@ func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
 			return err
 		},
 	}
-
-	cmd.Flags().BoolVar(&logs, "logs", false, "Download all job logs for the build")
 
 	return &cmd
 }

--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/buildkite/cli/v3/internal/build"
 	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
@@ -50,6 +52,10 @@ func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
 }
 
 func download(build build.Build, logs bool, f *factory.Factory) error {
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	s.Suffix = " Downloading logs"
+	s.Start()
+	defer s.Stop()
 	b, _, err := f.RestAPIClient.Builds.Get(build.Organization, build.Pipeline, fmt.Sprint(build.BuildNumber), nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This command will allow downloading all job logs for a build. It creates a directory and puts each job's log into a separate file within.
