### PR TITLE
Add job list in build output

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -27,7 +27,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err = os.WriteFile(schemaFile, []byte(schema), 0644); err != nil {
+		if err = os.WriteFile(schemaFile, []byte(schema), 0o644); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}

--- a/internal/agent/list.go
+++ b/internal/agent/list.go
@@ -12,8 +12,10 @@ import (
 	"github.com/pkg/browser"
 )
 
-var agentListStyle = lipgloss.NewStyle().Padding(1, 2)
-var viewPortStyle = agentListStyle.Copy()
+var (
+	agentListStyle = lipgloss.NewStyle().Padding(1, 2)
+	viewPortStyle  = agentListStyle.Copy()
+)
 
 type AgentListModel struct {
 	agentList          list.Model

--- a/internal/build/resolver/current_branch_test.go
+++ b/internal/build/resolver/current_branch_test.go
@@ -41,7 +41,6 @@ func TestResolveBuildFromCurrentBranch(t *testing.T) {
 		}
 		r := resolver.ResolveBuildFromCurrentBranch(testRepository(), pipelineResolver, &f)
 		b, err := r(context.Background())
-
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/build/resolver/user_builds_test.go
+++ b/internal/build/resolver/user_builds_test.go
@@ -127,7 +127,6 @@ func TestResolveBuildForCurrentUser(t *testing.T) {
 
 		r := resolver.ResolveBuildForCurrentUser("main", pipelineResolver, f)
 		build, err := r(context.Background())
-
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/build/view.go
+++ b/internal/build/view.go
@@ -58,7 +58,6 @@ func getBuildStateColor(state string) lipgloss.Color {
 }
 
 func renderBuildState(state string, blocked bool) string {
-
 	var stateIcon string
 	stateColor := getBuildStateColor(state)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,7 +202,7 @@ func createIfNotExistsConfigDir() (string, error) {
 
 	configDir := filepath.Join(homeDir, ".config")
 	if _, err := os.Stat(configDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(configDir, 0755)
+		err := os.Mkdir(configDir, 0o755)
 		if err != nil {
 			return "", err
 		}

--- a/internal/job/view.go
+++ b/internal/job/view.go
@@ -1,0 +1,87 @@
+package job
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func JobSummary(job *buildkite.Job) string {
+	jobName := getJobName(*job)
+  jobTotalTime, err := calculateTotalTime(job.StartedAt, job.FinishedAt)
+  if err != nil {
+    log.Fatal("Unable to calculate total job time", err)
+  }
+
+  jobInfo := fmt.Sprintf("%s %s (%s)", renderJobState(*job.State), jobName, lipgloss.NewStyle().Foreground(lipgloss.Color("#5A5A5A")).Render(jobTotalTime.String()))
+
+  summary := lipgloss.JoinVertical(lipgloss.Top,
+    lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
+    lipgloss.NewStyle().Bold(true).Padding(0, 1).Render(jobInfo),
+    )
+	return summary
+}
+
+func getJobName(job buildkite.Job) string {
+	var jobName string
+
+	switch {
+	case job.Name != nil:
+		jobName = *job.Name
+	case job.Label != nil:
+		jobName = *job.Label
+	default:
+		jobName = *job.Command
+	}
+
+	return jobName
+}
+
+func renderJobState(state string) string {
+	var stateIcon string
+	stateColor := getJobStateColor(state)
+
+	switch state {
+	case "passed":
+		stateIcon = "✔"
+	case "running":
+		stateIcon = "▶"
+	case "failed", "failing":
+		stateIcon = "✖"
+	case "canceled":
+		stateIcon = "🚫"
+	case "canceling":
+		stateIcon = "🚫(cancelling...)"
+	default:
+		stateIcon = "❔"
+	}
+
+	return lipgloss.NewStyle().Foreground(stateColor).Render(stateIcon)
+}
+
+func getJobStateColor(state string) lipgloss.Color {
+	var stateColor lipgloss.Color
+	switch state {
+	case "passed":
+		stateColor = lipgloss.Color("#9dcc3a") // green
+	case "running":
+		stateColor = lipgloss.Color("#FF6E00")
+	case "failed", "failing":
+		stateColor = lipgloss.Color("#ff0000")
+	default:
+		stateColor = lipgloss.Color("#5A5A5A") // grey
+	}
+	return stateColor
+}
+
+func calculateTotalTime(startedAt, finishedAt *buildkite.Timestamp) (time.Duration, error) {
+    if startedAt == nil || finishedAt == nil {
+        return 0, errors.New("both startedAt and finishedAt must be non-nil")
+    }
+
+    return finishedAt.Time.Sub(startedAt.Time), nil
+}

--- a/internal/job/view.go
+++ b/internal/job/view.go
@@ -12,17 +12,17 @@ import (
 
 func JobSummary(job *buildkite.Job) string {
 	jobName := getJobName(*job)
-  jobTotalTime, err := calculateTotalTime(job.StartedAt, job.FinishedAt)
-  if err != nil {
-    log.Fatal("Unable to calculate total job time", err)
-  }
+	jobTotalTime, err := calculateTotalTime(job.StartedAt, job.FinishedAt)
+	if err != nil {
+		log.Fatal("Unable to calculate total job time", err)
+	}
 
-  jobInfo := fmt.Sprintf("%s %s (%s)", renderJobState(*job.State), jobName, lipgloss.NewStyle().Foreground(lipgloss.Color("#5A5A5A")).Render(jobTotalTime.String()))
+	jobInfo := fmt.Sprintf("%s %s (%s)", renderJobState(*job.State), jobName, lipgloss.NewStyle().Foreground(lipgloss.Color("#5A5A5A")).Render(jobTotalTime.String()))
 
-  summary := lipgloss.JoinVertical(lipgloss.Top,
-    lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
-    lipgloss.NewStyle().Bold(true).Padding(0, 1).Render(jobInfo),
-    )
+	summary := lipgloss.JoinVertical(lipgloss.Top,
+		lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
+		lipgloss.NewStyle().Bold(true).Padding(0, 1).Render(jobInfo),
+	)
 	return summary
 }
 
@@ -79,9 +79,9 @@ func getJobStateColor(state string) lipgloss.Color {
 }
 
 func calculateTotalTime(startedAt, finishedAt *buildkite.Timestamp) (time.Duration, error) {
-    if startedAt == nil || finishedAt == nil {
-        return 0, errors.New("both startedAt and finishedAt must be non-nil")
-    }
+	if startedAt == nil || finishedAt == nil {
+		return 0, errors.New("both startedAt and finishedAt must be non-nil")
+	}
 
-    return finishedAt.Time.Sub(startedAt.Time), nil
+	return finishedAt.Time.Sub(startedAt.Time), nil
 }

--- a/internal/pipeline/resolver/config_test.go
+++ b/internal/pipeline/resolver/config_test.go
@@ -68,5 +68,4 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 			t.Errorf("pipeline name should resolve temporarily to pipeline1")
 		}
 	})
-
 }

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -34,7 +34,6 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		if len(pipelines) != 0 {
 			t.Errorf("Expected 0 pipeline, got %d", len(pipelines))
 		}
-
 	})
 
 	t.Run("one pipeline", func(t *testing.T) {

--- a/pkg/cmd/agent/stop.go
+++ b/pkg/cmd/agent/stop.go
@@ -56,7 +56,7 @@ func RunStop(cmd *cobra.Command, args []string, opts *AgentStopOptions) error {
 	// use a wait group to ensure we exit the program after all agents have finished
 	var wg sync.WaitGroup
 	// this semaphore is used to limit how many concurrent API requests can be sent
-	var sem = semaphore.NewWeighted(opts.limit)
+	sem := semaphore.NewWeighted(opts.limit)
 
 	var agents []agent.StoppableAgent
 	// this command accepts either input from stdin or positional arguments (not both) in that order

--- a/pkg/cmd/agent/view.go
+++ b/pkg/cmd/agent/view.go
@@ -37,7 +37,6 @@ func NewCmdAgentView(f *factory.Factory) *cobra.Command {
 
 			l := io.NewPendingCommand(func() tea.Msg {
 				agentData, _, err := f.RestAPIClient.Agents.Get(org, id)
-
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -39,7 +39,6 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 }
 
 func openBuildInBrowser(openInWeb bool, webUrl string) error {
-
 	if openInWeb {
 		fmt.Printf("Opening %s in your browser\n", webUrl)
 		err := browser.OpenURL(webUrl)

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -67,7 +67,6 @@ func cancelBuild(org string, pipeline string, buildId string, web bool, f *facto
 		}
 
 		return io.PendingOutput(renderResult(fmt.Sprintf("Cancelling build: %s\n", *build.WebURL)))
-
 	}, fmt.Sprintf("Cancelling build #%s from pipeline %s", buildId, pipeline))
 
 	p := tea.NewProgram(l)

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -59,7 +59,6 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 
 func newBuild(org string, pipeline string, f *factory.Factory, message string, commit string, branch string, web bool) error {
 	l := io.NewPendingCommand(func() tea.Msg {
-
 		if len(branch) == 0 {
 			p, _, err := f.RestAPIClient.Pipelines.Get(org, pipeline)
 			if err != nil {
@@ -85,7 +84,6 @@ func newBuild(org string, pipeline string, f *factory.Factory, message string, c
 
 		return io.PendingOutput(lipgloss.JoinVertical(lipgloss.Top,
 			lipgloss.NewStyle().Padding(1, 1).Render(fmt.Sprintf("Build created: %s\n", *build.WebURL))))
-
 	}, fmt.Sprintf("Starting new build for %s", pipeline))
 	p := tea.NewProgram(l)
 	_, err := p.Run()

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -67,7 +67,6 @@ func rebuild(org string, pipeline string, buildId string, web bool, f *factory.F
 		}
 
 		return io.PendingOutput(renderResult(fmt.Sprintf("Build created: %s\n", *build.WebURL)))
-
 	}, fmt.Sprintf("Rerunning build #%s for pipeline %s", buildId, pipeline))
 
 	p := tea.NewProgram(l)

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/build"
 	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
 	"github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/internal/job"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
@@ -83,9 +84,15 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 						fmt.Println("Error opening browser: ", err)
 					}
 				}
-
+  
 				// Obtain build summary and return
 				summary := build.BuildSummary(b)
+        if len(b.Jobs) > 0 {
+          summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nJobs")
+          for _, j := range b.Jobs{
+            summary += job.JobSummary(j)
+          }
+        }
 				if len(buildArtifacts) > 0 {
 					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nArtifacts")
 					for _, a := range buildArtifacts {

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -36,8 +36,8 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			If the pipeline argument is omitted, it will be resolved using the current directory.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var buildArtifacts = make([]buildkite.Artifact, 0)
-			var buildAnnotations = make([]buildkite.Annotation, 0)
+			buildArtifacts := make([]buildkite.Artifact, 0)
+			buildAnnotations := make([]buildkite.Annotation, 0)
 
 			pipelineRes := pipelineResolver.NewAggregateResolver(
 				pipelineResolver.ResolveFromPositionalArgument(args, 1, f.Config),
@@ -84,15 +84,15 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 						fmt.Println("Error opening browser: ", err)
 					}
 				}
-  
+
 				// Obtain build summary and return
 				summary := build.BuildSummary(b)
-        if len(b.Jobs) > 0 {
-          summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nJobs")
-          for _, j := range b.Jobs{
-            summary += job.JobSummary(j)
-          }
-        }
+				if len(b.Jobs) > 0 {
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nJobs")
+					for _, j := range b.Jobs {
+						summary += job.JobSummary(j)
+					}
+				}
 				if len(buildArtifacts) > 0 {
 					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nArtifacts")
 					for _, a := range buildArtifacts {


### PR DESCRIPTION
## Changes
This allows the printing of build jobs to the terminal. We can kind of safely assume that a build will always have at least one job, but could implement tests too if eventually.

The output looks like:
![CleanShot 2024-06-06 at 15 15 17](https://github.com/buildkite/cli/assets/10952642/3c079e20-5cd7-4559-bc49-da51edc7ab11)

I didn't want the time to become the focus, so made it grey in colour.
