### PR TITLE
Push linux packages to registries

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -27,7 +27,27 @@ steps:
 
   - wait
 
-  - label: ":rocket: :package: release"
+  - label: ":rocket: :package: upload packages ({{matrix}})"
+    matrix:
+      - "apk"
+      - "deb"
+      - "rpm"
+    plugins:
+      - artifacts#v1.9.3:
+          download:
+            - dist/linux/*
+      - docker-compose#v5.2.0:
+          command:
+            - .buildkite/upload-packages.sh
+            - "{{matrix}}"
+          config: .buildkite/docker-compose.yaml
+          entrypoint: /bin/sh
+          mount-buildkite-agent: true
+          run: goreleaser
+          shell: false
+          tty: true
+
+  - label: ":rocket: :github: release"
     artifact_paths:
       - dist/**/*
     env:

--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -29,7 +29,6 @@ steps:
 
   - label: ":rocket: :package: upload packages ({{matrix}})"
     matrix:
-      - "apk"
       - "deb"
       - "rpm"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,25 +52,6 @@ steps:
 
   - wait
 
-  - label: ":rocket: :package: upload packages ({{matrix}})"
-    matrix:
-      - "deb"
-      - "rpm"
-    plugins:
-      - artifacts#v1.9.3:
-          download:
-            - dist/linux/*
-      - docker-compose#v5.2.0:
-          command:
-            - .buildkite/upload-packages.sh
-            - "{{matrix}}"
-          config: .buildkite/docker-compose.yaml
-          entrypoint: /bin/sh
-          mount-buildkite-agent: true
-          run: goreleaser
-          shell: false
-          tty: true
-
   - block: ":package: Create a release?"
     prompt: "Fill out the tag to create for this release"
     branches:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,8 +50,6 @@ steps:
           shell: false
           tty: true
 
-  - wait
-
   - block: ":package: Create a release?"
     prompt: "Fill out the tag to create for this release"
     branches:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,6 @@ steps:
 
   - label: ":rocket: :package: upload packages ({{matrix}})"
     matrix:
-      - "apk"
       - "deb"
       - "rpm"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,28 @@ steps:
           shell: false
           tty: true
 
+  - wait
+
+  - label: ":rocket: :package: upload packages ({{matrix}})"
+    matrix:
+      - "apk"
+      - "deb"
+      - "rpm"
+    plugins:
+      - artifacts#v1.9.3:
+          download:
+            - dist/linux/*
+      - docker-compose#v5.2.0:
+          command:
+            - .buildkite/upload-packages.sh
+            - "{{matrix}}"
+          config: .buildkite/docker-compose.yaml
+          entrypoint: /bin/sh
+          mount-buildkite-agent: true
+          run: goreleaser
+          shell: false
+          tty: true
+
   - block: ":package: Create a release?"
     prompt: "Fill out the tag to create for this release"
     branches:

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -7,20 +7,6 @@
 # NOTE: do not exit on non-zero returns codes
 set -uo pipefail
 
-# should we publish the build packages
-PUBLISH=${PUBLISH:-false}
-
-audience() {
-    ORG=$1
-    REGISTRY=$2
-    echo "https://packages.buildkite.com/organizations/${ORG}/packages/registries/${REGISTRY}"
-}
-upload_url() {
-    ORG=$1
-    REGISTRY=$2
-    echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"
-}
-
 export GORELEASER_KEY=$(buildkite-agent secret get goreleaser_key)
 
 if [[ $? -ne 0 ]]; then
@@ -32,30 +18,3 @@ if ! goreleaser "$@"; then
     echo "Failed to build a release"
     exit 1
 fi
-
-if [[ $PUBLISH == false ]]; then
-    echo "Not publishing package to registries"
-    exit 0
-fi
-
-AUDIENCE=$(audience $ORGANIZATION $REGISTRY)
-
-# grab a token for pushing packages to buildkite with an expiry of 3 mins
-TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
-
-if [[ $? -ne 0 ]]; then
-    echo "Failed to retrieve OIDC token"
-    exit 1
-fi
-
-for FILE in dist/*.${PACKAGE}; do
-    curl -X POST $(upload_url $ORGANIZATION $REGISTRY) \
-         -H "Authorization: Bearer ${TOKEN}" \
-         -F "file=@${FILE}" \
-        --fail-with-body
-
-    if [[ $? -ne 0 ]]; then
-        echo "Failed to push RPM package $file"
-        exit 1
-    fi
-done

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -4,7 +4,7 @@
 # This script is used to upload packages to Buildkite registries
 #
 
-set -euo pipefail
+set -uo pipefail
 
 if [[ -z "${1}" ]]; then
     echo "Must pass in the package type: apk, deb, rpm"

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -39,13 +39,21 @@ fi
 
 for FILE in dist/linux/*.${PACKAGE}; do
     echo "--- Pushing $FILE"
-    curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \
-         -H "Authorization: Bearer ${TOKEN}" \
-         -F "file=@${FILE}" \
-        --fail-with-body
+    if [[ $PACKAGE = "apk" ]]; then
+        curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \
+             -H "Authorization: Bearer ${TOKEN}" \
+             -F "package[distro_version_id]=alpine/v3" \
+             -F "package[package_file]=@${FILE}" \
+            --fail-with-body
+    else
+        curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \
+             -H "Authorization: Bearer ${TOKEN}" \
+             -F "file=@${FILE}" \
+            --fail-with-body
+    fi
 
     if [[ $? -ne 0 ]]; then
-        echo "Failed to push package $file"
+        echo "Failed to push package $FILE"
         exit 1
     fi
 done

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -1,0 +1,49 @@
+#!/bin/env bash
+
+#
+# This script is used to upload packages to Buildkite registries
+#
+
+set -euo pipefail
+
+if [[ -z "${1}" ]]; then
+    echo "Must pass in the package type: apk, deb, rpm"
+    exit 1
+fi
+
+PACKAGE=${1}
+ORGANIZATION=${2:-buildkite}
+REGISTRY=${3:-cli-$PACKAGE}
+
+audience() {
+    ORG=$1
+    REGISTRY=$2
+    echo "https://packages.buildkite.com/organizations/${ORG}/packages/registries/${REGISTRY}"
+}
+upload_url() {
+    ORG=$1
+    REGISTRY=$2
+    echo "https://api.buildkite.com/v2/packages/organizations/${ORG}/registries/${REGISTRY}/packages"
+}
+
+AUDIENCE=$(audience $ORGANIZATION $REGISTRY)
+
+# grab a token for pushing packages to buildkite with an expiry of 3 mins
+TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to retrieve OIDC token"
+    exit 1
+fi
+
+for FILE in dist/linux/*.${PACKAGE}; do
+    curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \
+         -H "Authorization: Bearer ${TOKEN}" \
+         -F "file=@${FILE}" \
+        --fail-with-body
+
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to push package $file"
+        exit 1
+    fi
+done

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -29,6 +29,7 @@ upload_url() {
 AUDIENCE=$(audience $ORGANIZATION $REGISTRY)
 
 # grab a token for pushing packages to buildkite with an expiry of 3 mins
+echo "--- Fetching OIDC token for $AUDIENCE"
 TOKEN=$(buildkite-agent oidc request-token --audience "$AUDIENCE" --lifetime 180)
 
 if [[ $? -ne 0 ]]; then
@@ -37,6 +38,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 for FILE in dist/linux/*.${PACKAGE}; do
+    echo "--- Pushing $FILE"
     curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \
          -H "Authorization: Bearer ${TOKEN}" \
          -F "file=@${FILE}" \

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -18,7 +18,7 @@ REGISTRY=${3:-cli-$PACKAGE}
 audience() {
     ORG=$1
     REGISTRY=$2
-    echo "https://packages.buildkite.com/organizations/${ORG}/packages/registries/${REGISTRY}"
+    echo "https://packages.buildkite.com/${ORG}/${REGISTRY}"
 }
 upload_url() {
     ORG=$1

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -7,7 +7,7 @@
 set -uo pipefail
 
 if [[ -z "${1}" ]]; then
-    echo "Must pass in the package type: apk, deb, rpm"
+    echo "Must pass in the package type: deb, rpm"
     exit 1
 fi
 


### PR DESCRIPTION
Push build linux packages to buildkite registry. 
Verified this by pushing them from the build pipeline, so it should work from the release pipeline when it gets there

Note: APK has some quirks so leaving that off for now.