### PR TITLE
Allow non-interactive `bk configure` command

### DIFF
--- a/pkg/cmd/configure/add/add.go
+++ b/pkg/cmd/configure/add/add.go
@@ -22,6 +22,13 @@ func NewCmdAdd(f *factory.Factory) *cobra.Command {
 	return cmd
 }
 
+func ConfigureWithCredentials(f *factory.Factory, org, token string) error {
+	if err := f.Config.SelectOrganization(org); err != nil {
+		return err
+	}
+	return f.Config.SetTokenForOrg(org, token)
+}
+
 func ConfigureRun(f *factory.Factory) error {
 	var org, token string
 	nonEmpty := func(s string) error {
@@ -43,12 +50,5 @@ func ConfigureRun(f *factory.Factory) error {
 		return err
 	}
 
-	err = f.Config.SelectOrganization(org)
-	if err != nil {
-		return err
-	}
-
-	err = f.Config.SetTokenForOrg(org, token)
-
-	return err
+	return ConfigureWithCredentials(f, org, token)
 }

--- a/pkg/cmd/configure/configure.go
+++ b/pkg/cmd/configure/configure.go
@@ -9,7 +9,11 @@ import (
 )
 
 func NewCmdConfigure(f *factory.Factory) *cobra.Command {
-	var force bool
+	var (
+		force bool
+		org   string
+		token string
+	)
 
 	cmd := &cobra.Command{
 		Use:     "configure",
@@ -22,11 +26,19 @@ func NewCmdConfigure(f *factory.Factory) *cobra.Command {
 				return errors.New("API token already configured. You must use --force.")
 			}
 
+			// If flags are provided, use them directly
+			if org != "" && token != "" {
+				return addCmd.ConfigureWithCredentials(f, org, token)
+			}
+
+			// Otherwise fall back to interactive mode
 			return addCmd.ConfigureRun(f)
 		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Force setting a new token")
+	cmd.Flags().StringVar(&org, "org", "", "Organization slug")
+	cmd.Flags().StringVar(&token, "token", "", "API token")
 
 	cmd.AddCommand(addCmd.NewCmdAdd(f))
 


### PR DESCRIPTION
Currently `bk configure` is interactive and this prevents from using it in poduction, eg github actions. This PR adds `--org` and `--token` options for non-interactive bk CLI configure.

**Note**: due to multiple bugs in current buildkite packages system, I can't verify that I really can push packages after non-interactive configuration. But I can't push packages with current release version too. I am not familiar with other buildkite features, so unfortunately can't test my changes