### PR TITLE
Remove the beta caveat on brew post-install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,10 +18,6 @@ brews:
       - macos-archive
       - linux-archive
     directory: .
-    caveats: |
-      This is beta software
-
-      For any questions, issues or feedback, please file an issue at https://github.com/buildkite/cli/issues
     homepage: https://github.com/buildkite/cli
     description: Work with Buildkite from the command-line
     license: MIT


### PR DESCRIPTION
Currently there's a caveat on brew post-install:
![CleanShot 2024-10-22 at 15 49 26@2x](https://github.com/user-attachments/assets/4d90e434-1dc1-41b0-bd32-93ade8548d76)

that's no longer true! 3.x is stable 🥳 

this PR removes the caveat