### PR TITLE
Add user agent for http requests

### DIFF
--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/version"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/go-git/go-git/v5"
 	"github.com/sashabaranov/go-openai"
 )
+
+var userAgent string
 
 type Factory struct {
 	Config        *config.Config
@@ -25,15 +28,23 @@ type gqlHTTPClient struct {
 	token  string
 }
 
+func init() {
+	userAgent = fmt.Sprintf("%s buildkite-cli/%s", buildkite.DefaultUserAgent, version.Version)
+}
+
 func (a *gqlHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.token))
+	req.Header.Set("User-Agent", userAgent)
 	return a.client.Do(req)
 }
 
 func New(version string) (*Factory, error) {
 	repo, _ := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
 	conf := config.New(nil, repo)
-	buildkiteClient, err := buildkite.NewOpts(buildkite.WithTokenAuth(conf.APIToken()))
+	buildkiteClient, err := buildkite.NewOpts(
+		buildkite.WithTokenAuth(conf.APIToken()),
+		buildkite.WithUserAgent(userAgent),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("creating buildkite client: %w", err)
 	}


### PR DESCRIPTION
Add user-agent header for all api requests. This will allow us to check usage over time and ensure we can upgrade without breaking usage
