### PR TITLE
SUP-2875 | produce actionable error on missing default branch

### DIFF
--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -143,6 +143,12 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 					actionErr = fmt.Errorf("Error getting pipeline: %w", err)
 					return
 				}
+
+				// Check if the pipeline has a default branch set
+				if p.DefaultBranch == "" {
+					actionErr = fmt.Errorf("No default branch set for pipeline %s. Please specify a branch using --branch (-b)", pipeline)
+					return
+				}
 				branch = p.DefaultBranch
 			}
 


### PR DESCRIPTION
## Changes

We can check the returned value of the pipeline targeted as it's a field on the struct

```go
if p.DefaultBranch == "" {
	actionErr = fmt.Errorf("No default branch set for pipeline %s. Please specify a branch using --branch (-b)", pipeline)
	return
}
```

Here we just check that the `default_branch` of the pipeline isn't null, if it is then we produce a helpful error to use `--branch` in the command, else the build will be created on the _default branch_ for the pipeline.`

