### PR TITLE
Don't print command usage information on every error

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -22,9 +22,10 @@ import (
 
 func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   "bk <command> <subcommand> [flags]",
-		Short: "Buildkite CLI",
-		Long:  "Work with Buildkite from the command line.",
+		Use:          "bk <command> <subcommand> [flags]",
+		Short:        "Buildkite CLI",
+		Long:         "Work with Buildkite from the command line.",
+		SilenceUsage: true,
 		Example: heredoc.Doc(`
 			$ bk build view
 		`),


### PR DESCRIPTION
Currently, if a command errors in any way, it'll print an error, and then the usage for the command, for example, an authentication failure:
```
$ bkcli package push bennos-gemmos ../test-1.0.0.gem
Error: API error: request to create package failed: requesting presigned upload: executing POST presigned upload request: POST https://api.buildkite.com/v2/packages/organizations/bennos-super-secret-cool-time-org/registries/bennos-gemmos/packages/upload: 404 No organization found
Usage:
  bk package push registry-name {path/to/file | --stdin-file-name filename -} [flags]

Examples:
Push a package to a Buildkite registry
The web URL of the uploaded package will be printed to stdout.

$ bk package push my-registry my-package.tar.gz
$ cat my-package.tar.gz | bk package push my-registry --stdin-file-name my-package.tar.gz - # Pass package via stdin, note hyphen as the argument

# add -w to open the build in your web browser
$ bk package push my-registry my-package.tar.gz -w


Flags:
  -h, --help                     help for push
  -n, --stdin-file-name string   The filename to use for the package, if it's passed via stdin. Invalid otherwise.
  -w, --web                      Open in a web browser the package information after it has been uploaded.
```

The usage information here isn't helpful - this isn't an issue a different flagset would help - and indeed, it makes it more difficult to find the error that actually caused the command to fail.

To wit, this PR adds the `SilenceUsage` config option to the root command, which prevents this behaviour from occuring.