### PR TITLE
Initial commit for search of cwd using GQL and use GQL for git repo resolve

### DIFF
--- a/internal/graphql/generated.go
+++ b/internal/graphql/generated.go
@@ -8,6 +8,164 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// FindPipelineFromCwdOrganization includes the requested fields of the GraphQL type Organization.
+// The GraphQL type's documentation follows.
+//
+// An organization
+type FindPipelineFromCwdOrganization struct {
+	// Return all the pipelines the current user has access to for this organization
+	Pipelines *FindPipelineFromCwdOrganizationPipelinesPipelineConnection `json:"pipelines"`
+}
+
+// GetPipelines returns FindPipelineFromCwdOrganization.Pipelines, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganization) GetPipelines() *FindPipelineFromCwdOrganizationPipelinesPipelineConnection {
+	return v.Pipelines
+}
+
+// FindPipelineFromCwdOrganizationPipelinesPipelineConnection includes the requested fields of the GraphQL type PipelineConnection.
+type FindPipelineFromCwdOrganizationPipelinesPipelineConnection struct {
+	Edges []*FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge `json:"edges"`
+}
+
+// GetEdges returns FindPipelineFromCwdOrganizationPipelinesPipelineConnection.Edges, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganizationPipelinesPipelineConnection) GetEdges() []*FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge {
+	return v.Edges
+}
+
+// FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge includes the requested fields of the GraphQL type PipelineEdge.
+type FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge struct {
+	Node *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline `json:"node"`
+}
+
+// GetNode returns FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge.Node, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdge) GetNode() *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline {
+	return v.Node
+}
+
+// FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline includes the requested fields of the GraphQL type Pipeline.
+// The GraphQL type's documentation follows.
+//
+// A pipeline
+type FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline struct {
+	// The name of the pipeline
+	Name         string                                                                                              `json:"name"`
+	Organization FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization `json:"organization"`
+}
+
+// GetName returns FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline.Name, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline) GetName() string {
+	return v.Name
+}
+
+// GetOrganization returns FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline.Organization, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline) GetOrganization() FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization {
+	return v.Organization
+}
+
+// FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization includes the requested fields of the GraphQL type Organization.
+// The GraphQL type's documentation follows.
+//
+// An organization
+type FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization struct {
+	// The name of the organization
+	Name string `json:"name"`
+}
+
+// GetName returns FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization.Name, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization) GetName() string {
+	return v.Name
+}
+
+// FindPipelineFromCwdResponse is returned by FindPipelineFromCwd on success.
+type FindPipelineFromCwdResponse struct {
+	// Find an organization
+	Organization *FindPipelineFromCwdOrganization `json:"organization"`
+}
+
+// GetOrganization returns FindPipelineFromCwdResponse.Organization, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromCwdResponse) GetOrganization() *FindPipelineFromCwdOrganization {
+	return v.Organization
+}
+
+// FindPipelineFromGitRepoUrlOrganization includes the requested fields of the GraphQL type Organization.
+// The GraphQL type's documentation follows.
+//
+// An organization
+type FindPipelineFromGitRepoUrlOrganization struct {
+	// Return all the pipelines the current user has access to for this organization
+	Pipelines *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection `json:"pipelines"`
+}
+
+// GetPipelines returns FindPipelineFromGitRepoUrlOrganization.Pipelines, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganization) GetPipelines() *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection {
+	return v.Pipelines
+}
+
+// FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection includes the requested fields of the GraphQL type PipelineConnection.
+type FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection struct {
+	Edges []*FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge `json:"edges"`
+}
+
+// GetEdges returns FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection.Edges, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnection) GetEdges() []*FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge {
+	return v.Edges
+}
+
+// FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge includes the requested fields of the GraphQL type PipelineEdge.
+type FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge struct {
+	Node *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline `json:"node"`
+}
+
+// GetNode returns FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge.Node, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdge) GetNode() *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline {
+	return v.Node
+}
+
+// FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline includes the requested fields of the GraphQL type Pipeline.
+// The GraphQL type's documentation follows.
+//
+// A pipeline
+type FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline struct {
+	// The name of the pipeline
+	Name         string                                                                                                     `json:"name"`
+	Organization FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization `json:"organization"`
+}
+
+// GetName returns FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline.Name, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline) GetName() string {
+	return v.Name
+}
+
+// GetOrganization returns FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline.Organization, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipeline) GetOrganization() FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization {
+	return v.Organization
+}
+
+// FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization includes the requested fields of the GraphQL type Organization.
+// The GraphQL type's documentation follows.
+//
+// An organization
+type FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization struct {
+	// The name of the organization
+	Name string `json:"name"`
+}
+
+// GetName returns FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization.Name, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlOrganizationPipelinesPipelineConnectionEdgesPipelineEdgeNodePipelineOrganization) GetName() string {
+	return v.Name
+}
+
+// FindPipelineFromGitRepoUrlResponse is returned by FindPipelineFromGitRepoUrl on success.
+type FindPipelineFromGitRepoUrlResponse struct {
+	// Find an organization
+	Organization *FindPipelineFromGitRepoUrlOrganization `json:"organization"`
+}
+
+// GetOrganization returns FindPipelineFromGitRepoUrlResponse.Organization, and is useful for accessing the field via an interface.
+func (v *FindPipelineFromGitRepoUrlResponse) GetOrganization() *FindPipelineFromGitRepoUrlOrganization {
+	return v.Organization
+}
+
 // GetClusterQueueAgentOrganization includes the requested fields of the GraphQL type Organization.
 // The GraphQL type's documentation follows.
 //
