### PR TITLE
Update go buildkite

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -17,7 +17,11 @@ func main() {
 
 func mainRun() int {
 	ctx := context.Background()
-	f := factory.New(version.Version)
+	f, err := factory.New(version.Version)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create factory: %s\n", err)
+		return 1
+	}
 
 	rootCmd, err := root.NewCmdRoot(f)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/buildkite/cli/v3
 
-go 1.21
+go 1.22
 
-toolchain go1.21.6
+toolchain go1.22.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/buildkite/go-buildkite/v3 v3.11.0
+	github.com/buildkite/go-buildkite/v3 v3.12.0
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.6
 	github.com/charmbracelet/huh v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buildkite/go-buildkite/v3 v3.11.0 h1:A43KDOuNczqrY8wqlsHNtPoYbgWXYC/slkB/2JYXr5E=
 github.com/buildkite/go-buildkite/v3 v3.11.0/go.mod h1:TmZggyr5HqkOhNbTrcdOdmwuYbQqcfwr9MSyKyMQWAA=
+github.com/buildkite/go-buildkite/v3 v3.12.0 h1:VkJVwqx+5GD1434eyf2YuX3/LuCzSUlOycSvUA7YW04=
+github.com/buildkite/go-buildkite/v3 v3.12.0/go.mod h1:ux2rjcqNoE54wfFHO3Vlet+a57Tt2jqOqfc9Afs7R7g=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
 github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=

--- a/internal/build/resolver/userid_test.go
+++ b/internal/build/resolver/userid_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -30,20 +31,24 @@ func TestResolveBuildFromUserUUID(t *testing.T) {
 	t.Run("Errors when user id is not a member of the organization", func(t *testing.T) {
 		t.Parallel()
 		// mock a failed repsonse
-		transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusNotFound,
-			}, nil
-		})
-		client := &http.Client{Transport: transport}
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(s.Close)
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		fs := afero.NewMemMapFs()
 		f := &factory.Factory{
-			RestAPIClient: buildkite.NewClient(client),
+			RestAPIClient: apiClient,
 			Config:        config.New(fs, nil),
 		}
 
 		r := resolver.ResolveBuildForUserID("1234", pipelineResolver, f)
-		_, err := r(context.Background())
+		_, err = r(context.Background())
 
 		if err == nil {
 			t.Fatal("Resolver should return error if user not found")
@@ -59,12 +64,12 @@ func TestResolveBuildFromUserUUID(t *testing.T) {
 			{
 				StatusCode: http.StatusOK,
 				Body: io.NopCloser(strings.NewReader(`[{
-					"id": "abc123-4567-8910-...", 
+					"id": "abc123-4567-8910-...",
 					"number": 584,
 					"creator": {
 					"id": "0183c4e6-c88c-xxxx-b15e-7801077a9181",
 					"graphql_id": "VXNlci0tLTAxODNjNGU2LWM4OGxxxxxxxxxiMTVlLTc4MDEwNzdhOTE4MQ=="
-					}					
+					}
 					}]`)),
 			},
 			{
@@ -72,17 +77,24 @@ func TestResolveBuildFromUserUUID(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(in)),
 			},
 		}
+
 		// mock a failed repsonse
-		transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			resp := responses[callIndex]
 			callIndex++
-			return &resp, nil
-		})
+			w.WriteHeader(resp.StatusCode)
+			io.Copy(w, resp.Body)
+		}))
+		t.Cleanup(s.Close)
 
-		client := &http.Client{Transport: transport}
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		fs := afero.NewMemMapFs()
 		f := &factory.Factory{
-			RestAPIClient: buildkite.NewClient(client),
+			RestAPIClient: apiClient,
 			Config:        config.New(fs, nil),
 		}
 

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -15,7 +15,6 @@ type Factory struct {
 	Config        *config.Config
 	GitRepository *git.Repository
 	GraphQLClient graphql.Client
-	HttpClient    *http.Client
 	OpenAIClient  *openai.Client
 	RestAPIClient *buildkite.Client
 	Version       string
@@ -44,7 +43,6 @@ func New(version string) (*Factory, error) {
 	return &Factory{
 		Config:        conf,
 		GitRepository: repo,
-		HttpClient:    httpClient,
 		GraphQLClient: graphql.NewClient(config.DefaultGraphQLEndpoint, graphqlHTTPClient),
 		OpenAIClient:  openai.NewClient(conf.GetOpenAIToken()),
 		RestAPIClient: buildkiteClient,


### PR DESCRIPTION
**This PR:** Updates this tool to use the latest version of `go-buildkite`, [v3.12](https://github.com/buildkite/go-buildkite/releases/tag/v3.12.0). Included in this PR:
- Changes so that this tool uses the new [functional constructor](https://pkg.go.dev/github.com/buildkite/go-buildkite/v3@v3.12.0/buildkite#NewOpts)
- Removes usage of shortcutting roundtrippers for testing, and replaces them with the use of the [`httptest`](https://pkg.go.dev/net/http/httptest) library, which is possible now that we can set the baseURL of the buildkite library!