### PR TITLE
Enable goreleaser to push to homebrew-buildkite repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ brews:
     description: Work with Buildkite from the command-line
     license: MIT
     skip_upload: false
-    test: system "#{bin}/bk --version"
+    test: system "#{bin}/bk version"
     repository:
       owner: buildkite
       name: homebrew-buildkite

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ brews:
     homepage: https://github.com/buildkite/cli
     description: Work with Buildkite from the command-line
     license: MIT
-    skip_upload: true
+    skip_upload: false
     test: system "#{bin}/bk --version"
     repository:
       owner: buildkite


### PR DESCRIPTION
[This build](https://buildkite.com/buildkite/buildkite-cli-release/builds/25#01905c9c-b09a-44c6-a78f-4d5ee210b0ee) shows that the generated file looks correct so we can now enable pushing the file contents to the homebrew-buildkite repo which will make this available for users to install through Homebrew
