### PR TITLE
support flag for folks who use that kind of thing

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -37,7 +37,7 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 				return
 			}
 			// If --version flag is not used, show help
-			cmd.Help()
+			_ = cmd.Help()
 		},
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	agentCmd "github.com/buildkite/cli/v3/pkg/cmd/agent"
 	apiCmd "github.com/buildkite/cli/v3/pkg/cmd/api"
@@ -28,7 +30,15 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 		Annotations: map[string]string{
 			"versionInfo": versionCmd.Format(f.Version),
 		},
-		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			versionFlag, _ := cmd.Flags().GetBool("version")
+			if versionFlag {
+				fmt.Println(versionCmd.Format(f.Version))
+				return
+			}
+			// If --version flag is not used, show help
+			cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(agentCmd.NewCmdAgent(f))
@@ -42,6 +52,8 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 	cmd.AddCommand(packageCmd.NewCmdPackage(f))
 	cmd.AddCommand(useCmd.NewCmdUse(f))
 	cmd.AddCommand(versionCmd.NewCmdVersion(f))
+
+	cmd.Flags().BoolP("version", "v", false, "Print the version number")
 
 	return cmd, nil
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -14,7 +14,7 @@ func NewCmdVersion(f *factory.Factory) *cobra.Command {
 		Use:   "version",
 		Short: "Print the version of the CLI being used",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(os.Stdout, Format(f.Version))
+			fmt.Fprintf(os.Stdout, "%s\n", Format(f.Version))
 		},
 	}
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -11,10 +11,10 @@ import (
 
 func NewCmdVersion(f *factory.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:    "version",
-		Hidden: true,
+		Use:   "version",
+		Short: "Print the version of the CLI being used",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(os.Stdout, "%s\n", f.Version)
+			fmt.Fprintf(os.Stdout, Format(f.Version))
 		},
 	}
 }


### PR DESCRIPTION
## Changes

Some of our older users 😛 will be used to `--version` or `-v` for printing the version, so let's support that.
