### PR TITLE
🐛 Fix the API req for validate

### DIFF
--- a/pkg/cmd/pipeline/validate.go
+++ b/pkg/cmd/pipeline/validate.go
@@ -86,7 +86,7 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 			// Track validation errors
 			var validationErrors []string
 			fileCount := len(filePaths)
-			
+
 			fmt.Fprintf(cmd.OutOrStdout(), "Validating %d pipeline file(s)...\n\n", fileCount)
 
 			// Validate each file
@@ -103,7 +103,7 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "\n%d of %d file(s) failed validation.\n", errorCount, fileCount)
 				return fmt.Errorf("pipeline validation failed")
 			}
-			
+
 			fmt.Fprintf(cmd.OutOrStdout(), "\nAll pipeline files passed validation successfully!\n")
 			return nil
 		},
@@ -188,7 +188,7 @@ func validatePipeline(w io.Writer, filePath string) error {
 		// If online schema access fails, try the fallback schema
 		fmt.Fprintf(w, "⚠️  Warning: Could not access online pipeline schema: %s\n", err.Error())
 		fmt.Fprintf(w, "   Using simplified fallback schema for basic validation.\n\n")
-		
+
 		// Create a schema loader using the fallback schema
 		fallbackLoader := gojsonschema.NewBytesLoader(fallbackSchema)
 		result, err = gojsonschema.Validate(fallbackLoader, documentLoader)
@@ -235,7 +235,7 @@ func formatValidationError(err gojsonschema.ResultError) string {
 	}
 
 	message := err.Description()
-	
+
 	// Format the message with the field highlighted
 	if field != "" {
 		message = fmt.Sprintf("%s: %s", field, message)
@@ -243,7 +243,7 @@ func formatValidationError(err gojsonschema.ResultError) string {
 
 	// Include details about what was received vs what was expected if available
 	details := err.Details()
-	
+
 	// Add more context about expected values
 	var contextParts []string
 	if val, ok := details["field"]; ok && val != field {
@@ -255,12 +255,12 @@ func formatValidationError(err gojsonschema.ResultError) string {
 	if val, ok := details["actual"]; ok {
 		contextParts = append(contextParts, fmt.Sprintf("got: %v", val))
 	}
-	
+
 	// If we have context parts, add them to the message
 	if len(contextParts) > 0 {
 		message += fmt.Sprintf(" (%s)", strings.Join(contextParts, ", "))
 	}
-	
+
 	// Add a helpful hint based on the error type
 	switch err.Type() {
 	case "required":

--- a/pkg/cmd/pipeline/validate.go
+++ b/pkg/cmd/pipeline/validate.go
@@ -18,6 +18,34 @@ const (
 	schemaURL = "https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json"
 )
 
+// fallbackSchema is a simplified schema used when the online schema cannot be accessed
+// It implements the basic structure validation but doesn't include all checks
+var fallbackSchema = []byte(`{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"steps": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"label": { "type": "string" },
+					"command": { "type": "string" },
+					"plugins": { "type": "object" },
+					"agents": { "type": "object" },
+					"env": { "type": "object" },
+					"branches": { "type": ["string", "object"] },
+					"if": { "type": "string" },
+					"depends_on": { "type": ["string", "array"] }
+				}
+			}
+		},
+		"env": { "type": "object" },
+		"agents": { "type": "object" }
+	},
+	"required": ["steps"]
+}`)
+
 func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 	var filePaths []string
 
@@ -31,6 +59,8 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 
 			By default, this command looks for a file at .buildkite/pipeline.yaml or .buildkite/pipeline.yml
 			in the current directory. You can specify different files using the --file flag.
+
+			Note: This command does not require an API token since validation is done locally.
 		`),
 		Example: heredoc.Doc(`
 			# Validate the default pipeline file
@@ -42,8 +72,7 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 			# Validate multiple pipeline files
 			$ bk pipeline validate --file path/to/pipeline1.yaml --file path/to/pipeline2.yaml
 		`),
-		// Skip API token validation as pipeline validation is a local operation
-		// and doesn't require API access
+		// No PersistentPreRunE is set, so API token validation is skipped
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no file paths provided, find the default
 			if len(filePaths) == 0 {
@@ -54,22 +83,28 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 				filePaths = []string{defaultPath}
 			}
 
-			// Track if any validation failed
-			hasErrors := false
+			// Track validation errors
+			var validationErrors []string
+			fileCount := len(filePaths)
+			
+			fmt.Fprintf(cmd.OutOrStdout(), "Validating %d pipeline file(s)...\n\n", fileCount)
 
 			// Validate each file
 			for _, filePath := range filePaths {
 				err := validatePipeline(cmd.OutOrStdout(), filePath)
 				if err != nil {
-					hasErrors = true
+					validationErrors = append(validationErrors, fmt.Sprintf("%s: %v", filePath, err))
 					// Continue validating other files even if one fails
 				}
 			}
 
-			if hasErrors {
+			if len(validationErrors) > 0 {
+				errorCount := len(validationErrors)
+				fmt.Fprintf(cmd.OutOrStdout(), "\n%d of %d file(s) failed validation.\n", errorCount, fileCount)
 				return fmt.Errorf("pipeline validation failed")
 			}
-
+			
+			fmt.Fprintf(cmd.OutOrStdout(), "\nAll pipeline files passed validation successfully!\n")
 			return nil
 		},
 	}
@@ -81,19 +116,33 @@ func NewCmdPipelineValidate(f *factory.Factory) *cobra.Command {
 
 // findPipelineFile attempts to locate a pipeline file in the default locations
 func findPipelineFile() (string, error) {
-	// Check for pipeline.yaml or pipeline.yml in .buildkite directory
+	// Check for pipeline files in various standard locations
+	// The order matches the Buildkite agent's lookup order
 	paths := []string{
-		filepath.Join(".buildkite", "pipeline.yaml"),
+		"buildkite.yml",
+		"buildkite.yaml",
+		"buildkite.json",
 		filepath.Join(".buildkite", "pipeline.yml"),
+		filepath.Join(".buildkite", "pipeline.yaml"),
+		filepath.Join(".buildkite", "pipeline.json"),
+		filepath.Join("buildkite", "pipeline.yml"),
+		filepath.Join("buildkite", "pipeline.yaml"),
+		filepath.Join("buildkite", "pipeline.json"),
 	}
 
+	// Check each path
 	for _, path := range paths {
 		if fileExists(path) {
 			return path, nil
 		}
 	}
 
-	return "", fmt.Errorf("could not find pipeline file in default locations (.buildkite/pipeline.yaml or .buildkite/pipeline.yml), please specify one with --file")
+	// If no file found, provide detailed error message
+	return "", fmt.Errorf("could not find pipeline file in default locations. Please specify a file with --file or create one in a standard location:\n" +
+		"  • .buildkite/pipeline.yml\n" +
+		"  • .buildkite/pipeline.yaml\n" +
+		"  • buildkite.yml\n" +
+		"  • buildkite.yaml")
 }
 
 // fileExists checks if a file exists and is not a directory
@@ -113,20 +162,41 @@ func validatePipeline(w io.Writer, filePath string) error {
 		return fmt.Errorf("error reading pipeline file: %w", err)
 	}
 
+	// Trim whitespace to handle empty files more gracefully
+	if len(strings.TrimSpace(string(pipelineData))) == 0 {
+		fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+		fmt.Fprintf(w, "- File is empty\n")
+		return fmt.Errorf("empty pipeline file")
+	}
+
 	// Convert YAML to JSON for validation
 	jsonData, err := yaml.YAMLToJSON(pipelineData)
 	if err != nil {
-		return fmt.Errorf("error converting YAML to JSON: %w", err)
+		fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+		fmt.Fprintf(w, "- YAML parsing error: %s\n", err.Error())
+		fmt.Fprintf(w, "  Hint: Check for syntax errors like improper indentation, missing quotes, or invalid characters.\n")
+		return fmt.Errorf("invalid YAML format: %w", err)
 	}
 
 	// Load the schema and document
 	schemaLoader := gojsonschema.NewReferenceLoader(schemaURL)
 	documentLoader := gojsonschema.NewBytesLoader(jsonData)
 
-	// Validate against the schema
+	// Try to validate against the online schema
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		return fmt.Errorf("error validating pipeline: %w", err)
+		// If online schema access fails, try the fallback schema
+		fmt.Fprintf(w, "⚠️  Warning: Could not access online pipeline schema: %s\n", err.Error())
+		fmt.Fprintf(w, "   Using simplified fallback schema for basic validation.\n\n")
+		
+		// Create a schema loader using the fallback schema
+		fallbackLoader := gojsonschema.NewBytesLoader(fallbackSchema)
+		result, err = gojsonschema.Validate(fallbackLoader, documentLoader)
+		if err != nil {
+			fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+			fmt.Fprintf(w, "- Schema validation error: %s\n", err.Error())
+			return fmt.Errorf("schema validation error: %w", err)
+		}
 	}
 
 	if result.Valid() {
@@ -165,20 +235,44 @@ func formatValidationError(err gojsonschema.ResultError) string {
 	}
 
 	message := err.Description()
+	
+	// Format the message with the field highlighted
 	if field != "" {
 		message = fmt.Sprintf("%s: %s", field, message)
 	}
 
 	// Include details about what was received vs what was expected if available
 	details := err.Details()
+	
+	// Add more context about expected values
+	var contextParts []string
 	if val, ok := details["field"]; ok && val != field {
-		message += fmt.Sprintf(" (field: %v)", val)
+		contextParts = append(contextParts, fmt.Sprintf("field: %v", val))
 	}
 	if val, ok := details["expected"]; ok {
-		message += fmt.Sprintf(" (expected: %v)", val)
+		contextParts = append(contextParts, fmt.Sprintf("expected: %v", val))
 	}
 	if val, ok := details["actual"]; ok {
-		message += fmt.Sprintf(" (got: %v)", val)
+		contextParts = append(contextParts, fmt.Sprintf("got: %v", val))
+	}
+	
+	// If we have context parts, add them to the message
+	if len(contextParts) > 0 {
+		message += fmt.Sprintf(" (%s)", strings.Join(contextParts, ", "))
+	}
+	
+	// Add a helpful hint based on the error type
+	switch err.Type() {
+	case "required":
+		message += "\n    Hint: This field is required but was not found in your pipeline."
+	case "type_error":
+		message += "\n    Hint: Check that you're using the correct data type for this field."
+	case "enum":
+		message += "\n    Hint: The value must be one of the allowed options."
+	case "const":
+		message += "\n    Hint: This field must have the specific required value."
+	case "array_no_items":
+		message += "\n    Hint: This array cannot be empty."
 	}
 
 	return message

--- a/pkg/cmd/pipeline/validate_test.go
+++ b/pkg/cmd/pipeline/validate_test.go
@@ -200,7 +200,8 @@ func TestNewCmdPipelineValidate(t *testing.T) {
 	// Command should work without a factory
 	cmd := NewCmdPipelineValidate(nil)
 	if cmd == nil {
-		t.Error("Failed to create command without factory")
+		t.Fatal("Failed to create command without factory")
+		return
 	}
 
 	// Command should not have PersistentPreRunE set
@@ -212,7 +213,9 @@ func TestNewCmdPipelineValidate(t *testing.T) {
 	fileFlag := cmd.Flag("file")
 	if fileFlag == nil {
 		t.Error("Expected 'file' flag")
+		return
 	}
+
 	if fileFlag.Shorthand != "f" {
 		t.Errorf("Expected shorthand 'f', got %q", fileFlag.Shorthand)
 	}

--- a/pkg/cmd/pipeline/validate_test.go
+++ b/pkg/cmd/pipeline/validate_test.go
@@ -22,27 +22,26 @@ func TestValidatePipeline(t *testing.T) {
 	// - Each step must have at least a "command" field
 	// - A "label" field is optional and must be a string
 	// - A "command" field must be a string
-	schemaJSON := []byte(`{
-		"$schema": "http://json-schema.org/draft-07/schema#",
-		"type": "object",
-		"required": ["steps"],
-		"properties": {
-			"steps": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"label": { "type": "string" },
-						"command": { "type": "string" }
-					},
-					"required": ["command"]
-				}
-			}
-		}
-	}`)
+	testSchema := []byte(`{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["steps"],
+        "properties": {
+            "steps": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": { "type": "string" },
+                        "command": { "type": "string" }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }
+    }`)
 
-	// Create a schema loader for testing
-	testSchemaLoader := gojsonschema.NewBytesLoader(schemaJSON)
+	testSchemaLoader := gojsonschema.NewBytesLoader(testSchema)
 
 	tests := []struct {
 		name         string
@@ -80,6 +79,20 @@ func TestValidatePipeline(t *testing.T) {
 			expectError:  true,
 			expectOutput: "❌ Pipeline file is invalid",
 		},
+		{
+			name:         "empty file",
+			fileContent:  "",
+			expectError:  true,
+			expectOutput: "File is empty",
+		},
+		{
+			name: "invalid YAML syntax",
+			fileContent: `steps:
+  - label: "This has invalid syntax
+    command: echo "Missing closing quote and improper indentation`,
+			expectError:  true,
+			expectOutput: "YAML parsing error",
+		},
 	}
 
 	for _, test := range tests {
@@ -105,6 +118,12 @@ func TestValidatePipeline(t *testing.T) {
 			// Create a buffer to capture output
 			var stdout bytes.Buffer
 
+			// Test that no API token validation happens
+			validateCmd := NewCmdPipelineValidate(nil) // passing nil factory should work
+			if validateCmd.PersistentPreRunE != nil {
+				t.Error("Expected PersistentPreRunE to be nil (no validation)")
+			}
+
 			// Define a test validation function that uses our test schema
 			mockValidatePipeline := func(w io.Writer, filePath string) error {
 				// Read the pipeline file
@@ -113,10 +132,20 @@ func TestValidatePipeline(t *testing.T) {
 					return fmt.Errorf("error reading pipeline file: %w", err)
 				}
 
+				// Trim whitespace to handle empty files more gracefully
+				if len(strings.TrimSpace(string(pipelineData))) == 0 {
+					fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+					fmt.Fprintf(w, "- File is empty\n")
+					return fmt.Errorf("empty pipeline file")
+				}
+
 				// Convert YAML to JSON for validation
 				jsonData, err := yaml.YAMLToJSON(pipelineData)
 				if err != nil {
-					return fmt.Errorf("error converting YAML to JSON: %w", err)
+					fmt.Fprintf(w, "❌ Pipeline file is invalid: %s\n\n", filePath)
+					fmt.Fprintf(w, "- YAML parsing error: %s\n", err.Error())
+					fmt.Fprintf(w, "  Hint: Check for syntax errors like improper indentation, missing quotes, or invalid characters.\n")
+					return fmt.Errorf("invalid YAML format: %w", err)
 				}
 
 				// Validate using the test schema loader
@@ -161,6 +190,31 @@ func TestValidatePipeline(t *testing.T) {
 				t.Errorf("Expected output to contain %q, but got: %q", test.expectOutput, stdout.String())
 			}
 		})
+	}
+}
+
+// Test command creation without a factory
+func TestNewCmdPipelineValidate(t *testing.T) {
+	t.Parallel()
+
+	// Command should work without a factory
+	cmd := NewCmdPipelineValidate(nil)
+	if cmd == nil {
+		t.Error("Failed to create command without factory")
+	}
+
+	// Command should not have PersistentPreRunE set
+	if cmd.PersistentPreRunE != nil {
+		t.Error("Expected PersistentPreRunE to be nil")
+	}
+
+	// Check command flags
+	fileFlag := cmd.Flag("file")
+	if fileFlag == nil {
+		t.Error("Expected 'file' flag")
+	}
+	if fileFlag.Shorthand != "f" {
+		t.Errorf("Expected shorthand 'f', got %q", fileFlag.Shorthand)
 	}
 }
 

