### PR TITLE
Add a -w option to view uploaded package in web browser"

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+
+	"github.com/pkg/browser"
 )
 
 func GenerateGraphQLID(prefix, uuid string) string {
@@ -13,4 +15,15 @@ func GenerateGraphQLID(prefix, uuid string) string {
 	wr.Close()
 
 	return graphqlID.String()
+}
+
+func OpenInWebBrowser(openInWeb bool, webUrl string) error {
+	if openInWeb {
+		err := browser.OpenURL(webUrl)
+		if err != nil {
+			fmt.Println("Error opening browser: ", err)
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -1,13 +1,10 @@
 package build
 
 import (
-	"fmt"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -38,17 +35,6 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdBuildWatch(f))
 
 	return &cmd
-}
-
-func openBuildInBrowser(openInWeb bool, webUrl string) error {
-	if openInWeb {
-		err := browser.OpenURL(webUrl)
-		if err != nil {
-			fmt.Println("Error opening browser: ", err)
-			return err
-		}
-	}
-	return nil
 }
 
 func renderResult(result string) string {

--- a/pkg/cmd/build/cancel.go
+++ b/pkg/cmd/build/cancel.go
@@ -8,6 +8,7 @@ import (
 	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
 	"github.com/buildkite/cli/v3/internal/io"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/charmbracelet/huh/spinner"
@@ -84,5 +85,5 @@ func cancelBuild(ctx context.Context, org string, pipeline string, buildId strin
 
 	fmt.Printf("%s\n", renderResult(fmt.Sprintf("Build canceled: %s", build.WebURL)))
 
-	return openBuildInBrowser(web, build.WebURL)
+	return util.OpenInWebBrowser(web, build.WebURL)
 }

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/charmbracelet/huh/spinner"
@@ -142,5 +143,5 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 
 	fmt.Printf("%s\n", renderResult(fmt.Sprintf("Build created: %s", build.WebURL)))
 
-	return openBuildInBrowser(web, build.WebURL)
+	return util.OpenInWebBrowser(web, build.WebURL)
 }

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -8,6 +8,7 @@ import (
 	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
 	"github.com/buildkite/cli/v3/internal/build/resolver/options"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/charmbracelet/huh/spinner"
@@ -102,5 +103,5 @@ func rebuild(ctx context.Context, org string, pipeline string, buildId string, w
 
 	fmt.Printf("%s\n", renderResult(fmt.Sprintf("Build created: %s", build.WebURL)))
 
-	return openBuildInBrowser(web, build.WebURL)
+	return util.OpenInWebBrowser(web, build.WebURL)
 }


### PR DESCRIPTION
This PR adds a command line option (-w , --web)  to open the package information of the recently pushed package in a web browser.

This PR also refactors the location of the generic function to launch the web browser that has been used by the `build` command. 