### PR TITLE
Add AI chat command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/muesli/reflow v0.3.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/sashabaranov/go-openai v1.24.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.19.0
 	golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f h1:MvTmaQdww/z0Q4wrYjDSCcZ78NoftLQyHBSLW/Cx79Y=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/sashabaranov/go-openai v1.24.1 h1:DWK95XViNb+agQtuzsn+FyHhn3HQJ7Va8z04DQDJ1MI=
+github.com/sashabaranov/go-openai v1.24.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=

--- a/pkg/cmd/ai/ai.go
+++ b/pkg/cmd/ai/ai.go
@@ -3,18 +3,23 @@ package ai
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdAI(f *factory.Factory) *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "ai <command>",
-		Short: "Manage AI integration.",
-		Long:  "Work with Buildkite AI.",
+		Use:     "ai <command>",
+		Short:   "Manage AI integration.",
+		Long:    "Work with Buildkite AI.",
+		PreRunE: validation.OpenAITokenConfigured(f.Config),
 		Example: heredoc.Doc(`
 			# To configure your AI token
 			$ bk ai configure
 		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 	}
 
 	cmd.AddCommand(NewCmdAIConfigure(f))

--- a/pkg/cmd/ai/ai.go
+++ b/pkg/cmd/ai/ai.go
@@ -9,6 +9,7 @@ import (
 
 func NewCmdAI(f *factory.Factory) *cobra.Command {
 	cmd := cobra.Command{
+		Hidden:  true,
 		Use:     "ai <command>",
 		Short:   "Manage AI integration.",
 		Long:    "Work with Buildkite AI.",

--- a/pkg/cmd/ai/ai.go
+++ b/pkg/cmd/ai/ai.go
@@ -3,27 +3,23 @@ package ai
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/spf13/cobra"
 )
 
 func NewCmdAI(f *factory.Factory) *cobra.Command {
 	cmd := cobra.Command{
-		Hidden:  true,
-		Use:     "ai <command>",
-		Short:   "Manage AI integration.",
-		Long:    "Work with Buildkite AI.",
-		PreRunE: validation.OpenAITokenConfigured(f.Config),
+		Hidden: true,
+		Use:    "ai <command>",
+		Short:  "Manage AI integration.",
+		Long:   "Work with Buildkite AI.",
 		Example: heredoc.Doc(`
 			# To configure your AI token
 			$ bk ai configure
 		`),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(NewCmdAIConfigure(f))
+	cmd.AddCommand(NewCmdAIAsk(f))
 
 	return &cmd
 }

--- a/pkg/cmd/ai/ask.go
+++ b/pkg/cmd/ai/ask.go
@@ -1,0 +1,72 @@
+package ai
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	bk_io "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/sashabaranov/go-openai"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdAIAsk(f *factory.Factory) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "ask [prompt]",
+		Short: "Ask Buildkite AI a question.",
+		Long: heredoc.Doc(`
+			AI for Buildkite. You can interact with AI to help solve errors in your builds or surface documentation.
+		`),
+		Args:    cobra.MaximumNArgs(1),
+		PreRunE: validation.OpenAITokenConfigured(f.Config),
+		Example: heredoc.Doc(`
+			$ bk ai ask "How can I run a buildkite-agent on Ubuntu?"
+			$ echo "Why did my job fail with exit code 255?" | bk ai ask
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var input string
+			if bk_io.HasDataAvailable(cmd.InOrStdin()) {
+				stdin := new(strings.Builder)
+				_, err := io.Copy(stdin, cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				input = stdin.String()
+			} else if len(args) >= 0 {
+				input = args[0]
+			} else {
+				return errors.New("must supply a prompt")
+			}
+
+			client := *f.OpenAIClient
+			resp, err := client.CreateChatCompletion(cmd.Context(), openai.ChatCompletionRequest{
+				Model: openai.GPT3Dot5Turbo,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: input,
+					},
+				},
+			})
+			if err != nil {
+				return err
+			}
+			if len(resp.Choices) == 0 {
+				return errors.New("no response received")
+			}
+			var msg strings.Builder
+			for _, c := range resp.Choices {
+				msg.WriteString(c.Message.Content)
+				msg.WriteString("\n")
+			}
+
+			_, err = cmd.OutOrStdout().Write([]byte(msg.String()))
+			return err
+		},
+	}
+
+	return &cmd
+}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/go-git/go-git/v5"
+	"github.com/sashabaranov/go-openai"
 )
 
 type Factory struct {
@@ -17,6 +18,7 @@ type Factory struct {
 	GitRepository *git.Repository
 	GraphQLClient graphql.Client
 	HttpClient    *http.Client
+	OpenAIClient  *openai.Client
 	RestAPIClient *buildkite.Client
 	Version       string
 }
@@ -31,6 +33,7 @@ func New(version string) *Factory {
 		GitRepository: repo,
 		GraphQLClient: graphql.NewClient(config.DefaultGraphQLEndpoint, client),
 		HttpClient:    client,
+		OpenAIClient:  openai.NewClient(conf.GetOpenAIToken()),
 		RestAPIClient: buildkite.NewClient(client),
 		Version:       version,
 	}

--- a/pkg/cmd/validation/openai_token.go
+++ b/pkg/cmd/validation/openai_token.go
@@ -1,0 +1,18 @@
+package validation
+
+import (
+	"errors"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func OpenAITokenConfigured(conf *config.Config) func(cmd *cobra.Command, args []string) error {
+	var err error
+	if conf.GetOpenAIToken() == "" {
+		err = errors.New("You must set an OpenAI API token to use this command. Run `bk ai configure`.")
+	}
+	return func(cmd *cobra.Command, args []string) error {
+		return err
+	}
+}


### PR DESCRIPTION
Adds a _hidden_ AI command used to query OpenAI. Its the bare minimum at the moment. No prompting engineering to tweaking going on. I want to land this as is before trying to tweak it.