--- a/pkg/cmd/validation/config.go
+++ b/pkg/cmd/validation/config.go
@@ -2,10 +2,39 @@ package validation
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/spf13/cobra"
 )
+
+// CommandsNotRequiringToken is a list of command paths that don't require an API token
+var CommandsNotRequiringToken = []string{
+	"pipeline validate", // The pipeline validate command doesn't require an API token
+}
+
+// getCommandPath returns the full path of a command
+// e.g., "bk pipeline validate"
+func getCommandPath(cmd *cobra.Command) string {
+	var path []string
+	current := cmd
+
+	// Build path from the current command up to the root
+	for current != nil {
+		// Extract command name from the Use field (first word)
+		name := ""
+		if current.Use != "" {
+			name = strings.Fields(current.Use)[0]
+		}
+
+		if name != "" {
+			path = append([]string{name}, path...)
+		}
+		current = current.Parent()
+	}
+
+	return strings.Join(path, " ")
+}
 
 // CheckValidConfiguration returns a function that checks the viper configuration is valid to execute the command
 func CheckValidConfiguration(conf *config.Config) func(cmd *cobra.Command, args []string) error {
@@ -17,6 +46,16 @@ func CheckValidConfiguration(conf *config.Config) func(cmd *cobra.Command, args 
 	}
 
 	return func(cmd *cobra.Command, args []string) error {
+		// Skip token check for commands that don't need it
+		cmdPath := getCommandPath(cmd)
+
+		for _, exemptCmd := range CommandsNotRequiringToken {
+			// Check if the command path ends with the exempt command pattern
+			if strings.HasSuffix(cmdPath, exemptCmd) {
+				return nil // Skip validation for exempt commands
+			}
+		}
+
 		return err
 	}
 }

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -86,7 +86,6 @@ func TestCheckValidConfigurationExemptions(t *testing.T) {
 		// Check configuration for the pipeline validate command
 		validator := CheckValidConfiguration(conf)
 		err := validator(validateCmd, nil)
-
 		// Should not error even with empty config
 		if err != nil {
 			t.Errorf("Expected no error for exempted command, got: %v", err)
@@ -119,7 +118,6 @@ func TestCheckValidConfigurationExemptions(t *testing.T) {
 		// Check configuration for the pipeline validate command
 		validator := CheckValidConfiguration(conf)
 		err := validator(validateCmd, nil)
-
 		// Should not error - should recognize "pipeline validate" pattern
 		if err != nil {
 			t.Errorf("Expected no error for command with pattern matching 'pipeline validate', got: %v", err)

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -5,35 +5,145 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 )
 
-func TestCheckValidConfiguration(t *testing.T) {
+func TestGetCommandPath(t *testing.T) {
 	t.Parallel()
 
-	t.Run("API token is configured", func(t *testing.T) {
+	t.Run("returns correct path for simple commands", func(t *testing.T) {
 		t.Parallel()
 
-		conf := config.New(afero.NewMemMapFs(), nil)
-		_ = conf.SetTokenForOrg("testing", "testing")
-		_ = conf.SelectOrganization("testing")
+		// Create a command hierarchy
+		validateCmd := &cobra.Command{Use: "validate"}
+		pipelineCmd := &cobra.Command{Use: "pipeline"}
+		rootCmd := &cobra.Command{Use: "bk"}
 
-		f := CheckValidConfiguration(conf)
-		err := f(nil, nil)
-		if err != nil {
-			t.Error("expected no error returned", err)
+		// Set up command hierarchy properly using AddCommand
+		pipelineCmd.AddCommand(validateCmd)
+		rootCmd.AddCommand(pipelineCmd)
+
+		path := getCommandPath(validateCmd)
+		expected := "bk pipeline validate"
+
+		if path != expected {
+			t.Errorf("Expected path %q, got %q", expected, path)
 		}
 	})
 
-	t.Run("API token is not configured", func(t *testing.T) {
+	t.Run("handles Use field with arguments", func(t *testing.T) {
 		t.Parallel()
 
+		// Create a command with Use field containing arguments
+		cmd := &cobra.Command{Use: "validate [flags]"}
+		parentCmd := &cobra.Command{Use: "pipeline <command>"}
+		rootCmd := &cobra.Command{Use: "bk"}
+
+		// Set up command hierarchy properly using AddCommand
+		parentCmd.AddCommand(cmd)
+		rootCmd.AddCommand(parentCmd)
+
+		path := getCommandPath(cmd)
+		expected := "bk pipeline validate"
+
+		if path != expected {
+			t.Errorf("Expected path %q, got %q", expected, path)
+		}
+	})
+}
+
+func TestCheckValidConfigurationExemptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exempted commands skip validation", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a config with empty token (would normally fail)
 		conf := config.New(afero.NewMemMapFs(), nil)
 
-		f := CheckValidConfiguration(conf)
-		err := f(nil, nil)
+		// Create a validate command
+		validateCmd := &cobra.Command{
+			Use:   "validate",
+			Short: "validate command",
+		}
 
+		// Create a pipeline parent command
+		pipelineCmd := &cobra.Command{
+			Use:   "pipeline",
+			Short: "pipeline command",
+		}
+
+		// Root command
+		rootCmd := &cobra.Command{
+			Use:   "bk",
+			Short: "root command",
+		}
+
+		// Build command hierarchy properly
+		pipelineCmd.AddCommand(validateCmd)
+		rootCmd.AddCommand(pipelineCmd)
+
+		// Check configuration for the pipeline validate command
+		validator := CheckValidConfiguration(conf)
+		err := validator(validateCmd, nil)
+
+		// Should not error even with empty config
+		if err != nil {
+			t.Errorf("Expected no error for exempted command, got: %v", err)
+		}
+	})
+
+	t.Run("command name path is correctly built", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a config with empty token (would normally fail)
+		conf := config.New(afero.NewMemMapFs(), nil)
+
+		// Create a command structure with complex Use fields
+		validateCmd := &cobra.Command{
+			Use: "validate [flags]", // Contains extra content
+		}
+
+		pipelineCmd := &cobra.Command{
+			Use: "pipeline <command>", // Contains extra content
+		}
+
+		rootCmd := &cobra.Command{
+			Use: "bk [command]", // Contains extra content
+		}
+
+		// Build hierarchy properly
+		pipelineCmd.AddCommand(validateCmd)
+		rootCmd.AddCommand(pipelineCmd)
+
+		// Check configuration for the pipeline validate command
+		validator := CheckValidConfiguration(conf)
+		err := validator(validateCmd, nil)
+
+		// Should not error - should recognize "pipeline validate" pattern
+		if err != nil {
+			t.Errorf("Expected no error for command with pattern matching 'pipeline validate', got: %v", err)
+		}
+	})
+
+	t.Run("non-exempted commands require validation", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a config with empty token (should fail)
+		conf := config.New(afero.NewMemMapFs(), nil)
+
+		// Create a non-exempted command
+		otherCmd := &cobra.Command{
+			Use: "other",
+		}
+
+		// Check configuration for a non-exempt command
+		validator := CheckValidConfiguration(conf)
+		err := validator(otherCmd, nil)
+
+		// Should error with empty config
 		if err == nil {
-			t.Error("expected an error returned")
+			t.Error("Expected error for non-exempted command, got nil")
 		}
 	})
 }


### PR DESCRIPTION
# Fix validate command; don't require API token

The `validate` command was still inheriting the `pipeline.go` requirement for config check. This meant that API keys were still needed to validate a pipeline.

## Changes

This adjusts the way we validate in our `validate/config.go`; it allows us to pass commands which do not require API tokens

- `pkg/cmd/validation` checks on the path of a command via `getCommandPath`, if that path is in `CommandsNotRequiringToken` then we don't need an API token

## Improvements

This should enable us to set other commands that don't require API tokens
