### PR TITLE
bk artifacts list command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/briandowns/spinner v1.23.1 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.4.5 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fatih/color v1.14.1 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
+github.com/briandowns/spinner v1.23.1 h1:t5fDPmScwUjozhDj4FA46p5acZWIPXYE30qW2Ptu650=
+github.com/briandowns/spinner v1.23.1/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/buildkite/go-buildkite/v4 v4.1.0 h1:n1f3EAe8/64ju9QjSWJYMjD8++mn1pOLK/tZscD5DKo=
 github.com/buildkite/go-buildkite/v4 v4.1.0/go.mod h1:xlYVIETMCk46KUkmfRoztoIf888KwdY5uZXNinZ1PX0=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
@@ -99,6 +101,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
+github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/internal/artifact/view.go
+++ b/internal/artifact/view.go
@@ -9,7 +9,8 @@ func ArtifactSummary(artifact *buildkite.Artifact) string {
 	artifactSummary := lipgloss.JoinVertical(lipgloss.Top,
 		lipgloss.NewStyle().Align(lipgloss.Left).Padding(0, 1).Render(),
 		lipgloss.JoinHorizontal(lipgloss.Left,
-			lipgloss.NewStyle().Width(60).Align(lipgloss.Left).Padding(0, 1).Render(artifact.Path),
+			lipgloss.NewStyle().Width(38).Align(lipgloss.Left).Padding(0, 1).Render(artifact.ID),
+			lipgloss.NewStyle().Width(50).Align(lipgloss.Left).Padding(0, 1).Render(artifact.Path),
 			lipgloss.NewStyle().Align(lipgloss.Right).Padding(0, 1).Render(FormatBytes(artifact.FileSize)),
 		),
 	)

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -34,7 +34,6 @@ func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.
 		}
 
 		builds, _, err := f.RestAPIClient.Builds.ListByPipeline(context.TODO(), f.Config.OrganizationSlug(), pipeline.Name, opts)
-		fmt.Println(builds, err)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/artifacts/artifacts.go
+++ b/pkg/cmd/artifacts/artifacts.go
@@ -1,0 +1,49 @@
+package artifacts
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/build/resolver"
+	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
+	"github.com/buildkite/cli/v3/internal/build/resolver/options"
+	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdArtifacts(f *factory.Factory) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "artifacts <command>",
+		Args:  cobra.ArbitraryArgs,
+		Long:  "Manage pipeline build artifacts",
+		Short: "Manage pipeline build artifacts",
+		Example: heredoc.Doc(`
+			# To view pipeline build artifacts
+			$ bk artifacts list -b "build number"
+		`),
+		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
+	}
+	cmd.AddCommand(NewCmdArtifactsList(f))
+
+	return &cmd
+}
+
+func resolveFrom(pipeline string, f *factory.Factory, args []string) resolver.AggregateResolver {
+	//resolve a pipeline based on how bk build resolves the pipeline
+	pipelineRes := pipelineResolver.NewAggregateResolver(
+		pipelineResolver.ResolveFromFlag(pipeline, f.Config),
+		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOne)),
+	)
+
+	// we resolve a build  an optional argument or positional argument
+	optionsResolver := options.AggregateResolver{
+		options.ResolveBranchFromRepository(f.GitRepository),
+	}
+
+	buildRes := buildResolver.NewAggregateResolver(
+		buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),
+		buildResolver.ResolveBuildWithOpts(f, pipelineRes.Resolve, optionsResolver...),
+	)
+	return buildRes
+}

