### PR TITLE
Add a pipeline validation command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/charmbracelet/huh/spinner v0.0.0-20240608175402-5b41f0b45136
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20231215171016-7ba2b450712d
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/muesli/reflow v0.3.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/vektah/gqlparser/v2 v2.5.22
+	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -43,6 +45,8 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/vektah/gqlparser v1.3.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
@@ -248,6 +250,12 @@ github.com/vektah/gqlparser/v2 v2.5.22 h1:yaaeJ0fu+nv1vUMW0Hl+aS1eiv1vMfapBNjpff
 github.com/vektah/gqlparser/v2 v2.5.22/go.mod h1:xMl+ta8a5M1Yo1A1Iwt/k7gSpscwSnHZdw7tfhEGfTM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark v1.7.4 h1:BDXOHExt+A7gwPCJgPIIq7ENvceR7we7rOS9TNoLZeg=

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -25,6 +25,6 @@ func NewCmdPipeline(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdPipelineCreate(f))
 	cmd.AddCommand(NewCmdPipelineView(f))
 	cmd.AddCommand(NewCmdPipelineValidate(f))
-	
+
 	return &cmd
 }

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -15,11 +15,16 @@ func NewCmdPipeline(f *factory.Factory) *cobra.Command {
 		Example: heredoc.Doc(`
 			# To create a new pipeline
 			$ bk pipeline create my-org/my-pipeline
+			
+			# To validate a pipeline configuration
+			$ bk pipeline validate
 		`),
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
 	}
 
 	cmd.AddCommand(NewCmdPipelineCreate(f))
 	cmd.AddCommand(NewCmdPipelineView(f))
+	cmd.AddCommand(NewCmdPipelineValidate(f))
+	
 	return &cmd
 }

