### PR TITLE
Buildkite Package Registries command help wording fixes.

### DIFF
--- a/pkg/cmd/pkg/package.go
+++ b/pkg/cmd/pkg/package.go
@@ -11,7 +11,7 @@ func NewCmdPackage(f *factory.Factory) *cobra.Command {
 		Use:               "package <command>",
 		Aliases:           []string{"pkg"},
 		Short:             "Manage packages",
-		Long:              "Work with Buildkite Packages",
+		Long:              "Work with Buildkite Package Registries",
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
 	}
 

--- a/pkg/cmd/pkg/push_test.go
+++ b/pkg/cmd/pkg/push_test.go
@@ -88,7 +88,7 @@ func TestPackagePush(t *testing.T) {
 			stdin:          strings.NewReader("test package stream contents!"),
 			args:           []string{"my-registry", "-"},
 			wantErr:        ErrInvalidConfig,
-			wantErrContain: "When passing a package via stdin, the --stdin-file-name flag must be provided",
+			wantErrContain: "When passing a package file via stdin, the --stdin-file-name flag must be provided",
 		},
 
 		// Happy paths


### PR DESCRIPTION
Updating wording of Buildkite Package Registries commands to reflect:

- current product name,
- make packages sound more like files, to make them more applicable to other package ecosystems, and
- correct name reference to slug.
