### PR TITLE
Only use a spinner on a tty

### DIFF
--- a/internal/io/spinner.go
+++ b/internal/io/spinner.go
@@ -1,0 +1,21 @@
+package io
+
+import (
+	"os"
+
+	"github.com/charmbracelet/huh/spinner"
+	"github.com/mattn/go-isatty"
+)
+
+func SpinWhile(name string, action func()) error {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		action()
+
+		return nil
+	}
+
+	return spinner.New().
+		Title(name).
+		Action(action).
+		Run()
+}

--- a/pkg/cmd/pkg/push.go
+++ b/pkg/cmd/pkg/push.go
@@ -7,10 +7,10 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	bk_io "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/go-buildkite/v4"
-	"github.com/charmbracelet/huh/spinner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -74,15 +74,12 @@ func NewCmdPackagePush(f *factory.Factory) *cobra.Command {
 			}
 
 			var pkg buildkite.Package
-			spinErr := spinner.New().
-				Title("Pushing package").
-				Action(func() {
-					pkg, _, err = f.RestAPIClient.PackagesService.Create(cmd.Context(), f.Config.OrganizationSlug(), cfg.RegistrySlug, buildkite.CreatePackageInput{
-						Filename: packageName,
-						Package:  from,
-					})
-				}).
-				Run()
+			spinErr := bk_io.SpinWhile("Pushing package", func() {
+				pkg, _, err = f.RestAPIClient.PackagesService.Create(cmd.Context(), f.Config.OrganizationSlug(), cfg.RegistrySlug, buildkite.CreatePackageInput{
+					Filename: packageName,
+					Package:  from,
+				})
+			})
 			if spinErr != nil {
 				return spinErr
 			}


### PR DESCRIPTION
I tried to use bk to push a package from GitHub Actions, but it failed:

https://github.com/sj26/github-actions-to-buildkite-packages-javascript-example/actions/runs/12133880719/job/33830150889#step:5:8

<img width="777" alt="Screenshot 2024-12-05 at 11 52 33 AM" src="https://github.com/user-attachments/assets/34b14720-77a8-4c8e-9113-2d01e49791f1">

Pretty sure that message comes via `spinErr`. I think it's because it's trying to start spinner, and that seems to require a tty.

This wraps up the spinner a little function that checks if we're in a tty when starting a spinner, and skips the spinner if we're not.

I haven't attempted tests yet .. I just wanted to see if this works.

I did test this locally and could still push a package and it showed a spinner. I couldn't figure out quickly how to simulate a no-tty environment.