### PR TITLE
SUP-2363 Fix segfault when not in a repo

### DIFF
--- a/internal/build/resolver/current_branch.go
+++ b/internal/build/resolver/current_branch.go
@@ -13,6 +13,12 @@ import (
 
 // ResolveBuildFromCurrentBranch Finds the most recent build for the branch in the current working directory
 func ResolveBuildFromCurrentBranch(repo *git.Repository, pipelineResolver pipelineResolver.PipelineResolverFn, f *factory.Factory) BuildResolverFn {
+	// there is nothing to resolve from if we aren't in a git repository, so short circuit that
+	if repo == nil {
+		return func(ctx context.Context) (*build.Build, error) {
+			return nil, nil
+		}
+	}
 	return func(ctx context.Context) (*build.Build, error) {
 		// find the pipeline first, then we can make a graphql query to find the most recent build for that branch
 		pipeline, err := pipelineResolver(ctx)

--- a/internal/build/resolver/current_branch_test.go
+++ b/internal/build/resolver/current_branch_test.go
@@ -81,6 +81,16 @@ func TestResolveBuildFromCurrentBranch(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("Pass through if not in a repository", func(t *testing.T) {
+		t.Parallel()
+		r := resolver.ResolveBuildFromCurrentBranch(nil, pipelineResolver, &factory.Factory{})
+		b, err := r(context.Background())
+
+		if b != nil || err != nil {
+			t.Fatal("Should not find a build if not in a repository")
+		}
+	})
 }
 
 type doer struct {

--- a/internal/build/resolver/resolver.go
+++ b/internal/build/resolver/resolver.go
@@ -33,6 +33,13 @@ func (ar AggregateResolver) Resolve(ctx context.Context) (*build.Build, error) {
 	return nil, nil
 }
 
+func (ar AggregateResolver) WithResolverWhen(condition bool, resovler BuildResolverFn) AggregateResolver {
+	if condition {
+		return append(ar, resovler)
+	}
+	return ar
+}
+
 // NewAggregateResolver creates an AggregateResolver from a list of BuildResolverFn, appending a final resolver for
 // capturing the case that no build is found by any resolver
 func NewAggregateResolver(resolvers ...BuildResolverFn) AggregateResolver {

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -45,6 +45,8 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 
 			buildRes := buildResolver.NewAggregateResolver(
 				buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),
+			).WithResolverWhen(
+				f.GitRepository != nil,
 				buildResolver.ResolveBuildFromCurrentBranch(f.GitRepository, pipelineRes.Resolve, f),
 			)
 


### PR DESCRIPTION
There is a segfault when running `bk build view` outside of a repo. This fixes that by checking for a nil repo before usage
