### PR TITLE
API command

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,8 +64,6 @@ steps:
   # this tags the commit with the input from the previous block step and pushes it to github
   # that will trigger the buildkite-cli-release pipeline off the tag which will create a release in github
   - label: ":rocket: Pushing a tag to release"
-    agents:
-      queue: untrusted
     command: ".buildkite/tag.sh"
     branches:
       - 3.x

--- a/internal/cluster/query.go
+++ b/internal/cluster/query.go
@@ -30,7 +30,6 @@ func QueryCluster(ctx context.Context, OrganizationSlug string, ClusterID string
 
 		i, edge := i, edge
 		eg.Go(func() error {
-
 			agent, err := graphql.GetClusterQueueAgent(ctx, f.GraphQLClient, OrganizationSlug, []string{edge.Node.Id})
 			if err != nil {
 				return fmt.Errorf("unable to read Cluster Queue Agents %s: %s", edge.Node.Id, err.Error())

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -47,6 +47,9 @@ func NewCmdAPI(f *factory.Factory) *cobra.Command {
         "name": "My Updated Cluster",
       }
       '
+
+      # To get all test suites
+      $ bk api --analytics /suites
       `),
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/spf13/cobra"
+)
+
+var (
+	method      string
+	headers     []string
+	data        string
+	baseURL     string
+	graphqlFlag bool
+	queryFile   string
+)
+
+func NewCmdAPI(f *factory.Factory) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "api <endpoint>",
+		Short: "Interact with the Buildkite API",
+		Long:  "Interact with either the REST or GraphQL Buildkite APIs",
+		Args:  cobra.MaximumNArgs(1),
+		Example: heredoc.Doc(`
+      # To make an API call
+      $ bk api pipelines/example-pipeline/builds/420
+      `),
+		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return apiCaller(cmd, args, f)
+		},
+	}
+
+	cmd.Flags().StringVarP(&method, "method", "X", "GET", "HTTP method to use")
+	cmd.Flags().StringArrayVarP(&headers, "header", "H", []string{}, "Headers to include in the request")
+	cmd.Flags().StringVarP(&data, "data", "d", "", "Data to send in the request body")
+	cmd.Flags().StringVar(&baseURL, "base-url", fmt.Sprintf("https://api.buildkite.com/v2/organizations/%s", f.Config.OrganizationSlug()), "Base URL for the API")
+	cmd.Flags().BoolVar(&graphqlFlag, "graphql", false, "Use GraphQL API")
+	cmd.Flags().StringVarP(&queryFile, "file", "f", "", "File containing GraphQL query")
+
+	return &cmd
+}
+
+func apiCaller(cmd *cobra.Command, args []string, f *factory.Factory) error {
+	var endpoint string
+
+	if len(args) > 1 {
+		return fmt.Errorf("Incorrect numebr of arguments. Expected 1, got %d", len(args))
+	}
+
+	if len(args) == 0 {
+		endpoint = "/"
+	} else {
+		endpoint = args[0]
+	}
+	url := baseURL + endpoint
+
+	var req *http.Request
+	var err error
+
+	if graphqlFlag {
+		return errors.New("GraphQL not supported at this time.")
+	}
+
+	if data != "" {
+		req, err = http.NewRequest(method, url, strings.NewReader(data))
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	for _, header := range headers {
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) == 2 {
+			req.Header.Add(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+
+	req.Header.Set("Authorization", "Bearer "+f.Config.APIToken())
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response: %w", err)
+	}
+
+	var jsonResponse interface{}
+	err = json.Unmarshal(body, &jsonResponse)
+	if err != nil {
+		return fmt.Errorf("error parsing JSON response: %w", err)
+	}
+
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, body, "", "  ")
+	if err != nil {
+		fmt.Println(string(body))
+		return fmt.Errorf("error parsing JSON response: %w", err)
+	}
+
+	fmt.Println(prettyJSON.String())
+
+	return nil
+}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -53,6 +53,9 @@ func NewCmdAPI(f *factory.Factory) *cobra.Command {
       `),
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if data != "" && !cmd.Flags().Changed("method") {
+				method = "POST"
+			}
 			return apiCaller(cmd, args, f)
 		},
 	}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	agentCmd "github.com/buildkite/cli/v3/pkg/cmd/agent"
 	aiCmd "github.com/buildkite/cli/v3/pkg/cmd/ai"
+	apiCmd "github.com/buildkite/cli/v3/pkg/cmd/api"
 	buildCmd "github.com/buildkite/cli/v3/pkg/cmd/build"
 	clusterCmd "github.com/buildkite/cli/v3/pkg/cmd/cluster"
 	configureCmd "github.com/buildkite/cli/v3/pkg/cmd/configure"
@@ -32,6 +33,7 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 
 	cmd.AddCommand(agentCmd.NewCmdAgent(f))
 	cmd.AddCommand(aiCmd.NewCmdAI(f))
+	cmd.AddCommand(apiCmd.NewCmdAPI(f))
 	cmd.AddCommand(buildCmd.NewCmdBuild(f))
 	cmd.AddCommand(clusterCmd.NewCmdCluster(f))
 	cmd.AddCommand(configureCmd.NewCmdConfigure(f))


### PR DESCRIPTION
## Changes
This adds an `api` command to the CLI, which can be used to make any API call that can currently be made via REST in the Buildkite [REST API](https://buildkite.com/docs/apis/rest-api). 

Non-existing Pipeline/resource:
![CleanShot 2024-08-29 at 20 59 57@2x](https://github.com/user-attachments/assets/882eedeb-560a-4ef4-80f6-749db8db715d)

Existing Pipeline:
![CleanShot 2024-08-29 at 21 00 48@2x](https://github.com/user-attachments/assets/1c7924da-1cf6-4950-b822-6c327a92a326)

With data/creating a Pipeline:
![CleanShot 2024-08-30 at 06 52 21](https://github.com/user-attachments/assets/91da155a-5dd7-49d1-b323-d65784aca840)