--- a/pkg/cmd/pipeline/validate.go
+++ b/pkg/cmd/pipeline/validate.go
@@ -1,0 +1,192 @@
+package pipeline
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const (
+	schemaURL = "https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json"
+)
+
+func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
+	var filePaths []string
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "validate [flags]",
+		Short:                 "Validate a pipeline YAML file",
+		Args:                  cobra.NoArgs,
+		Long: heredoc.Doc(`
+			Validate a pipeline YAML file against the Buildkite pipeline schema.
+
+			By default, this command looks for a file at .buildkite/pipeline.yaml or .buildkite/pipeline.yml
+			in the current directory. You can specify different files using the --file flag.
+		`),
+		Example: heredoc.Doc(`
+			# Validate the default pipeline file
+			$ bk pipeline validate
+
+			# Validate a specific pipeline file
+			$ bk pipeline validate --file path/to/pipeline.yaml
+
+			# Validate multiple pipeline files
+			$ bk pipeline validate --file path/to/pipeline1.yaml --file path/to/pipeline2.yaml
+		`),
+		// Skip API token validation as pipeline validation is a local operation
+		// and doesn't require API access
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If no file paths provided, find the default
+			if len(filePaths) == 0 {
+				defaultPath, err := findPipelineFile()
+				if err != nil {
+					return err
+				}
+				filePaths = []string{defaultPath}
+			}
+
+			// Track if any validation failed
+			hasErrors := false
+
+			// Validate each file
+			for _, filePath := range filePaths {
+				err := validatePipeline(cmd.OutOrStdout(), filePath)
+				if err != nil {
+					hasErrors = true
+					// Continue validating other files even if one fails
+				}
+			}
+
+			if hasErrors {
+				return fmt.Errorf("pipeline validation failed")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringArrayVarP(&filePaths, "file", "f", []string{}, "Path to the pipeline YAML file(s) to validate")
+
+	return &cmd
+}
+
+// findPipelineFile attempts to locate a pipeline file in the default locations
+func findPipelineFile() (string, error) {
+	// Check for pipeline.yaml or pipeline.yml in .buildkite directory
+	paths := []string{
+		filepath.Join(".buildkite", "pipeline.yaml"),
+		filepath.Join(".buildkite", "pipeline.yml"),
+	}
+
+	for _, path := range paths {
+		if fileExists(path) {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find pipeline file in default locations (.buildkite/pipeline.yaml or .buildkite/pipeline.yml), please specify one with --file")
+}
+
+// fileExists checks if a file exists and is not a directory
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// validatePipeline validates the given pipeline file against the schema
+func validatePipeline(w io.Writer, filePath string) error {
+	// Read the pipeline file
+	pipelineData, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error reading pipeline file: %w", err)
+	}
+
+	// Convert YAML to JSON for validation
+	jsonData, err := yaml.YAMLToJSON(pipelineData)
+	if err != nil {
+		return fmt.Errorf("error converting YAML to JSON: %w", err)
+	}
+
+	// Load the schema and document
+	schemaLoader := gojsonschema.NewReferenceLoader(schemaURL)
+	documentLoader := gojsonschema.NewBytesLoader(jsonData)
+
+	// Validate against the schema
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("error validating pipeline: %w", err)
+	}
+
+	if result.Valid() {
+		fmt.Fprintf(w, "✅ Pipeline file is valid: %s\n", filePath)
+		return nil
+	}
+
+	// Return validation errors
+	fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+	for _, err := range result.Errors() {
+		// Format the error message for better readability
+		message := formatValidationError(err)
+		fmt.Fprintf(w, "- %s\n", message)
+	}
+
+	return fmt.Errorf("pipeline validation failed")
+}
+
+// formatValidationError formats a validation error for better readability
+func formatValidationError(err gojsonschema.ResultError) string {
+	// Clean up the context to make it more readable
+	context := err.Context().String()
+	field := err.Field()
+
+	// If the context is just the root, simplify it
+	if context == "(root)" {
+		context = ""
+	}
+
+	// For array items, make the error message more readable
+	if strings.Contains(field, "[") && strings.Contains(field, "]") {
+		parts := strings.Split(field, ".")
+		for i, part := range parts {
+			if strings.Contains(part, "[") {
+				index := strings.TrimRight(strings.TrimLeft(part, "["), "]")
+				name := strings.Split(part, "[")[0]
+				parts[i] = fmt.Sprintf("%s item #%s", name, index)
+			}
+		}
+		field = strings.Join(parts, " > ")
+	} else if field != "" {
+		field = strings.ReplaceAll(field, ".", " > ")
+	}
+
+	message := err.Description()
+	if field != "" {
+		message = fmt.Sprintf("%s: %s", field, message)
+	}
+
+	// Include details about what was received vs what was expected if available
+	details := err.Details()
+	if val, ok := details["field"]; ok && val != field {
+		message += fmt.Sprintf(" (field: %v)", val)
+	}
+	if val, ok := details["expected"]; ok {
+		message += fmt.Sprintf(" (expected: %v)", val)
+	}
+	if val, ok := details["actual"]; ok {
+		message += fmt.Sprintf(" (got: %v)", val)
+	}
+
+	return message
+}