@@ -409,6 +567,30 @@ func (v *UnblockJobResponse) GetJobTypeBlockUnblock() *UnblockJobJobTypeBlockUnb
 	return v.JobTypeBlockUnblock
 }
 
+// __FindPipelineFromCwdInput is used internally by genqlient
+type __FindPipelineFromCwdInput struct {
+	Organization string  `json:"organization"`
+	Term         *string `json:"term"`
+}
+
+// GetOrganization returns __FindPipelineFromCwdInput.Organization, and is useful for accessing the field via an interface.
+func (v *__FindPipelineFromCwdInput) GetOrganization() string { return v.Organization }
+
+// GetTerm returns __FindPipelineFromCwdInput.Term, and is useful for accessing the field via an interface.
+func (v *__FindPipelineFromCwdInput) GetTerm() *string { return v.Term }
+
+// __FindPipelineFromGitRepoUrlInput is used internally by genqlient
+type __FindPipelineFromGitRepoUrlInput struct {
+	Organization string `json:"organization"`
+	Repo         string `json:"repo"`
+}
+
+// GetOrganization returns __FindPipelineFromGitRepoUrlInput.Organization, and is useful for accessing the field via an interface.
+func (v *__FindPipelineFromGitRepoUrlInput) GetOrganization() string { return v.Organization }
+
+// GetRepo returns __FindPipelineFromGitRepoUrlInput.Repo, and is useful for accessing the field via an interface.
+func (v *__FindPipelineFromGitRepoUrlInput) GetRepo() string { return v.Repo }
+
 // __GetClusterQueueAgentInput is used internally by genqlient
 type __GetClusterQueueAgentInput struct {
 	OrgSlug string   `json:"orgSlug"`
@@ -452,6 +634,98 @@ type __UnblockJobInput struct {
 
 // GetId returns __UnblockJobInput.Id, and is useful for accessing the field via an interface.
 func (v *__UnblockJobInput) GetId() string { return v.Id }
+
+// The query or mutation executed by FindPipelineFromCwd.
+const FindPipelineFromCwd_Operation = `
+query FindPipelineFromCwd ($organization: ID!, $term: String) {
+	organization(slug: $organization) {
+		pipelines(first: 10, search: $term) {
+			edges {
+				node {
+					name
+					organization {
+						name
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+func FindPipelineFromCwd(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	organization string,
+	term *string,
+) (*FindPipelineFromCwdResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "FindPipelineFromCwd",
+		Query:  FindPipelineFromCwd_Operation,
+		Variables: &__FindPipelineFromCwdInput{
+			Organization: organization,
+			Term:         term,
+		},
+	}
+	var err_ error
+
+	var data_ FindPipelineFromCwdResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by FindPipelineFromGitRepoUrl.
+const FindPipelineFromGitRepoUrl_Operation = `
+query FindPipelineFromGitRepoUrl ($organization: ID!, $repo: String!) {
+	organization(slug: $organization) {
+		pipelines(first: 10, repository: {url:$repo}) {
+			edges {
+				node {
+					name
+					organization {
+						name
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+func FindPipelineFromGitRepoUrl(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	organization string,
+	repo string,
+) (*FindPipelineFromGitRepoUrlResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "FindPipelineFromGitRepoUrl",
+		Query:  FindPipelineFromGitRepoUrl_Operation,
+		Variables: &__FindPipelineFromGitRepoUrlInput{
+			Organization: organization,
+			Repo:         repo,
+		},
+	}
+	var err_ error
+
+	var data_ FindPipelineFromGitRepoUrlResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
 
 // The query or mutation executed by GetClusterQueueAgent.
 const GetClusterQueueAgent_Operation = `

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -71,6 +71,9 @@ func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.
 	//
 	// resolvedPipelines = append(resolvedPipelines, cwdPipelines...)
 
+  if len(resolvedPipelines) < 1 {
+    return nil, nil
+  }
 	return resolvedPipelines, nil
 }
 

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -24,7 +24,7 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 		spinErr := spinner.New().
 			Title("Resolving pipeline").
 			Action(func() {
-				pipelines, err = resolveFromRepository(f)
+				pipelines, err = resolveFromRepository(ctx, f)
 			}).
 			Run()
 		if spinErr != nil {
@@ -45,7 +45,7 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 	}
 }
 
-func resolveFromRepository(f *factory.Factory) ([]pipeline.Pipeline, error) {
+func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.Pipeline, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, errors.New("Could not resolve current working directory")
@@ -64,7 +64,7 @@ func resolveFromRepository(f *factory.Factory) ([]pipeline.Pipeline, error) {
 		resolvedPipelines = append(resolvedPipelines, foundPipelines...)
 	}
 
-	cwdPipelines, err := findPipelinesFromCwd(filepath.Base(cwd), f.Config.OrganizationSlug(), f)
+	cwdPipelines, err := findPipelinesFromCwd(ctx, filepath.Base(cwd), f.Config.OrganizationSlug(), f)
 	if err != nil {
 		return resolvedPipelines, nil
 	}
@@ -74,9 +74,9 @@ func resolveFromRepository(f *factory.Factory) ([]pipeline.Pipeline, error) {
 	return resolvedPipelines, nil
 }
 
-func findPipelinesFromCwd(cwd string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
+func findPipelinesFromCwd(ctx context.Context, cwd string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
 	resolvedPipelines := make([]pipeline.Pipeline, 0)
-	res, err := graphql.FindPipelineFromCwd(context.Background(), f.GraphQLClient, org, &cwd)
+	res, err := graphql.FindPipelineFromCwd(ctx, f.GraphQLClient, org, &cwd)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -74,23 +74,23 @@ func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.
 	return resolvedPipelines, nil
 }
 
-func findPipelinesFromCwd(ctx context.Context, cwd string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
-	resolvedPipelines := make([]pipeline.Pipeline, 0)
-	res, err := graphql.FindPipelineFromCwd(ctx, f.GraphQLClient, org, &cwd)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, p := range res.Organization.Pipelines.Edges {
-		resolvedPipelines = append(resolvedPipelines, pipeline.Pipeline{Name: p.Node.GetName(), Org: p.Node.Organization.GetName()})
-	}
-
-	if len(resolvedPipelines) > 0 {
-		return resolvedPipelines, nil
-	}
-
-	return nil, nil
-}
+// func findPipelinesFromCwd(ctx context.Context, cwd string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
+// 	resolvedPipelines := make([]pipeline.Pipeline, 0)
+// 	res, err := graphql.FindPipelineFromCwd(ctx, f.GraphQLClient, org, &cwd)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+//
+// 	for _, p := range res.Organization.Pipelines.Edges {
+// 		resolvedPipelines = append(resolvedPipelines, pipeline.Pipeline{Name: p.Node.GetName(), Org: p.Node.Organization.GetName()})
+// 	}
+//
+// 	if len(resolvedPipelines) > 0 {
+// 		return resolvedPipelines, nil
+// 	}
+//
+// 	return nil, nil
+// }
 
 func findPipelinesFromRepo(ctx context.Context, repo string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
 	resolvedPipelines := make([]pipeline.Pipeline, 0)

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -71,9 +71,9 @@ func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.
 	//
 	// resolvedPipelines = append(resolvedPipelines, cwdPipelines...)
 
-  if len(resolvedPipelines) < 1 {
-    return nil, nil
-  }
+	if len(resolvedPipelines) < 1 {
+		return nil, nil
+	}
 	return resolvedPipelines, nil
 }
 

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -102,6 +102,10 @@ func findPipelinesFromRepo(ctx context.Context, repo string, org string, f *fact
 		return nil, err
 	}
 
+  if len(res.Organization.Pipelines.Edges) < 1 {
+    return nil, nil
+  }
+
 	for _, p := range res.Organization.Pipelines.Edges {
 		resolvedPipelines = append(resolvedPipelines, pipeline.Pipeline{Name: p.Node.GetName(), Org: p.Node.Organization.GetName()})
 	}

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -2,9 +2,9 @@ package resolver
 
 import (
 	"context"
-	"errors"
-	"os"
-	"path/filepath"
+	// "errors"
+	// "os"
+	// "path/filepath"
 
 	"github.com/buildkite/cli/v3/internal/graphql"
 	"github.com/buildkite/cli/v3/internal/pipeline"
@@ -46,10 +46,10 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 }
 
 func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.Pipeline, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, errors.New("Could not resolve current working directory")
-	}
+	// cwd, err := os.Getwd()
+	// if err != nil {
+	// 	return nil, errors.New("Could not resolve current working directory")
+	// }
 	resolvedPipelines := make([]pipeline.Pipeline, 0)
 	repos, err := getRepoURLs(f.GitRepository)
 	if err != nil {
@@ -64,12 +64,12 @@ func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.
 		resolvedPipelines = append(resolvedPipelines, foundPipelines...)
 	}
 
-	cwdPipelines, err := findPipelinesFromCwd(ctx, filepath.Base(cwd), f.Config.OrganizationSlug(), f)
-	if err != nil {
-		return resolvedPipelines, nil
-	}
-
-	resolvedPipelines = append(resolvedPipelines, cwdPipelines...)
+	// cwdPipelines, err := findPipelinesFromCwd(ctx, filepath.Base(cwd), f.Config.OrganizationSlug(), f)
+	// if err != nil {
+	// 	return resolvedPipelines, nil
+	// }
+	//
+	// resolvedPipelines = append(resolvedPipelines, cwdPipelines...)
 
 	return resolvedPipelines, nil
 }

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -102,9 +102,9 @@ func findPipelinesFromRepo(ctx context.Context, repo string, org string, f *fact
 		return nil, err
 	}
 
-  if len(res.Organization.Pipelines.Edges) < 1 {
-    return nil, nil
-  }
+	if len(res.Organization.Pipelines.Edges) < 1 {
+		return nil, nil
+	}
 
 	for _, p := range res.Organization.Pipelines.Edges {
 		resolvedPipelines = append(resolvedPipelines, pipeline.Pipeline{Name: p.Node.GetName(), Org: p.Node.Organization.GetName()})

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -56,7 +56,7 @@ func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.
 		return nil, err
 	}
 	for _, repo := range repos {
-		foundPipelines, err := findPipelinesFromRepo(repo, f.Config.OrganizationSlug(), f)
+		foundPipelines, err := findPipelinesFromRepo(ctx, repo, f.Config.OrganizationSlug(), f)
 		if err != nil {
 			continue
 		}
@@ -85,12 +85,16 @@ func findPipelinesFromCwd(ctx context.Context, cwd string, org string, f *factor
 		resolvedPipelines = append(resolvedPipelines, pipeline.Pipeline{Name: p.Node.GetName(), Org: p.Node.Organization.GetName()})
 	}
 
-	return resolvedPipelines, nil
+	if len(resolvedPipelines) > 0 {
+		return resolvedPipelines, nil
+	}
+
+	return nil, nil
 }
 
-func findPipelinesFromRepo(repo string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
+func findPipelinesFromRepo(ctx context.Context, repo string, org string, f *factory.Factory) ([]pipeline.Pipeline, error) {
 	resolvedPipelines := make([]pipeline.Pipeline, 0)
-	res, err := graphql.FindPipelineFromGitRepoUrl(context.Background(), f.GraphQLClient, org, repo)
+	res, err := graphql.FindPipelineFromGitRepoUrl(ctx, f.GraphQLClient, org, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -1,10 +1,12 @@
 package resolver
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
@@ -24,10 +26,12 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("no pipelines found", func(t *testing.T) {
 		t.Parallel()
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		// mock a response that doesn't match the current repository url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
 		f := testFactory(client, "testOrg", testRepository(false, false))
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -38,10 +42,12 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("one pipeline", func(t *testing.T) {
 		t.Parallel()
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		// mock an http client response with a single pipeline matching the current repo url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)
 		f := testFactory(client, "testOrg", testRepository(true, true))
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -52,11 +58,13 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("multiple pipelines", func(t *testing.T) {
 		t.Parallel()
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		// mock an http client response with 2 pipelines matching the current repo url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"},
 		{"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)
 		f := testFactory(client, "testOrg", testRepository(true, true))
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -66,9 +74,11 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	})
 
 	t.Run("no repository found", func(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
 		f := testFactory(client, "testOrg", nil)
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if pipelines != nil {
 			t.Errorf("Expected nil, got %v", pipelines)
 		}
@@ -78,9 +88,11 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	})
 
 	t.Run("no remote repository found", func(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
 		f := testFactory(client, "testOrg", testRepository(true, true))
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if pipelines != nil {
 			t.Errorf("Expected nil, got %v", pipelines)
 		}
@@ -94,12 +106,13 @@ func TestResolvePipelinesFromCwd(t *testing.T) {
 	t.Parallel()
 
 	t.Run("multiple pipelines", func(t *testing.T) {
-		t.Parallel()
+    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+    defer cancel()
 		// mock an http client response with 2 pipelines matching the current repo url
 		client := mockHttpClient(`[{"slug": "this-is-testDir-pipeline-2"},
 		{"slug": "this-is-testDir-pipeline-2"}]`)
 		f := testFactory(client, "testOrg", testRepository(false, false))
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -26,8 +26,8 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("no pipelines found", func(t *testing.T) {
 		t.Parallel()
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		// mock a response that doesn't match the current repository url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
 		f := testFactory(client, "testOrg", testRepository(false, false))
@@ -42,8 +42,8 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("one pipeline", func(t *testing.T) {
 		t.Parallel()
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		// mock an http client response with a single pipeline matching the current repo url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)
 		f := testFactory(client, "testOrg", testRepository(true, true))
@@ -58,8 +58,8 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 
 	t.Run("multiple pipelines", func(t *testing.T) {
 		t.Parallel()
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		// mock an http client response with 2 pipelines matching the current repo url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"},
 		{"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)
@@ -74,8 +74,8 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	})
 
 	t.Run("no repository found", func(t *testing.T) {
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
 		f := testFactory(client, "testOrg", nil)
 		pipelines, err := resolveFromRepository(ctx, f)
@@ -88,8 +88,8 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	})
 
 	t.Run("no remote repository found", func(t *testing.T) {
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		client := mockHttpClient(`[{"slug": "", "repository": ""}]`)
 		f := testFactory(client, "testOrg", testRepository(true, true))
 		pipelines, err := resolveFromRepository(ctx, f)
@@ -106,8 +106,9 @@ func TestResolvePipelinesFromCwd(t *testing.T) {
 	t.Parallel()
 
 	t.Run("multiple pipelines", func(t *testing.T) {
-    ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
-    defer cancel()
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		// mock an http client response with 2 pipelines matching the current repo url
 		client := mockHttpClient(`[{"slug": "this-is-testDir-pipeline-2"},
 		{"slug": "this-is-testDir-pipeline-2"}]`)

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -30,7 +30,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		defer cancel()
 		// mock a response that doesn't match the current repository url
 		client := mockHttpClient(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
-		f := testFactory(client, "testOrg", testRepository(false, false))
+		f := testFactory(client, "testOrg", testRepository(true, true))
 		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)

--- a/internal/pipeline/resolver/resolve_pipeline.graphql
+++ b/internal/pipeline/resolver/resolve_pipeline.graphql
@@ -1,0 +1,29 @@
+query FindPipelineFromCwd($organization: ID!, $term: String){
+  organization(slug: $organization){
+    pipelines(first:10, search: $term){
+      edges {
+        node {
+          name
+          organization {
+            name
+          }
+        }
+      }
+    }
+  }
+}
+
+query FindPipelineFromGitRepoUrl($organization: ID!, $repo: String!) {
+  organization(slug: $organization){
+    pipelines(first:10, repository: {url: $repo}){
+      edges {
+        node {
+          name
+          organization {
+            name
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Changes
- Implements GraphQL queries for string search (used for pipeline name) and repository search
- Separates out the logic for resolving pipelines to single use functions
- Maintains a []pipeline.Pipeline in the calling function that gets appended to and returns the full resulting list
