### PR TITLE
✨ Cluster view output options

### DIFF
--- a/pkg/cmd/cluster/view.go
+++ b/pkg/cmd/cluster/view.go
@@ -1,15 +1,99 @@
+// pkg/cmd/cluster/view.go
+
 package cluster
 
 import (
+	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/buildkite/cli/v3/internal/cluster"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/output"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/charmbracelet/huh/spinner"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
+
+// CreatedByView represents cluster creator information
+type CreatedByView struct {
+	ID        string    `json:"id" yaml:"id"`
+	GraphQLID string    `json:"graphql_id" yaml:"graphql_id"`
+	Name      string    `json:"name" yaml:"name"`
+	Email     string    `json:"email" yaml:"email"`
+	AvatarURL string    `json:"avatar_url" yaml:"avatar_url"`
+	CreatedAt time.Time `json:"created_at" yaml:"created_at"`
+}
+
+// ClusterView provides a formatted view of cluster data
+type ClusterView struct {
+	ID              string         `json:"id" yaml:"id"`
+	GraphQLID       string         `json:"graphql_id" yaml:"graphql_id"`
+	DefaultQueueID  string         `json:"default_queue_id" yaml:"default_queue_id"`
+	Name            string         `json:"name" yaml:"name"`
+	Description     string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Emoji           string         `json:"emoji,omitempty" yaml:"emoji,omitempty"`
+	Color           string         `json:"color,omitempty" yaml:"color,omitempty"`
+	URL             string         `json:"url" yaml:"url"`
+	WebURL          string         `json:"web_url" yaml:"web_url"`
+	DefaultQueueURL string         `json:"default_queue_url" yaml:"default_queue_url"`
+	QueuesURL       string         `json:"queues_url" yaml:"queues_url"`
+	CreatedAt       time.Time      `json:"created_at" yaml:"created_at"`
+	CreatedBy       *CreatedByView `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+}
+
+// TextOutput implements the output.Formatter interface
+func (c ClusterView) TextOutput() string {
+	var b bytes.Buffer
+
+	// Helper functions for consistent styling
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("5"))
+	label := lipgloss.NewStyle().Width(15).Bold(true)
+	section := func(name string) {
+		fmt.Fprintf(&b, "\n%s\n", title.Render(name))
+	}
+	field := func(name, value string) {
+		fmt.Fprintf(&b, "%s %s\n", label.Render(name+":"), value)
+	}
+
+	// Basic Information
+	section("Cluster Details")
+	field("Name", c.Name)
+	if c.Emoji != "" {
+		field("Emoji", c.Emoji)
+	}
+	if c.Description != "" {
+		field("Description", c.Description)
+	}
+	if c.Color != "" {
+		field("Color", c.Color)
+	}
+
+	// IDs and URLs
+	section("Identifiers")
+	field("ID", c.ID)
+	field("GraphQL ID", c.GraphQLID)
+	field("Default Queue ID", c.DefaultQueueID)
+
+	// URLs
+	section("URLs")
+	field("Web URL", c.WebURL)
+	field("API URL", c.URL)
+	field("Queues URL", c.QueuesURL)
+	field("Queue URL", c.DefaultQueueURL)
+
+	// Creator Information
+	if c.CreatedBy != nil {
+		section("Created By")
+		field("Name", c.CreatedBy.Name)
+		field("Email", c.CreatedBy.Email)
+		field("ID", c.CreatedBy.ID)
+		field("Created At", c.CreatedAt.Format(time.RFC3339))
+	}
+
+	return b.String()
+}
 
 func NewCmdClusterView(f *factory.Factory) *cobra.Command {
 	cmd := cobra.Command{
@@ -23,35 +107,56 @@ func NewCmdClusterView(f *factory.Factory) *cobra.Command {
 			It accepts org slug and cluster id.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			orgSlug := f.Config.OrganizationSlug()
-			clusterID := args[0]
-			clusterRes, _, err := f.RestAPIClient.Clusters.Get(cmd.Context(), orgSlug, clusterID)
+			format, err := output.GetFormat(cmd.Flags())
 			if err != nil {
 				return err
 			}
 
-			var output string
+			var cluster buildkite.Cluster
 			spinErr := spinner.New().
 				Title("Loading cluster information").
 				Action(func() {
-					output = cluster.ClusterViewTable(buildkite.Cluster{
-						Name:           clusterRes.Name,
-						ID:             clusterRes.ID,
-						DefaultQueueID: clusterRes.DefaultQueueID,
-						Color:          clusterRes.Color,
-					})
+					cluster, _, err = f.RestAPIClient.Clusters.Get(cmd.Context(), f.Config.OrganizationSlug(), args[0])
 				}).
 				Run()
 			if spinErr != nil {
 				return spinErr
 			}
+			if err != nil {
+				return err
+			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", output)
+			view := ClusterView{
+				ID:              cluster.ID,
+				GraphQLID:       cluster.GraphQLID,
+				DefaultQueueID:  cluster.DefaultQueueID,
+				Name:            cluster.Name,
+				Description:     cluster.Description,
+				Emoji:           cluster.Emoji,
+				Color:           cluster.Color,
+				URL:             cluster.URL,
+				WebURL:          cluster.WebURL,
+				DefaultQueueURL: cluster.DefaultQueueURL,
+				QueuesURL:       cluster.QueuesURL,
+				CreatedAt:       cluster.CreatedAt.Time,
+			}
 
-			return err
+			if cluster.CreatedBy.ID != "" {
+				view.CreatedBy = &CreatedByView{
+					ID:        cluster.CreatedBy.ID,
+					GraphQLID: cluster.CreatedBy.GraphQLID,
+					Name:      cluster.CreatedBy.Name,
+					Email:     cluster.CreatedBy.Email,
+					AvatarURL: cluster.CreatedBy.AvatarURL,
+					CreatedAt: cluster.CreatedBy.CreatedAt.Time,
+				}
+			}
+
+			return output.Write(cmd.OutOrStdout(), view, format)
 		},
 	}
+
+	output.AddFlags(cmd.Flags())
 
 	return &cmd
 }


### PR DESCRIPTION
## Changes

- In https://github.com/buildkite/cli/pull/443 we implemented support for output options
- We use that in the `cluster view` command

## Usage

```sh
bk cluster view this-is-an-id -o json
```

![CleanShot 2025-02-17 at 15 16 17](https://github.com/user-attachments/assets/0ef4e7f8-413b-438f-bd5e-5681c84e59f7)