### PR TITLE
Check tag doesn't exist before pushing

### DIFF
--- a/.buildkite/tag.sh
+++ b/.buildkite/tag.sh
@@ -8,17 +8,17 @@ set -euo pipefail
 
 TAG="$(buildkite-agent meta-data get "release-tag")"
 
-echo "--- Verifying tag ${TAG}"
-echo "Remote tags:"
-git ls-remote --tags
-echo "Local tags:"
-git tag -l
-# TODO verify the tag format and that its semver newer than the most previous
+if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "Error: Tag ${TAG} already exists at origin"
+  exit 1
+fi
+
+echo "${TAG} does not exist at origin. Proceeding... 🚀"
 
 echo "--- Downloading gh"
-curl -sL https://github.com/cli/cli/releases/download/v2.51.0/gh_2.51.0_linux_amd64.tar.gz | tar xz
+curl -sL https://github.com/cli/cli/releases/download/v2.57.0/gh_2.57.0_linux_amd64.tar.gz | tar xz
 echo "--- Logging in to gh"
-gh_2.51.0_linux_amd64/bin/gh auth setup-git
+gh_2.57.0_linux_amd64/bin/gh auth setup-git
 
 echo "+++ Tagging ${BUILDKITE_COMMIT} with ${TAG}"
 git tag "${TAG}"


### PR DESCRIPTION
## Changes
Currently the script naively assumes that the tag is OK to push, it also has some kind of pointless output like listing all the tags; no one is looking at that.
