### PR TITLE
Environment Variable config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/cli/v3
 
-go 1.22
+go 1.23
 
-toolchain go1.22.5
+toolchain go1.23.3
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 
 	"github.com/buildkite/cli/v3/internal/pipeline"
+	"github.com/buildkite/go-buildkite/v4"
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -22,10 +23,11 @@ import (
 
 const (
 	DefaultGraphQLEndpoint = "https://graphql.buildkite.com/v1"
-	appData                = "AppData"
-	configFilePath         = "bk.yaml"
-	localConfigFilePath    = "." + configFilePath
-	xdgConfigHome          = "XDG_CONFIG_HOME"
+
+	appData             = "AppData"
+	configFilePath      = "bk.yaml"
+	localConfigFilePath = "." + configFilePath
+	xdgConfigHome       = "XDG_CONFIG_HOME"
 )
 
 // Config contains the configuration for the currently selected organization
@@ -133,6 +135,15 @@ func (conf *Config) GetGraphQLEndpoint() string {
 		return value
 	}
 	return DefaultGraphQLEndpoint
+}
+
+func (conf *Config) RESTAPIEndpoint() string {
+	value := os.Getenv("BUILDKITE_REST_API_ENDPOINT")
+	if value != "" {
+		return value
+	}
+
+	return buildkite.DefaultBaseURL
 }
 
 func (conf *Config) HasConfiguredOrganization(slug string) bool {

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -40,6 +40,7 @@ func New(version string) (*Factory, error) {
 	repo, _ := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
 	conf := config.New(nil, repo)
 	buildkiteClient, err := buildkite.NewOpts(
+		buildkite.WithBaseURL(conf.RESTAPIEndpoint()),
 		buildkite.WithTokenAuth(conf.APIToken()),
 		buildkite.WithUserAgent(userAgent),
 	)


### PR DESCRIPTION
**This PR:** Allows users to specify their buildkite API tokens and organization slugs via environment variable, allowing them to end-run around the `bk configure` command. This should make running the `bk` cli in headless environments (like CI jobs 👀) much easier.

Environment variables take precedence over config items specified in files, as is fairly standard across CLI tools.

Example:
```
$ rm ~/.config/bk.yaml
$ export BUILDKITE_API_TOKEN=bkua_haha_nice_try 
$ export BUILDKITE_ORGANIZATION_SLUG=bennos-extra-secret-org 
$ bk pipeline view "my-cool-pipeline"
  My Cool Pipeline: Possibly the coolest pipeline around
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

                         Speed: 11s    Reliability: 80%

    agents:
      queue: default

    steps:
      - command: buildkite-agent pipeline upload
```


Additionally, it adds another envar for `BUILDKITE_REST_API_HOST`, similar to the graphql host envar added in #406. This should make local development easier.

🍷🧀 This PR should pair with #407 nicely - they allow gradations in how interactive you want CLI configuration to be 