### PR TITLE
Allow for an alternate buildkite.com to be specified

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,14 @@ func (conf *Config) ConfiguredOrganizations() []string {
 	return keys
 }
 
+func (conf *Config) GetGraphQLEndpoint() string {
+	value := os.Getenv("BUILDKITE_GRAPHQL_ENDPOINT")
+	if value != "" {
+		return value
+	}
+	return DefaultGraphQLEndpoint
+}
+
 func (conf *Config) HasConfiguredOrganization(slug string) bool {
 	m := conf.userConfig.GetStringMap("organizations")
 	_, ok := m[slug]

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -52,7 +52,7 @@ func New(version string) (*Factory, error) {
 	return &Factory{
 		Config:        conf,
 		GitRepository: repo,
-		GraphQLClient: graphql.NewClient(config.DefaultGraphQLEndpoint, graphqlHTTPClient),
+		GraphQLClient: graphql.NewClient(conf.GetGraphQLEndpoint(), graphqlHTTPClient),
 		RestAPIClient: buildkiteClient,
 		Version:       version,
 	}, nil


### PR DESCRIPTION
Given a `BUILDKITE_GRAPHQL_ENDPOINT` env is found, use it as the base for the GraphQL API calls being made instead of the built-in default.