### PR TITLE
Alternative prompt confirmation

### DIFF
--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -46,13 +46,18 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a pipeline")
 			}
 
-			_ = huh.NewConfirm().
+			form := huh.NewConfirm().
 				Title(fmt.Sprintf("Create new build on %s?", pipeline.Name)).
 				Affirmative("Yes!").
 				Negative("No!").
 				Value(&confirm).
-				WithTheme(huh.ThemeDracula()).
-				Run()
+				WithTheme(huh.ThemeDracula())
+
+      if confirm {
+        form.Skip()
+      } else {
+        form.Run()
+      }
 
 			if confirm {
 				return newBuild(pipeline.Org, pipeline.Name, f, message, commit, branch, web)
@@ -69,6 +74,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
 		"If omitted, it will be resolved using the current directory.",
 	)
+  cmd.Flags().BoolVarP(&confirm, "confirm", "", false, "Skip the confirmation step. Useful if being used in automation/CI")
 	cmd.Flags().SortFlags = false
 	return &cmd
 }

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -9,6 +10,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +19,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 	var commit string
 	var message string
 	var pipeline string
+	var confirm bool
 	var web bool
 
 	cmd := cobra.Command{
@@ -43,7 +46,19 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a pipeline")
 			}
 
-			return newBuild(pipeline.Org, pipeline.Name, f, message, commit, branch, web)
+			_ = huh.NewConfirm().
+				Title(fmt.Sprintf("Create new build on %s?", pipeline.Name)).
+				Affirmative("Yes!").
+				Negative("No!").
+				Value(&confirm).
+				WithTheme(huh.ThemeDracula()).
+				Run()
+
+			if confirm {
+				return newBuild(pipeline.Org, pipeline.Name, f, message, commit, branch, web)
+			} else {
+				return errors.New("Create was aborted.")
+			}
 		},
 	}
 

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -53,11 +53,11 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 				Value(&confirm).
 				WithTheme(huh.ThemeDracula())
 
-      if confirm {
-        form.Skip()
-      } else {
-        form.Run()
-      }
+			if confirm {
+				form.Skip()
+			} else {
+				_ = form.Run()
+			}
 
 			if confirm {
 				return newBuild(pipeline.Org, pipeline.Name, f, message, commit, branch, web)
@@ -74,7 +74,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
 		"If omitted, it will be resolved using the current directory.",
 	)
-  cmd.Flags().BoolVarP(&confirm, "confirm", "", false, "Skip the confirmation step. Useful if being used in automation/CI")
+	cmd.Flags().BoolVarP(&confirm, "confirm", "", false, "Skip the confirmation step. Useful if being used in automation/CI")
 	cmd.Flags().SortFlags = false
 	return &cmd
 }


### PR DESCRIPTION
This is an alternative to #292. It fixes a few issues around user cancellation and error reporting and changes the flag