--- a/pkg/cmd/pipeline/validate.go
+++ b/pkg/cmd/pipeline/validate.go
@@ -147,14 +147,7 @@ func validatePipeline(w io.Writer, filePath string) error {
 
 // formatValidationError formats a validation error for better readability
 func formatValidationError(err gojsonschema.ResultError) string {
-	// Clean up the context to make it more readable
-	context := err.Context().String()
 	field := err.Field()
-
-	// If the context is just the root, simplify it
-	if context == "(root)" {
-		context = ""
-	}
 
 	// For array items, make the error message more readable
 	if strings.Contains(field, "[") && strings.Contains(field, "]") {

--- a/pkg/cmd/pipeline/validate_test.go
+++ b/pkg/cmd/pipeline/validate_test.go
@@ -55,21 +55,21 @@ func TestValidatePipeline(t *testing.T) {
 			fileContent: `steps:
   - label: "Hello, world! 👋"
     command: echo "Hello, world!"`,
-			expectError: false,
+			expectError:  false,
 			expectOutput: "✅ Pipeline file is valid",
 		},
 		{
 			name: "valid pipeline with command only",
 			fileContent: `steps:
   - command: echo "Hello, world!"`,
-			expectError: false,
+			expectError:  false,
 			expectOutput: "✅ Pipeline file is valid",
 		},
 		{
 			name: "invalid pipeline missing command",
 			fileContent: `steps:
   - label: "Hello, world!"`,
-			expectError: true,
+			expectError:  true,
 			expectOutput: "❌ Pipeline file is invalid",
 		},
 		{
@@ -77,7 +77,7 @@ func TestValidatePipeline(t *testing.T) {
 			fileContent: `steps:
   - label: 123
     command: echo "Hello, world!"`,
-			expectError: true,
+			expectError:  true,
 			expectOutput: "❌ Pipeline file is invalid",
 		},
 	}
@@ -240,7 +240,7 @@ func TestFindPipelineFile(t *testing.T) {
 		// Mock fileExists to return true for both files
 		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
 			return path == filepath.Join(".buildkite", "pipeline.yaml") ||
-				   path == filepath.Join(".buildkite", "pipeline.yml")
+				path == filepath.Join(".buildkite", "pipeline.yml")
 		})
 
 		path, err := findPipelineFileFn()

--- a/pkg/cmd/pipeline/validate_test.go
+++ b/pkg/cmd/pipeline/validate_test.go
@@ -1,0 +1,338 @@
+package pipeline
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestValidatePipeline(t *testing.T) {
+	t.Parallel()
+
+	// Create a test schema that matches actual Buildkite schema requirements:
+	// This simplified schema ensures:
+	// - Steps are required
+	// - Each step must have at least a "command" field
+	// - A "label" field is optional and must be a string
+	// - A "command" field must be a string
+	schemaJSON := []byte(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"required": ["steps"],
+		"properties": {
+			"steps": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"label": { "type": "string" },
+						"command": { "type": "string" }
+					},
+					"required": ["command"]
+				}
+			}
+		}
+	}`)
+
+	// Create a schema loader for testing
+	testSchemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
+
+	tests := []struct {
+		name         string
+		fileContent  string
+		expectError  bool
+		expectOutput string
+	}{
+		{
+			name: "valid pipeline",
+			fileContent: `steps:
+  - label: "Hello, world! 👋"
+    command: echo "Hello, world!"`,
+			expectError: false,
+			expectOutput: "✅ Pipeline file is valid",
+		},
+		{
+			name: "valid pipeline with command only",
+			fileContent: `steps:
+  - command: echo "Hello, world!"`,
+			expectError: false,
+			expectOutput: "✅ Pipeline file is valid",
+		},
+		{
+			name: "invalid pipeline missing command",
+			fileContent: `steps:
+  - label: "Hello, world!"`,
+			expectError: true,
+			expectOutput: "❌ Pipeline file is invalid",
+		},
+		{
+			name: "invalid pipeline with wrong type",
+			fileContent: `steps:
+  - label: 123
+    command: echo "Hello, world!"`,
+			expectError: true,
+			expectOutput: "❌ Pipeline file is invalid",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a temporary file
+			tmpFile, err := os.CreateTemp("", "pipeline-*.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			// Write test content to the file
+			if _, err := tmpFile.Write([]byte(test.fileContent)); err != nil {
+				t.Fatal(err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Create a buffer to capture output
+			var stdout bytes.Buffer
+
+			// Define a test validation function that uses our test schema
+			mockValidatePipeline := func(w io.Writer, filePath string) error {
+				// Read the pipeline file
+				pipelineData, err := os.ReadFile(filePath)
+				if err != nil {
+					return fmt.Errorf("error reading pipeline file: %w", err)
+				}
+
+				// Convert YAML to JSON for validation
+				jsonData, err := yaml.YAMLToJSON(pipelineData)
+				if err != nil {
+					return fmt.Errorf("error converting YAML to JSON: %w", err)
+				}
+
+				// Validate using the test schema loader
+				documentLoader := gojsonschema.NewBytesLoader(jsonData)
+				result, err := gojsonschema.Validate(testSchemaLoader, documentLoader)
+				if err != nil {
+					return fmt.Errorf("error validating pipeline: %w", err)
+				}
+
+				if result.Valid() {
+					fmt.Fprintf(w, "✅ Pipeline file is valid: %s\n", filePath)
+					return nil
+				}
+
+				// Return validation errors
+				fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+				for _, err := range result.Errors() {
+					// Format the error message for better readability
+					message := formatValidationError(err)
+					fmt.Fprintf(w, "- %s\n", message)
+				}
+
+				return fmt.Errorf("pipeline validation failed")
+			}
+
+			// Call our mock validation function directly
+			err = mockValidatePipeline(&stdout, tmpFile.Name())
+
+			// Check error expectation
+			if test.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+			}
+
+			// Check output
+			if !strings.Contains(stdout.String(), test.expectOutput) {
+				t.Errorf("Expected output to contain %q, but got: %q", test.expectOutput, stdout.String())
+			}
+		})
+	}
+}
+
+// Mock implementation of findPipelineFile for testing
+func mockFindPipelineFile(fileExistsFn func(string) bool) func() (string, error) {
+	return func() (string, error) {
+		// Check for pipeline.yaml or pipeline.yml in .buildkite directory
+		paths := []string{
+			filepath.Join(".buildkite", "pipeline.yaml"),
+			filepath.Join(".buildkite", "pipeline.yml"),
+		}
+
+		for _, path := range paths {
+			if fileExistsFn(path) {
+				return path, nil
+			}
+		}
+
+		return "", fmt.Errorf("could not find pipeline file in default locations (.buildkite/pipeline.yaml or .buildkite/pipeline.yml), please specify one with --file")
+	}
+}
+
+func TestFindPipelineFile(t *testing.T) {
+	t.Parallel()
+
+	// Test finding no file
+	t.Run("no file exists", func(t *testing.T) {
+		// Mock fileExists to always return false
+		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
+			return false
+		})
+
+		_, err := findPipelineFileFn()
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	// Test finding pipeline.yml
+	t.Run("find pipeline.yml", func(t *testing.T) {
+		// Mock fileExists to return true only for pipeline.yml
+		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
+			return path == filepath.Join(".buildkite", "pipeline.yml")
+		})
+
+		path, err := findPipelineFileFn()
+		if err != nil {
+			t.Errorf("Expected no error but got: %v", err)
+		}
+
+		expected := filepath.Join(".buildkite", "pipeline.yml")
+		if path != expected {
+			t.Errorf("Expected %q but got %q", expected, path)
+		}
+	})
+
+	// Test finding pipeline.yaml
+	t.Run("find pipeline.yaml", func(t *testing.T) {
+		// Mock fileExists to return true only for pipeline.yaml
+		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
+			return path == filepath.Join(".buildkite", "pipeline.yaml")
+		})
+
+		path, err := findPipelineFileFn()
+		if err != nil {
+			t.Errorf("Expected no error but got: %v", err)
+		}
+
+		expected := filepath.Join(".buildkite", "pipeline.yaml")
+		if path != expected {
+			t.Errorf("Expected %q but got %q", expected, path)
+		}
+	})
+
+	// Test preference for pipeline.yaml over pipeline.yml
+	t.Run("prefer pipeline.yaml over pipeline.yml", func(t *testing.T) {
+		// Mock fileExists to return true for both files
+		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
+			return path == filepath.Join(".buildkite", "pipeline.yaml") ||
+				   path == filepath.Join(".buildkite", "pipeline.yml")
+		})
+
+		path, err := findPipelineFileFn()
+		if err != nil {
+			t.Errorf("Expected no error but got: %v", err)
+		}
+
+		// Should find pipeline.yaml since it's checked first
+		expected := filepath.Join(".buildkite", "pipeline.yaml")
+		if path != expected {
+			t.Errorf("Expected %q but got %q", expected, path)
+		}
+	})
+}
+
+// Test formatting validation errors
+func TestFormatValidationError(t *testing.T) {
+	t.Parallel()
+
+	// This is a simplified test since we can't directly create gojsonschema.ResultError objects
+	// Create a test schema that we can use to generate validation errors
+	schemaJSON := []byte(`{
+		"type": "object",
+		"properties": {
+			"steps": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"label": { "type": "string" },
+						"command": { "type": "string" }
+					}
+				}
+			}
+		}
+	}`)
+
+	// Invalid YAML that will cause validation errors
+	invalidYaml := `
+steps:
+  - label: "Test"
+    command: echo "Hello"
+  - label: "Test 2"
+    command: 123
+`
+
+	tmpFile, err := os.CreateTemp("", "invalid-pipeline-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write([]byte(invalidYaml)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+
+	// Load the pipeline file
+	pipelineData, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("error reading pipeline file: %v", err)
+	}
+
+	// Convert YAML to JSON for validation
+	jsonData, err := yaml.YAMLToJSON(pipelineData)
+	if err != nil {
+		t.Fatalf("error converting YAML to JSON: %v", err)
+	}
+
+	// Validate using our test schema
+	schemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
+	documentLoader := gojsonschema.NewBytesLoader(jsonData)
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		t.Fatalf("error validating pipeline: %v", err)
+	}
+
+	// Output the validation errors to the buffer
+	fmt.Fprintf(&buf, "❌ Pipeline file is invalid: %s\n\n", tmpFile.Name())
+	for _, err := range result.Errors() {
+		message := formatValidationError(err)
+		fmt.Fprintf(&buf, "- %s\n", message)
+	}
+
+	output := buf.String()
+
+	// Output should mention the error for the invalid field type
+	if !strings.Contains(output, "invalid") {
+		t.Errorf("Expected output to mention invalid field, got: %s", output)
+	}
+}

--- a/pkg/cmd/pipeline/validate_test.go
+++ b/pkg/cmd/pipeline/validate_test.go
@@ -188,6 +188,7 @@ func TestFindPipelineFile(t *testing.T) {
 
 	// Test finding no file
 	t.Run("no file exists", func(t *testing.T) {
+		t.Parallel()
 		// Mock fileExists to always return false
 		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
 			return false
@@ -201,6 +202,7 @@ func TestFindPipelineFile(t *testing.T) {
 
 	// Test finding pipeline.yml
 	t.Run("find pipeline.yml", func(t *testing.T) {
+		t.Parallel()
 		// Mock fileExists to return true only for pipeline.yml
 		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
 			return path == filepath.Join(".buildkite", "pipeline.yml")
@@ -219,6 +221,7 @@ func TestFindPipelineFile(t *testing.T) {
 
 	// Test finding pipeline.yaml
 	t.Run("find pipeline.yaml", func(t *testing.T) {
+		t.Parallel()
 		// Mock fileExists to return true only for pipeline.yaml
 		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
 			return path == filepath.Join(".buildkite", "pipeline.yaml")
@@ -237,6 +240,7 @@ func TestFindPipelineFile(t *testing.T) {
 
 	// Test preference for pipeline.yaml over pipeline.yml
 	t.Run("prefer pipeline.yaml over pipeline.yml", func(t *testing.T) {
+		t.Parallel()
 		// Mock fileExists to return true for both files
 		findPipelineFileFn := mockFindPipelineFile(func(path string) bool {
 			return path == filepath.Join(".buildkite", "pipeline.yaml") ||


### PR DESCRIPTION
# Add "bk pipeline validate" command

This PR adds a new `bk pipeline validate` command to the Buildkite CLI that allows users to validate their pipeline YAML files against the official Buildkite pipeline schema.

## Features

- Validate pipeline YAML files against the official Buildkite schema without needing to push to CI
- Support for validating multiple files at once via the `--file` flag
- Automatic detection of default pipeline files (`.buildkite/pipeline.yaml` or `.buildkite/pipeline.yml`)
- Clear, actionable error messages that pinpoint validation issues

## Usage Examples

```bash
# Validate the default pipeline file
$ bk pipeline validate

# Validate a specific file
$ bk pipeline validate --file path/to/pipeline.yaml

# Validate multiple files
$ bk pipeline validate --file pipeline1.yaml --file pipeline2.yaml
```
