### PR TITLE
Improve output of [build view]

### DIFF
--- a/internal/artifact/view.go
+++ b/internal/artifact/view.go
@@ -9,8 +9,8 @@ func ArtifactSummary(artifact *buildkite.Artifact) string {
 	artifactSummary := lipgloss.JoinVertical(lipgloss.Top,
 		lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
 		lipgloss.JoinHorizontal(lipgloss.Left,
-			lipgloss.NewStyle().Width(30).Align(lipgloss.Left).Padding(0, 1).Render(*artifact.Filename),
-			lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(FormatBytes(*artifact.FileSize)),
+			lipgloss.NewStyle().Width(60).Align(lipgloss.Left).Padding(0, 1).Render(*artifact.Path),
+			lipgloss.NewStyle().Align(lipgloss.Right).Padding(0, 1).Render(FormatBytes(*artifact.FileSize)),
 		),
 	)
 

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -81,7 +81,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				// Obtain build summary and return
 				summary := build.BuildSummary(b)
 				if len(b.Jobs) > 0 {
-					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nJobs")
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Underline(true).Render("\nJobs")
 					for _, j := range b.Jobs {
 						bkJob := *j
 						if *bkJob.Type == "script" {
@@ -90,13 +90,13 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 					}
 				}
 				if len(buildArtifacts) > 0 {
-					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nArtifacts")
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Underline(true).Render("\n\nArtifacts")
 					for _, a := range buildArtifacts {
 						summary += artifact.ArtifactSummary(&a)
 					}
 				}
 				if len(buildAnnotations) > 0 {
-					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Render("\nAnnotations")
+					summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Underline(true).Render("\n\nAnnotations")
 					for _, a := range buildAnnotations {
 						summary += annotation.AnnotationSummary(&a)
 					}


### PR DESCRIPTION
- Added spacing around sections to avoid getting lost between them
- Underlined the section headers to show separation from the body
- Adjusted the output of the annotations to be [path] rather than [name]

![CleanShot 2024-06-18 at 20 54 15](https://github.com/buildkite/cli/assets/10952642/f9669330-1bba-4f75-aeba-b530a0a303ed)
