### PR TITLE
Remove extra spinner when viewing build

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -40,7 +40,6 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 
 func openBuildInBrowser(openInWeb bool, webUrl string) error {
 	if openInWeb {
-		fmt.Printf("Opening %s in your browser\n", webUrl)
 		err := browser.OpenURL(webUrl)
 		if err != nil {
 			fmt.Println("Error opening browser: ", err)
@@ -52,5 +51,5 @@ func openBuildInBrowser(openInWeb bool, webUrl string) error {
 
 func renderResult(result string) string {
 	return lipgloss.JoinVertical(lipgloss.Top,
-		lipgloss.NewStyle().Padding(1, 1).Render(result))
+		lipgloss.NewStyle().Padding(0, 0).Render(result))
 }

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -67,7 +67,7 @@ func cancelBuild(org string, pipeline string, buildId string, web bool, f *facto
 			return err
 		}
 
-		return io.PendingOutput(renderResult(fmt.Sprintf("Cancelling build: %s\n", *build.WebURL)))
+		return io.PendingOutput(renderResult(fmt.Sprintf("Build canceled: %s", *build.WebURL)))
 	}, fmt.Sprintf("Cancelling build #%s from pipeline %s", buildId, pipeline))
 
 	p := tea.NewProgram(l)

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -9,7 +9,6 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -84,8 +83,7 @@ func newBuild(org string, pipeline string, f *factory.Factory, message string, c
 			return err
 		}
 
-		return io.PendingOutput(lipgloss.JoinVertical(lipgloss.Top,
-			lipgloss.NewStyle().Padding(1, 1).Render(fmt.Sprintf("Build created: %s\n", *build.WebURL))))
+		return io.PendingOutput(renderResult(fmt.Sprintf("Build created: %s", *build.WebURL)))
 	}, fmt.Sprintf("Starting new build for %s", pipeline))
 	p := tea.NewProgram(l)
 	_, err := p.Run()

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -68,7 +68,7 @@ func rebuild(org string, pipeline string, buildId string, web bool, f *factory.F
 			return err
 		}
 
-		return io.PendingOutput(renderResult(fmt.Sprintf("Build created: %s\n", *build.WebURL)))
+		return io.PendingOutput(renderResult(fmt.Sprintf("Build created: %s", *build.WebURL)))
 	}, fmt.Sprintf("Rerunning build #%s for pipeline %s", buildId, pipeline))
 
 	p := tea.NewProgram(l)

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/annotation"
@@ -57,8 +56,14 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a build")
 			}
 
+			if web {
+				buildUrl := fmt.Sprintf("https://buildkite.com/%s/%s/builds/%s", bld.Organization, bld.Pipeline, args[0])
+				fmt.Printf("Opening %s in your browser\n\n", buildUrl)
+				return browser.OpenURL(buildUrl)
+			}
+
 			l := io.NewPendingCommand(func() tea.Msg {
-				var buildUrl string
+
 				b, _, err := f.RestAPIClient.Builds.Get(bld.Organization, bld.Pipeline, fmt.Sprint(bld.BuildNumber), &buildkite.BuildsListOptions{})
 				if err != nil {
 					return err
@@ -72,16 +77,6 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				buildAnnotations, _, err = f.RestAPIClient.Annotations.ListByBuild(bld.Organization, bld.Pipeline, fmt.Sprint(bld.BuildNumber), &buildkite.AnnotationListOptions{})
 				if err != nil {
 					return err
-				}
-
-				if web {
-					buildUrl = fmt.Sprintf("https://buildkite.com/%s/%s/builds/%d", bld.Organization, bld.Pipeline, *b.Number)
-					fmt.Printf("Opening %s in your browser\n\n", buildUrl)
-					time.Sleep(1 * time.Second)
-					err = browser.OpenURL(buildUrl)
-					if err != nil {
-						fmt.Println("Error opening browser: ", err)
-					}
 				}
 
 				// Obtain build summary and return

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -57,7 +57,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 			}
 
 			if web {
-				buildUrl := fmt.Sprintf("https://buildkite.com/%s/%s/builds/%s", bld.Organization, bld.Pipeline, args[0])
+				buildUrl := fmt.Sprintf("https://buildkite.com/%s/%s/builds/%d", bld.Organization, bld.Pipeline, bld.BuildNumber)
 				fmt.Printf("Opening %s in your browser\n\n", buildUrl)
 				return browser.OpenURL(buildUrl)
 			}


### PR DESCRIPTION
Removed the sleep timer before opening the web URL in the browser. The timer caused the extra spinner to show. And to maintain consistency with the `bk agent view` command, the cli will not return an output if the -w flag is specified. 
 