### PR TITLE
Add confirm prompt to `bk build cancel`

### DIFF
--- a/internal/io/confirm.go
+++ b/internal/io/confirm.go
@@ -1,0 +1,26 @@
+package io
+
+import (
+	"github.com/charmbracelet/huh"
+)
+
+func Confirm(confirmed *bool, title string) error {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(title).
+				Affirmative("Yes").
+				Negative("No").
+				Value(confirmed),
+		).WithHide(*confirmed), // user can bypass the prompt by passing the flag
+	)
+
+	err := form.Run()
+
+	// no need to return error if ctrl-c
+	if err != nil && err == huh.ErrUserAborted {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -9,7 +9,6 @@ import (
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
@@ -45,22 +44,8 @@ func NewCmdBuildCancel(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a build")
 			}
 
-			form := huh.NewForm(
-				huh.NewGroup(
-					huh.NewConfirm().
-						Title(fmt.Sprintf("Cancel build #%d on %s", bld.BuildNumber, bld.Pipeline)).
-						Affirmative("Yes").
-						Negative("No").
-						Value(&confirmed),
-				).WithHide(confirmed), // user can bypass the prompt by passing the flag
-			)
-
-			err = form.Run()
+			err = io.Confirm(&confirmed, fmt.Sprintf("Cancel build #%d on %s", bld.BuildNumber, bld.Pipeline))
 			if err != nil {
-				// no need to return error if ctrl-c
-				if err == huh.ErrUserAborted {
-					return nil
-				}
 				return err
 			}
 

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -9,7 +9,6 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
@@ -45,22 +44,8 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("could not resolve a pipeline")
 			}
 
-			form := huh.NewForm(
-				huh.NewGroup(
-					huh.NewConfirm().
-						Title(fmt.Sprintf("Create new build on %s?", pipeline.Name)).
-						Affirmative("Yes").
-						Negative("No").
-						Value(&confirmed),
-				).WithHide(confirmed), // user can bypass the prompt by passing the flag
-			)
-
-			err = form.Run()
+			err = io.Confirm(&confirmed, fmt.Sprintf("Create new build on %s?", pipeline.Name))
 			if err != nil {
-				// no need to return error if ctrl-c
-				if err == huh.ErrUserAborted {
-					return nil
-				}
 				return err
 			}
 


### PR DESCRIPTION
Adds a confirm prompt to `bk build cancel` the same way as `bk build new`.

Also extracts the confirm prompt logic to reduce duplication
