### PR TITLE
Change bk build pipeline argument to a flag

### DIFF
--- a/internal/pipeline/resolver/flag.go
+++ b/internal/pipeline/resolver/flag.go
@@ -1,0 +1,27 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/pipeline"
+)
+
+func ResolveFromFlag(flag string, conf *config.Config) PipelineResolverFn {
+	return func(context.Context) (*pipeline.Pipeline, error) {
+		// if the flag is empty, pass through
+		if flag == "" {
+			return nil, nil
+		}
+		org, name := parsePipelineArg(flag, conf)
+
+		// if we get here, we should be able to parse the value and return an error if not
+		// this is because a user has explicitly given an input value for us to use - we shoulnt ignore it on error
+		if org == "" || name == "" {
+			return nil, fmt.Errorf("unable to parse the input pipeline argument: \"%s\"", flag)
+		}
+
+		return &pipeline.Pipeline{Name: name, Org: org}, nil
+	}
+}

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -22,6 +22,11 @@ func PickOne(pipelines []pipeline.Pipeline) *pipeline.Pipeline {
 		return nil
 	}
 
+	// no need to prompt for only one option
+	if len(pipelines) == 1 {
+		return &pipelines[0]
+	}
+
 	names := make([]string, len(pipelines))
 	for i, p := range pipelines {
 		names[i] = p.Name

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -14,25 +14,24 @@ import (
 )
 
 func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
-	var message string
-	var commit string
 	var branch string
+	var commit string
+	var message string
+	var pipeline string
 	var web bool
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "new [pipeline] [flags]",
-		Short:                 "Creates a new pipeline build",
-		Args:                  cobra.MaximumNArgs(1),
+		Use:                   "new [flags]",
+		Short:                 "Create a new build",
+		Args:                  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Creates a new build for the specified pipeline and output the URL to the build.
-
-			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
-			If the pipeline argument is omitted, it will be resolved using the current directory.
+			Create a new build on a pipeline.
+			The web URL to the build will be printed to stdout.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvers := resolver.NewAggregateResolver(
-				resolver.ResolveFromPositionalArgument(args, 0, f.Config),
+				resolver.ResolveFromFlag(pipeline, f.Config),
 				resolver.ResolveFromConfig(f.Config, resolver.PickOne),
 				resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOne)),
 			)
@@ -53,6 +52,9 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&commit, "commit", "c", "HEAD", "The commit to build.")
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "The branch to build. Defaults to the default branch of the pipeline.")
 	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
+		"If omitted, it will be resolved using the current directory.",
+	)
 	cmd.Flags().SortFlags = false
 	return &cmd
 }

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -14,21 +14,20 @@ import (
 
 func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 	var web bool
+	var pipeline string
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "rebuild [number [pipeline]] [flags]",
-		Short:                 "Reruns a build.",
+		Use:                   "rebuild [number] [flags]",
+		Short:                 "Rebuild a build.",
+		Args:                  cobra.MaximumNArgs(1),
 		Long: heredoc.Doc(`
-			Runs a new build from the specified build number and pipeline and outputs the URL to the new build.
-
-			It accepts a build number and a pipeline slug  as an argument.
-			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
-			If the pipeline argument is omitted, it will be resolved using the current directory.
+			Rebuild a build.
+			The web URL to the build will be printed to stdout.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pipelineRes := pipelineResolver.NewAggregateResolver(
-				pipelineResolver.ResolveFromPositionalArgument(args, 1, f.Config),
+				pipelineResolver.ResolveFromFlag(pipeline, f.Config),
 				pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
 				pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOne)),
 			)
@@ -51,6 +50,9 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser after it has been created.")
+	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
+		"If omitted, it will be resolved using the current directory.",
+	)
 	cmd.Flags().SortFlags = false
 	return &cmd
 }

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -22,18 +22,16 @@ import (
 
 func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 	var web bool
+	var pipeline string
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "view [number [pipeline]] [flags]",
+		Use:                   "view [number] [flags]",
 		Short:                 "View build information.",
 		Long: heredoc.Doc(`
 			View a build's information.
 
-			It accepts a build number and a pipeline slug as an argument.
-			If the build argument is be omitted, the most recent build on the current branch will be resolved.
-			The pipeline can be a {pipeline_slug} or in the format {org_slug}/{pipeline_slug}.
-			If the pipeline argument is omitted, it will be resolved using the current directory.
+			You can pass an optional build number to view. If omitted, the most recent build on the current branch will be resolved.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buildArtifacts := make([]buildkite.Artifact, 0)
@@ -116,6 +114,9 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&web, "web", "w", false, "Open the build in a web browser.")
+	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to view. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
+		"If omitted, it will be resolved using the current directory.",
+	)
 
 	return &cmd
 }

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -28,6 +28,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Use:                   "view [number] [flags]",
 		Short:                 "View build information.",
+		Args:                  cobra.MaximumNArgs(1),
 		Long: heredoc.Doc(`
 			View a build's information.
 
@@ -38,7 +39,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			buildAnnotations := make([]buildkite.Annotation, 0)
 
 			pipelineRes := pipelineResolver.NewAggregateResolver(
-				pipelineResolver.ResolveFromPositionalArgument(args, 1, f.Config),
+				pipelineResolver.ResolveFromFlag(pipeline, f.Config),
 				pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
 				pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOne)),
 			)


### PR DESCRIPTION
This changes the positional pipeline argument to a flag instead. This should make more sense to users to allow specifying which pipeline to operate on within the build commands
