### PR TITLE
SUP-2582 | watch command

### DIFF
--- a/internal/io/prompt.go
+++ b/internal/io/prompt.go
@@ -2,15 +2,29 @@ package io
 
 import "github.com/charmbracelet/huh"
 
+const (
+	typeOrganizationMessage = "Pick an organization"
+	typePipelineMessage     = "Select a pipeline"
+)
+
 // PromptForOne will show the list of options to the user, allowing them to select one to return.
 // It's possible for them to choose none or cancel the selection, resulting in an error.
-func PromptForOne(options []string) (string, error) {
+func PromptForOne(resource string, options []string) (string, error) {
+	var message string
+	switch resource {
+	case "pipeline":
+		message = typePipelineMessage
+	case "organization":
+		message = typeOrganizationMessage
+	default:
+		message = "Please select one of the options below"
+	}
 	selected := new(string)
 	err := huh.NewForm(huh.NewGroup(
 		huh.NewSelect[string]().
-			Title("Pick an organization").
+			Title(message).
 			Options(
-				huh.NewOptions[string](options...)...,
+				huh.NewOptions(options...)...,
 			).Value(selected),
 	),
 	).Run()

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -32,7 +32,7 @@ func PickOne(pipelines []pipeline.Pipeline) *pipeline.Pipeline {
 		names[i] = p.Name
 	}
 
-	chosen, err := io.PromptForOne(names)
+	chosen, err := io.PromptForOne("pipeline", names)
 	if err != nil {
 		return nil
 	}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -35,6 +35,7 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdBuildNew(f))
 	cmd.AddCommand(NewCmdBuildRebuild(f))
 	cmd.AddCommand(NewCmdBuildView(f))
+	cmd.AddCommand(NewCmdBuildWatch(f))
 
 	return &cmd
 }

--- a/pkg/cmd/build/watch.go
+++ b/pkg/cmd/build/watch.go
@@ -1,0 +1,102 @@
+package build
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/build"
+	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
+	"github.com/buildkite/cli/v3/internal/build/resolver/options"
+	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdBuildWatch(f *factory.Factory) *cobra.Command {
+	var pipeline, branch string
+	var intervalSeconds int
+
+	cmd := cobra.Command{
+		Use:   "watch [number] [flags]",
+		Short: "Watch a build's progress in real-time",
+		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			Watch a build's progress in real-time.
+
+			You can pass an optional build number to watch. If omitted, the most recent build on the current branch will be watched.
+		`),
+		Example: heredoc.Doc(`
+			# Watch the most recent build for the current branch
+			$ bk build watch
+
+			# Watch a specific build
+			$ bk build watch 429
+
+			# Watch the most recent build on a specific branch
+			$ bk build watch -b feature-x
+
+			# Watch a build on a specific pipeline
+			$ bk build watch -p my-pipeline
+
+			# Set a custom polling interval (in seconds)
+			$ bk build watch --interval 5
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pipelineRes := pipelineResolver.NewAggregateResolver(
+				pipelineResolver.ResolveFromFlag(pipeline, f.Config),
+				pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
+				pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOne)),
+			)
+
+			optionsResolver := options.AggregateResolver{
+				options.ResolveBranchFromFlag(branch),
+				options.ResolveBranchFromRepository(f.GitRepository),
+			}
+
+			buildRes := buildResolver.NewAggregateResolver(
+				buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),
+				buildResolver.ResolveBuildWithOpts(f, pipelineRes.Resolve, optionsResolver...),
+			)
+
+			bld, err := buildRes.Resolve(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if bld == nil {
+				return fmt.Errorf("no running builds found")
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Watching build %d on %s/%s\n", bld.BuildNumber, bld.Organization, bld.Pipeline)
+
+			ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					b, _, err := f.RestAPIClient.Builds.Get(bld.Organization, bld.Pipeline, fmt.Sprint(bld.BuildNumber), &buildkite.BuildsListOptions{})
+					if err != nil {
+						return err
+					}
+
+					summary := build.BuildSummary(b)
+					fmt.Fprintf(cmd.OutOrStdout(), "\033[2J\033[H%s\n", summary) // Clear screen and move cursor to top-left
+
+					if b.FinishedAt != nil {
+						return nil
+					}
+				case <-cmd.Context().Done():
+					return nil
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to watch. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.")
+	cmd.Flags().StringVarP(&branch, "branch", "b", "", "The branch to watch builds for.")
+	cmd.Flags().IntVar(&intervalSeconds, "interval", 1, "Polling interval in seconds")
+
+	return &cmd
+}

--- a/pkg/cmd/use/use.go
+++ b/pkg/cmd/use/use.go
@@ -34,7 +34,7 @@ func useRun(org *string, conf *config.Config) error {
 	// prompt to choose from configured orgs if one is not already selected
 	if org == nil {
 		var err error
-		selected, err = io.PromptForOne(conf.ConfiguredOrganizations())
+		selected, err = io.PromptForOne("organization", conf.ConfiguredOrganizations())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes
- Expand the `PromptForOne` function so that it takes in a resource, `pipeline` or `organization`, default to a generic message to _select one_
- Adds a `watch` command that can resolve a few different options such as branch etc
- If no running build is found on any of the options provided it will return the most recent build

## Demo
https://github.com/user-attachments/assets/62d6b8af-85ba-4260-8247-567256de7b05

## Job List/Output
![CleanShot 2024-09-13 at 10 41 24](https://github.com/user-attachments/assets/181278c9-04ea-4f55-9468-8c904bab1f5a)
