### PR TITLE
Extract Common HTTP Client Logic

### DIFF
--- a/internal/http/README.md
+++ b/internal/http/README.md
@@ -1,0 +1,79 @@
+# HTTP Client Package
+
+This package provides a common HTTP client with standardized headers and error handling for Buildkite API requests.
+
+## Features
+
+- Standardized authorization header handling
+- Common error handling for API responses
+- Support for different HTTP methods (GET, POST, PUT, DELETE)
+- JSON request and response handling
+- Configurable base URL and user agent
+
+## Usage
+
+### Creating a client
+
+```go
+import (
+    "github.com/buildkite/cli/v3/internal/http"
+)
+
+// Basic client with token
+client := http.NewClient("your-api-token")
+
+// Client with custom base URL
+client := http.NewClient(
+    "your-api-token",
+    http.WithBaseURL("https://api.example.com"),
+)
+
+// Client with custom user agent
+client := http.NewClient(
+    "your-api-token",
+    http.WithUserAgent("my-app/1.0"),
+)
+
+// Client with custom HTTP client
+client := http.NewClient(
+    "your-api-token",
+    http.WithHTTPClient(customHTTPClient),
+)
+```
+
+### Making requests
+
+```go
+// GET request
+var response SomeResponseType
+err := client.Get(ctx, "/endpoint", &response)
+
+// POST request with body
+requestBody := map[string]string{"key": "value"}
+var response SomeResponseType
+err := client.Post(ctx, "/endpoint", requestBody, &response)
+
+// PUT request
+err := client.Put(ctx, "/endpoint", requestBody, &response)
+
+// DELETE request
+err := client.Delete(ctx, "/endpoint", &response)
+
+// Custom method
+err := client.Do(ctx, "PATCH", "/endpoint", requestBody, &response)
+```
+
+### Error handling
+
+```go
+err := client.Get(ctx, "/endpoint", &response)
+if err != nil {
+    // Check if it's an HTTP error
+    if httpErr, ok := err.(*http.ErrorResponse); ok {
+        fmt.Printf("HTTP error: %d %s\n", httpErr.StatusCode, httpErr.Status)
+        fmt.Printf("Response body: %s\n", httpErr.Body)
+    } else {
+        fmt.Printf("Other error: %v\n", err)
+    }
+}
+```

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -1,0 +1,168 @@
+// Package http provides a common HTTP client with standardized headers and error handling
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Client is an HTTP client that handles common operations for Buildkite API requests
+type Client struct {
+	baseURL   string
+	token     string
+	userAgent string
+	client    *http.Client
+}
+
+// ClientOption is a function that modifies a Client
+type ClientOption func(*Client)
+
+// WithBaseURL sets the base URL for API requests
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
+// WithUserAgent sets the User-Agent header for requests
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) {
+		c.userAgent = userAgent
+	}
+}
+
+// WithHTTPClient sets the underlying HTTP client
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *Client) {
+		c.client = client
+	}
+}
+
+// NewClient creates a new HTTP client with the given token and options
+func NewClient(token string, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL:   "https://api.buildkite.com",
+		token:     token,
+		userAgent: "buildkite-cli",
+		client:    http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Get performs a GET request to the specified endpoint
+func (c *Client) Get(ctx context.Context, endpoint string, v interface{}) error {
+	return c.Do(ctx, http.MethodGet, endpoint, nil, v)
+}
+
+// Post performs a POST request to the specified endpoint with the given body
+func (c *Client) Post(ctx context.Context, endpoint string, body interface{}, v interface{}) error {
+	return c.Do(ctx, http.MethodPost, endpoint, body, v)
+}
+
+// Put performs a PUT request to the specified endpoint with the given body
+func (c *Client) Put(ctx context.Context, endpoint string, body interface{}, v interface{}) error {
+	return c.Do(ctx, http.MethodPut, endpoint, body, v)
+}
+
+// Delete performs a DELETE request to the specified endpoint
+func (c *Client) Delete(ctx context.Context, endpoint string, v interface{}) error {
+	return c.Do(ctx, http.MethodDelete, endpoint, nil, v)
+}
+
+// Do performs an HTTP request with the given method, endpoint, and body
+func (c *Client) Do(ctx context.Context, method, endpoint string, body interface{}, v interface{}) error {
+	// Ensure endpoint starts with "/"
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+
+	// Create the request URL
+	reqURL, err := url.JoinPath(c.baseURL, endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to create request URL: %w", err)
+	}
+
+	// Create the request body
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	// Create the request
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set common headers
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	req.Header.Set("User-Agent", c.userAgent)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// Execute the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for error status
+	if resp.StatusCode >= 400 {
+		return &ErrorResponse{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			URL:        reqURL,
+			Body:       respBody,
+		}
+	}
+
+	// Parse the response if a target was provided
+	if v != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, v); err != nil {
+			return fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ErrorResponse represents an error response from the API
+type ErrorResponse struct {
+	StatusCode int
+	Status     string
+	URL        string
+	Body       []byte
+}
+
+// Error implements the error interface
+func (e *ErrorResponse) Error() string {
+	msg := fmt.Sprintf("HTTP request failed: %d %s (%s)", e.StatusCode, e.Status, e.URL)
+	if len(e.Body) > 0 {
+		msg += fmt.Sprintf(": %s", e.Body)
+	}
+	return msg
+}

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -1,0 +1,188 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testResponse struct {
+	Message string `json:"message"`
+}
+
+func TestClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("makes request with authorization header", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedToken string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(testResponse{Message: "success"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-token", WithBaseURL(server.URL))
+
+		var resp testResponse
+		err := client.Get(context.Background(), "/test", &resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedToken := "Bearer test-token"
+		if receivedToken != expectedToken {
+			t.Errorf("expected Authorization header %q, got %q", expectedToken, receivedToken)
+		}
+
+		if resp.Message != "success" {
+			t.Errorf("expected response message %q, got %q", "success", resp.Message)
+		}
+	})
+
+	t.Run("handles JSON response", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(testResponse{Message: "test message"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-token", WithBaseURL(server.URL))
+
+		var resp testResponse
+		err := client.Get(context.Background(), "/test", &resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if resp.Message != "test message" {
+			t.Errorf("expected message %q, got %q", "test message", resp.Message)
+		}
+	})
+
+	t.Run("handles error response", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"error": "bad request"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-token", WithBaseURL(server.URL))
+
+		var resp testResponse
+		err := client.Get(context.Background(), "/test", &resp)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		// Error should contain status code and possibly the error message
+		if errStr := err.Error(); errStr == "" {
+			t.Error("expected non-empty error message")
+		}
+	})
+
+	t.Run("adds user agent header", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedUA string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedUA = r.Header.Get("User-Agent")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(testResponse{Message: "success"})
+		}))
+		defer server.Close()
+
+		expectedUA := "test-user-agent"
+		client := NewClient("test-token", WithBaseURL(server.URL), WithUserAgent(expectedUA))
+
+		var resp testResponse
+		err := client.Get(context.Background(), "/test", &resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if receivedUA != expectedUA {
+			t.Errorf("expected User-Agent header %q, got %q", expectedUA, receivedUA)
+		}
+	})
+
+	t.Run("handles POST request with body", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			receivedBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed to read request body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(testResponse{Message: "success"})
+		}))
+		defer server.Close()
+
+		client := NewClient("test-token", WithBaseURL(server.URL))
+
+		requestBody := map[string]string{"test": "data"}
+		var resp testResponse
+		err := client.Post(context.Background(), "/test", requestBody, &resp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check that the body was correctly serialized
+		var parsed map[string]string
+		if err := json.Unmarshal(receivedBody, &parsed); err != nil {
+			t.Fatalf("failed to parse received body: %v", err)
+		}
+		if parsed["test"] != "data" {
+			t.Errorf("expected body to contain %q, got %q", "data", parsed["test"])
+		}
+	})
+}
+
+func TestErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("formats status code errors", func(t *testing.T) {
+		t.Parallel()
+
+		err := &ErrorResponse{
+			StatusCode: 404,
+			Status:     "Not Found",
+			URL:        "https://example.com/resource",
+		}
+
+		expected := "HTTP request failed: 404 Not Found (https://example.com/resource)"
+		if err.Error() != expected {
+			t.Errorf("expected error message %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("includes body in error", func(t *testing.T) {
+		t.Parallel()
+
+		err := &ErrorResponse{
+			StatusCode: 400,
+			Status:     "Bad Request",
+			URL:        "https://example.com/resource",
+			Body:       []byte(`{"error":"Invalid input"}`),
+		}
+
+		expected := "HTTP request failed: 400 Bad Request (https://example.com/resource): {\"error\":\"Invalid input\"}"
+		if err.Error() != expected {
+			t.Errorf("expected error message %q, got %q", expected, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR introduces a new `internal/http` package that provides a common HTTP client for making API requests. The implementation standardizes the way we set up authorization headers, handle errors, and process responses across the codebase.

## Motivation

Previously, HTTP request setup with authorization appeared in multiple places:
1. In `pkg/cmd/api/api.go` (apiCaller function)
2. In `internal/config/token.go` (fetchTokenInfo method)

Both set up similar HTTP clients, handle authorization, and process responses, but with slightly different approaches. This led to code duplication and potential inconsistencies in error handling. By extracting this common logic into a single package, we can reduce duplication and ensure consistent behavior across the codebase.

## Changes

- Created new `internal/http` package with:
  - A client that handles common API operations (GET, POST, PUT, DELETE)
  - Standardized authorization header handling
  - Consistent error handling with detailed error messages
  - Support for configurable base URL and user agent
  - Comprehensive test suite
- Refactored `pkg/cmd/api/api.go` to use the new HTTP client
- Refactored `internal/config/token.go` to use the new HTTP client
- Added documentation for the new package

## Testing

The changes are covered by new unit tests in the `internal/http` package.