--- a/pkg/cmd/artifacts/list.go
+++ b/pkg/cmd/artifacts/list.go
@@ -1,0 +1,107 @@
+package artifacts
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/artifact"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/charmbracelet/huh/spinner"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdArtifactsList(f *factory.Factory) *cobra.Command {
+	var pipeline, job string
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "list [number] [flags]",
+		Short:                 "List artifacts for a build or a job in a build.",
+		Args:                  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			List artifacts for a build or a job in a build.
+
+			You can pass an optional build number. If omitted, the most recent build on the current branch will be resolved.
+	`),
+		Example: heredoc.Doc(`
+			# by default, artifacts of the most recent build for the current branch is shown
+			$ bk artifacts list 
+			# to list artifacts of a specific build
+			$ bk artifacts list 429 
+			# to list artifacts of a specific job in a build
+			$ bk artifacts list 429 --job 0193903e-ecd9-4c51-9156-0738da987e87  
+			# if not inside a repository or to use a specific pipeline, pass -p
+			$ bk artifacts list -p monolith 
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			buildRes := resolveFrom(pipeline, f, args)
+
+			bld, err := buildRes.Resolve(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if bld == nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "No build found.\n")
+				return nil
+			}
+
+			var buildArtifacts []buildkite.Artifact
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+
+			spinErr := spinner.New().
+				Title("Loading build information").
+				Action(func() {
+					wg.Add(1)
+
+					go func() {
+						defer wg.Done()
+						var apiErr error
+						buildArtifacts, _, apiErr = f.RestAPIClient.Artifacts.ListByBuild(cmd.Context(), bld.Organization, bld.Pipeline, fmt.Sprint(bld.BuildNumber), nil)
+						if apiErr != nil {
+							mu.Lock()
+							err = apiErr
+							mu.Unlock()
+						}
+					}()
+
+					wg.Wait()
+				}).
+				Run()
+			if spinErr != nil {
+				return spinErr
+			}
+			if err != nil {
+				return err
+			}
+
+			summary := lipgloss.JoinVertical(lipgloss.Top,
+				lipgloss.NewStyle().Bold(true).Padding(0, 1).Render(fmt.Sprintf("Artifacts for build: %d", bld.BuildNumber)),
+			)
+			if len(buildArtifacts) > 0 {
+				summary += lipgloss.NewStyle().Bold(true).Padding(0, 1).Underline(true).Render("\n\nArtifacts")
+				for _, a := range buildArtifacts {
+					summary += artifact.ArtifactSummary(&a)
+				}
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", summary)
+
+			return err
+		},
+	}
+
+	cmd.Flags().StringVarP(&job, "job", "j", "", "List artifacts for a specific job on the given build.")
+	cmd.Flags().StringVarP(&pipeline, "pipeline", "p", "", "The pipeline to view. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.\n"+
+		"If omitted, it will be resolved using the current directory.",
+	)
+
+	cmd.Flags().SortFlags = false
+
+	return &cmd
+}

--- a/pkg/cmd/artifacts/list.go
+++ b/pkg/cmd/artifacts/list.go
@@ -18,7 +18,7 @@ func NewCmdArtifactsList(f *factory.Factory) *cobra.Command {
 
 	cmd := cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "list [number] [flags]",
+		Use:                   "list [build number] [flags]",
 		Short:                 "List artifacts for a build or a job in a build.",
 		Args:                  cobra.MaximumNArgs(1),
 		Long: heredoc.Doc(`
@@ -28,13 +28,13 @@ func NewCmdArtifactsList(f *factory.Factory) *cobra.Command {
 	`),
 		Example: heredoc.Doc(`
 			# by default, artifacts of the most recent build for the current branch is shown
-			$ bk artifacts list 
+			$ bk artifacts list
 			# to list artifacts of a specific build
 			$ bk artifacts list 429 
 			# to list artifacts of a specific job in a build
 			$ bk artifacts list 429 --job 0193903e-ecd9-4c51-9156-0738da987e87  
 			# if not inside a repository or to use a specific pipeline, pass -p
-			$ bk artifacts list -p monolith 
+			$ bk artifacts list 429 -p monolith 
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	agentCmd "github.com/buildkite/cli/v3/pkg/cmd/agent"
 	apiCmd "github.com/buildkite/cli/v3/pkg/cmd/api"
+	artifactsCmd "github.com/buildkite/cli/v3/pkg/cmd/artifacts"
 	buildCmd "github.com/buildkite/cli/v3/pkg/cmd/build"
 	clusterCmd "github.com/buildkite/cli/v3/pkg/cmd/cluster"
 	configureCmd "github.com/buildkite/cli/v3/pkg/cmd/configure"
@@ -44,6 +45,7 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 
 	cmd.AddCommand(agentCmd.NewCmdAgent(f))
 	cmd.AddCommand(apiCmd.NewCmdAPI(f))
+	cmd.AddCommand(artifactsCmd.NewCmdArtifacts(f))
 	cmd.AddCommand(buildCmd.NewCmdBuild(f))
 	cmd.AddCommand(clusterCmd.NewCmdCluster(f))
 	cmd.AddCommand(configureCmd.NewCmdConfigure(f))


### PR DESCRIPTION
This PR implements `bk artifacts list` command 

``` 
List artifacts for a build or a job in a build.

You can pass an optional build number. If omitted, the most recent build on the current branch will be resolved.

Usage:
  bk artifacts list [build number] [flags]

Examples:
# by default, artifacts of the most recent build for the current branch is shown
$ bk artifacts list
# to list artifacts of a specific build
$ bk artifacts list 429 
# to list artifacts of a specific job in a build
$ bk artifacts list 429 --job 0193903e-ecd9-4c51-9156-0738da987e87  
# if not inside a repository or to use a specific pipeline, pass -p
$ bk artifacts list 429 -p monolith 


Flags:
  -j, --job string        List artifacts for a specific job on the given build.
  -p, --pipeline string   The pipeline to view. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}. 
                          If omitted, it will be resolved using the current directory.
  -h, --help              help for list
  ``` 
  
I have also added the artifacts UUID when listing artifacts for a build or a job to provide user a reference when we implement the `bk artifacts download <artifact uuid>` command.

![Screenshot 2024-12-11 at 11 47 31 AM](https://github.com/user-attachments/assets/99b015a2-37b5-47f6-8554-13abdd55404e)
