### PR TITLE
Produce an error rather than a blank build URL when no build created

### DIFF
--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -136,6 +136,10 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 		return err
 	}
 
+	if build.WebURL == "" {
+		return fmt.Errorf("no build was created")
+	}
+
 	fmt.Printf("%s\n", renderResult(fmt.Sprintf("Build created: %s", build.WebURL)))
 
 	return openBuildInBrowser(web, build.WebURL)


### PR DESCRIPTION
## Changes

We currently just output a blank URL when no build is created due to things like IP limitations;

```shell
Build created:
```

However that's not a great experience, so we should at least inform that no build was created while we assess erroring on build creation failure for specific reasons.
