### PR TITLE
Show spinner while pushing package

### DIFF
--- a/pkg/cmd/pkg/package.go
+++ b/pkg/cmd/pkg/package.go
@@ -9,6 +9,7 @@ import (
 func NewCmdPackage(f *factory.Factory) *cobra.Command {
 	cmd := cobra.Command{
 		Use:               "package <command>",
+		Aliases:           []string{"pkg"},
 		Short:             "Manage packages",
 		Long:              "Work with Buildkite Packages",
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),


### PR DESCRIPTION
This modifies `package push` to show a spinner while its uploading so there is some user feedback.

Also adds a `pkg` alias for `package`.
