### PR TITLE
SUP-1423 | Error standardisation

### DIFF
--- a/cmd/bk/main.go
+++ b/cmd/bk/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
+	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	"github.com/buildkite/cli/v3/internal/version"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/root"
@@ -17,22 +17,51 @@ func main() {
 
 func mainRun() int {
 	ctx := context.Background()
+
+	// Create factory
 	f, err := factory.New(version.Version)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create factory: %s\n", err)
-		return 1
+		errHandler := bkErrors.NewHandler()
+		errHandler.Handle(bkErrors.NewInternalError(
+			err,
+			"failed to initialize CLI",
+			"This is likely a bug in the CLI",
+			"Please report this issue to the Buildkite CLI team",
+		))
+		return bkErrors.ExitCodeInternalError
 	}
 
+	// Create root command
 	rootCmd, err := root.NewCmdRoot(f)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create root command: %s\n", err)
-		return 1
+		errHandler := bkErrors.NewHandler()
+		errHandler.Handle(bkErrors.NewInternalError(
+			err,
+			"failed to create command structure",
+			"This is likely a bug in the CLI",
+			"Please report this issue to the Buildkite CLI team",
+		))
+		return bkErrors.ExitCodeInternalError
 	}
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
-		// Errors already get printed by the cobra command runner
-		return 1
+	// Set context
+	rootCmd.SetContext(ctx)
+
+	// Get verbose flag value
+	verbose, _ := rootCmd.PersistentFlags().GetBool("verbose")
+
+	// Silence Cobra's error printing so we can handle it ourselves
+	rootCmd.SilenceErrors = true
+
+	// Execute the command
+	err = rootCmd.Execute()
+	if err != nil {
+		// Handle the error with our error handler
+		errHandler := bkErrors.NewHandler().WithVerbose(verbose)
+		errHandler.HandleWithDetails(err, rootCmd.CommandPath())
+		return bkErrors.GetExitCodeForError(err)
 	}
 
-	return 0
+	// If we get here, the command executed successfully
+	return bkErrors.ExitCodeSuccess
 }

--- a/internal/errors/README.md
+++ b/internal/errors/README.md
@@ -1,0 +1,112 @@
+# Error Handling Package
+
+This package provides standardized error handling for the Buildkite CLI. It handles different types of errors consistently, provides helpful error messages and suggestions to users, and ensures a unified approach to error reporting across the application.
+
+## Features
+
+- **Categorized Errors**: Different error types (validation, API, not found, etc.) with specific handling
+- **Contextual Error Messages**: Errors include context about what operation failed
+- **Helpful Suggestions**: Error messages include suggestions on how to fix the issue
+- **Command Integration**: Easy integration with Cobra commands
+- **API Error Handling**: Specialized handling for API errors with status code interpretation
+- **Exit Codes**: Appropriate exit codes for different error types
+
+## Usage
+
+### Creating Errors
+
+```go
+import (
+    bkErrors "github.com/buildkite/cli/v3/internal/errors"
+)
+
+// Create various types of errors
+validationErr := bkErrors.NewValidationError(
+    err, // Original error (can be nil)
+    "Invalid input", // Details about the error
+    "Try using a different value", // Suggestions (optional)
+    "Check the documentation for valid options" // More suggestions
+)
+
+apiErr := bkErrors.NewAPIError(err, "API request failed")
+
+notFoundErr := bkErrors.NewResourceNotFoundError(err, "Resource not found")
+```
+
+### Adding Context to Errors
+
+```go
+// Add suggestions to an existing error
+err = bkErrors.WithSuggestions(err, 
+    "Try this instead", 
+    "Or try this other option"
+)
+
+// Add details to an existing error
+err = bkErrors.WithDetails(err, "Additional context")
+```
+
+### Checking Error Types
+
+```go
+if bkErrors.IsNotFound(err) {
+    // Handle not found error
+}
+
+if bkErrors.IsValidationError(err) {
+    // Handle validation error
+}
+
+if bkErrors.IsAPIError(err) {
+    // Handle API error
+}
+```
+
+### Wrapping API Errors
+
+```go
+// Wrap HTTP errors with appropriate context
+err = bkErrors.WrapAPIError(err, "fetching pipeline")
+```
+
+### Command Integration
+
+```go
+// Wrap a command's RunE function with standard error handling
+cmd := &cobra.Command{
+    RunE: bkErrors.WrapRunE(func(cmd *cobra.Command, args []string) error {
+        // Command implementation
+        return err
+    }),
+}
+```
+
+### Using the Error Handler
+
+```go
+// Create an error handler
+handler := bkErrors.NewHandler().
+    WithVerbose(verbose).
+    WithWriter(os.Stderr)
+
+// Handle an error
+handler.Handle(err)
+
+// Handle an error with operation context
+handler.HandleWithDetails(err, "creating resource")
+
+// Print a warning
+handler.PrintWarning("Something might be wrong: %s", details)
+```
+
+### Using the Command Error Handler
+
+```go
+// In main.go:
+func main() {
+    rootCmd, _ := root.NewCmdRoot(f)
+    
+    // Execute with error handling
+    bkErrors.ExecuteWithErrorHandling(rootCmd, verbose)
+}
+```

--- a/internal/errors/api.go
+++ b/internal/errors/api.go
@@ -43,7 +43,7 @@ func WrapAPIError(err error, operation string) error {
 func handleHTTPError(httpErr *httpClient.ErrorResponse, operation string) error {
 	statusCode := httpErr.StatusCode
 	details := fmt.Sprintf("%s failed with status %d", operation, statusCode)
-	
+
 	// Try to parse the response body as JSON
 	var apiErr APIErrorResponse
 	if len(httpErr.Body) > 0 {
@@ -70,7 +70,7 @@ func handleHTTPError(httpErr *httpClient.ErrorResponse, operation string) error 
 	case statusCode == http.StatusNotFound:
 		err = NewResourceNotFoundError(httpErr, details, suggestForNotFound(httpErr.URL)...)
 	case statusCode == http.StatusUnauthorized:
-		err = NewAuthenticationError(httpErr, details, 
+		err = NewAuthenticationError(httpErr, details,
 			"Check your API token in the configuration",
 			"Run 'bk configure' to set up your token correctly")
 	case statusCode == http.StatusForbidden:
@@ -93,7 +93,7 @@ func handleHTTPError(httpErr *httpClient.ErrorResponse, operation string) error 
 // handleBadRequestError processes a 400 Bad Request error
 func handleBadRequestError(httpErr *httpClient.ErrorResponse, details string, apiErr APIErrorResponse) error {
 	suggestions := []string{}
-	
+
 	// Add specific errors as suggestions
 	if len(apiErr.Errors) > 0 {
 		for _, errMsg := range apiErr.Errors {

--- a/internal/errors/api.go
+++ b/internal/errors/api.go
@@ -96,9 +96,7 @@ func handleBadRequestError(httpErr *httpClient.ErrorResponse, details string, ap
 
 	// Add specific errors as suggestions
 	if len(apiErr.Errors) > 0 {
-		for _, errMsg := range apiErr.Errors {
-			suggestions = append(suggestions, errMsg)
-		}
+		suggestions = append(suggestions, apiErr.Errors...)
 	} else {
 		suggestions = append(suggestions, "Check the request parameters for invalid values")
 	}

--- a/internal/errors/api.go
+++ b/internal/errors/api.go
@@ -1,0 +1,134 @@
+package errors
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	httpClient "github.com/buildkite/cli/v3/internal/http"
+)
+
+// APIErrorResponse represents a Buildkite API error response
+type APIErrorResponse struct {
+	Message string            `json:"message"`
+	Errors  []string          `json:"errors,omitempty"`
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// WrapAPIError wraps an API error with appropriate context and suggestions
+func WrapAPIError(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+
+	// If it's already a CLI error, add context but preserve the category
+	if cliErr, ok := err.(*Error); ok {
+		if operation != "" {
+			cliErr.Details = fmt.Sprintf("%s: %s", operation, cliErr.Details)
+		}
+		return cliErr
+	}
+
+	// Handle HTTP client errors
+	if httpErr, ok := err.(*httpClient.ErrorResponse); ok {
+		return handleHTTPError(httpErr, operation)
+	}
+
+	// For all other errors, wrap as a generic API error
+	return NewAPIError(err, fmt.Sprintf("API request failed during: %s", operation))
+}
+
+// handleHTTPError processes an HTTP error and creates an appropriate CLI error
+func handleHTTPError(httpErr *httpClient.ErrorResponse, operation string) error {
+	statusCode := httpErr.StatusCode
+	details := fmt.Sprintf("%s failed with status %d", operation, statusCode)
+	
+	// Try to parse the response body as JSON
+	var apiErr APIErrorResponse
+	if len(httpErr.Body) > 0 {
+		if err := json.Unmarshal(httpErr.Body, &apiErr); err == nil {
+			// Successfully parsed API error
+			if apiErr.Message != "" {
+				details = fmt.Sprintf("%s: %s", details, apiErr.Message)
+			}
+		} else {
+			// If not JSON, include the raw body
+			if len(httpErr.Body) > 0 {
+				bodyStr := string(httpErr.Body)
+				if len(bodyStr) > 200 {
+					bodyStr = bodyStr[:200] + "..."
+				}
+				details = fmt.Sprintf("%s: %s", details, bodyStr)
+			}
+		}
+	}
+
+	// Create appropriate error based on status code
+	var err error
+	switch {
+	case statusCode == http.StatusNotFound:
+		err = NewResourceNotFoundError(httpErr, details, suggestForNotFound(httpErr.URL)...)
+	case statusCode == http.StatusUnauthorized:
+		err = NewAuthenticationError(httpErr, details, 
+			"Check your API token in the configuration",
+			"Run 'bk configure' to set up your token correctly")
+	case statusCode == http.StatusForbidden:
+		err = NewPermissionDeniedError(httpErr, details,
+			"Verify that your API token has the required scopes",
+			"You may need to create a new token with additional permissions")
+	case statusCode == http.StatusBadRequest:
+		err = handleBadRequestError(httpErr, details, apiErr)
+	case statusCode >= 500:
+		err = NewAPIError(httpErr, details,
+			"This appears to be a server-side error",
+			"Try again later or check the Buildkite status page")
+	default:
+		err = NewAPIError(httpErr, details)
+	}
+
+	return err
+}
+
+// handleBadRequestError processes a 400 Bad Request error
+func handleBadRequestError(httpErr *httpClient.ErrorResponse, details string, apiErr APIErrorResponse) error {
+	suggestions := []string{}
+	
+	// Add specific errors as suggestions
+	if len(apiErr.Errors) > 0 {
+		for _, errMsg := range apiErr.Errors {
+			suggestions = append(suggestions, errMsg)
+		}
+	} else {
+		suggestions = append(suggestions, "Check the request parameters for invalid values")
+	}
+
+	// Add field-specific errors
+	if len(apiErr.Details) > 0 {
+		for field, msg := range apiErr.Details {
+			suggestions = append(suggestions, fmt.Sprintf("%s: %s", field, msg))
+		}
+	}
+
+	return NewValidationError(httpErr, details, suggestions...)
+}
+
+// suggestForNotFound generates suggestions for a 404 Not Found error
+func suggestForNotFound(url string) []string {
+	suggestions := []string{
+		"Check that the resource exists and you have access to it",
+	}
+
+	// Add more specific suggestions based on the URL pattern
+	if strings.Contains(url, "/pipelines/") {
+		suggestions = append(suggestions, "Verify the pipeline slug is correct")
+	} else if strings.Contains(url, "/builds/") {
+		suggestions = append(suggestions, "Verify the build number is correct")
+	} else if strings.Contains(url, "/artifacts/") {
+		suggestions = append(suggestions, "Verify the artifact ID is correct")
+	} else if strings.Contains(url, "/agents/") {
+		suggestions = append(suggestions, "Verify the agent ID is correct")
+	}
+
+	return suggestions
+}

--- a/internal/errors/api_test.go
+++ b/internal/errors/api_test.go
@@ -1,0 +1,232 @@
+package errors
+
+import (
+	"encoding/json"
+	"testing"
+
+	httpClient "github.com/buildkite/cli/v3/internal/http"
+)
+
+func TestWrapAPIError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("handles nil error", func(t *testing.T) {
+		t.Parallel()
+		result := WrapAPIError(nil, "test operation")
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("preserves CLI error category", func(t *testing.T) {
+		t.Parallel()
+		original := NewValidationError(nil, "Invalid input")
+		result := WrapAPIError(original, "test operation")
+		
+		if !IsValidationError(result) {
+			t.Error("Expected validation error category to be preserved")
+		}
+	})
+
+	t.Run("adds operation context to CLI error", func(t *testing.T) {
+		t.Parallel()
+		original := NewValidationError(nil, "Invalid input")
+		result := WrapAPIError(original, "test operation")
+		
+		cliErr, ok := result.(*Error)
+		if !ok {
+			t.Fatal("Expected result to be a *Error")
+		}
+		
+		if cliErr.Details != "test operation: Invalid input" {
+			t.Errorf("Expected details to include operation, got: %q", cliErr.Details)
+		}
+	})
+
+	t.Run("wraps generic error as API error", func(t *testing.T) {
+		t.Parallel()
+		original := &simpleError{message: "something went wrong"}
+		result := WrapAPIError(original, "test operation")
+		
+		if !IsAPIError(result) {
+			t.Error("Expected generic error to be wrapped as API error")
+		}
+	})
+}
+
+func TestHandleHTTPError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("handles 404 not found", func(t *testing.T) {
+		t.Parallel()
+		httpErr := &httpClient.ErrorResponse{
+			StatusCode: 404,
+			Status:     "Not Found",
+			URL:        "https://api.buildkite.com/v2/pipelines/missing",
+			Body:       []byte(`{"message":"Pipeline not found"}`),
+		}
+		
+		result := handleHTTPError(httpErr, "get pipeline")
+		
+		if !IsNotFound(result) {
+			t.Error("Expected result to be a not found error")
+		}
+		
+		// Check for pipeline-specific suggestion
+		cliErr, ok := result.(*Error)
+		if !ok {
+			t.Fatal("Expected result to be a *Error")
+		}
+		
+		foundSuggestion := false
+		for _, suggestion := range cliErr.Suggestions {
+			if suggestion == "Verify the pipeline slug is correct" {
+				foundSuggestion = true
+				break
+			}
+		}
+		
+		if !foundSuggestion {
+			t.Error("Expected pipeline-specific suggestion for not found error")
+		}
+	})
+
+	t.Run("handles 401 unauthorized", func(t *testing.T) {
+		t.Parallel()
+		httpErr := &httpClient.ErrorResponse{
+			StatusCode: 401,
+			Status:     "Unauthorized",
+			URL:        "https://api.buildkite.com/v2/user",
+			Body:       []byte(`{"message":"Unauthorized"}`),
+		}
+		
+		result := handleHTTPError(httpErr, "get user")
+		
+		if !IsAuthenticationError(result) {
+			t.Error("Expected result to be an authentication error")
+		}
+		
+		// Check for token suggestion
+		cliErr, ok := result.(*Error)
+		if !ok {
+			t.Fatal("Expected result to be a *Error")
+		}
+		
+		foundSuggestion := false
+		for _, suggestion := range cliErr.Suggestions {
+			if suggestion == "Check your API token in the configuration" {
+				foundSuggestion = true
+				break
+			}
+		}
+		
+		if !foundSuggestion {
+			t.Error("Expected token-specific suggestion for unauthorized error")
+		}
+	})
+
+	t.Run("handles 403 forbidden", func(t *testing.T) {
+		t.Parallel()
+		httpErr := &httpClient.ErrorResponse{
+			StatusCode: 403,
+			Status:     "Forbidden",
+			URL:        "https://api.buildkite.com/v2/builds",
+			Body:       []byte(`{"message":"Forbidden"}`),
+		}
+		
+		result := handleHTTPError(httpErr, "cancel build")
+		
+		if !IsPermissionDeniedError(result) {
+			t.Error("Expected result to be a permission denied error")
+		}
+	})
+
+	t.Run("handles 400 bad request with field errors", func(t *testing.T) {
+		t.Parallel()
+		apiErr := APIErrorResponse{
+			Message: "Invalid request",
+			Details: map[string]string{
+				"name": "cannot be blank",
+				"url":  "invalid format",
+			},
+		}
+		
+		body, _ := json.Marshal(apiErr)
+		httpErr := &httpClient.ErrorResponse{
+			StatusCode: 400,
+			Status:     "Bad Request",
+			URL:        "https://api.buildkite.com/v2/pipelines",
+			Body:       body,
+		}
+		
+		result := handleHTTPError(httpErr, "create pipeline")
+		
+		if !IsValidationError(result) {
+			t.Error("Expected result to be a validation error")
+		}
+		
+		// Check that field errors are included in suggestions
+		cliErr, ok := result.(*Error)
+		if !ok {
+			t.Fatal("Expected result to be a *Error")
+		}
+		
+		foundNameError := false
+		foundURLError := false
+		for _, suggestion := range cliErr.Suggestions {
+			if suggestion == "name: cannot be blank" {
+				foundNameError = true
+			}
+			if suggestion == "url: invalid format" {
+				foundURLError = true
+			}
+		}
+		
+		if !foundNameError || !foundURLError {
+			t.Error("Expected field-specific errors to be included in suggestions")
+		}
+	})
+
+	t.Run("handles 500 server error", func(t *testing.T) {
+		t.Parallel()
+		httpErr := &httpClient.ErrorResponse{
+			StatusCode: 500,
+			Status:     "Internal Server Error",
+			URL:        "https://api.buildkite.com/v2/builds",
+			Body:       []byte(`{"message":"Internal server error"}`),
+		}
+		
+		result := handleHTTPError(httpErr, "list builds")
+		
+		if !IsAPIError(result) {
+			t.Error("Expected result to be an API error")
+		}
+		
+		// Check for server error suggestion
+		cliErr, ok := result.(*Error)
+		if !ok {
+			t.Fatal("Expected result to be a *Error")
+		}
+		
+		foundSuggestion := false
+		for _, suggestion := range cliErr.Suggestions {
+			if suggestion == "This appears to be a server-side error" {
+				foundSuggestion = true
+				break
+			}
+		}
+		
+		if !foundSuggestion {
+			t.Error("Expected server error suggestion")
+		}
+	})
+}
+
+// simpleError is a simple implementation of the error interface for testing
+type simpleError struct {
+	message string
+}
+
+func (e *simpleError) Error() string {
+	return e.message
+}

--- a/internal/errors/api_test.go
+++ b/internal/errors/api_test.go
@@ -22,7 +22,7 @@ func TestWrapAPIError(t *testing.T) {
 		t.Parallel()
 		original := NewValidationError(nil, "Invalid input")
 		result := WrapAPIError(original, "test operation")
-		
+
 		if !IsValidationError(result) {
 			t.Error("Expected validation error category to be preserved")
 		}
@@ -32,12 +32,12 @@ func TestWrapAPIError(t *testing.T) {
 		t.Parallel()
 		original := NewValidationError(nil, "Invalid input")
 		result := WrapAPIError(original, "test operation")
-		
+
 		cliErr, ok := result.(*Error)
 		if !ok {
 			t.Fatal("Expected result to be a *Error")
 		}
-		
+
 		if cliErr.Details != "test operation: Invalid input" {
 			t.Errorf("Expected details to include operation, got: %q", cliErr.Details)
 		}
@@ -47,7 +47,7 @@ func TestWrapAPIError(t *testing.T) {
 		t.Parallel()
 		original := &simpleError{message: "something went wrong"}
 		result := WrapAPIError(original, "test operation")
-		
+
 		if !IsAPIError(result) {
 			t.Error("Expected generic error to be wrapped as API error")
 		}
@@ -65,19 +65,19 @@ func TestHandleHTTPError(t *testing.T) {
 			URL:        "https://api.buildkite.com/v2/pipelines/missing",
 			Body:       []byte(`{"message":"Pipeline not found"}`),
 		}
-		
+
 		result := handleHTTPError(httpErr, "get pipeline")
-		
+
 		if !IsNotFound(result) {
 			t.Error("Expected result to be a not found error")
 		}
-		
+
 		// Check for pipeline-specific suggestion
 		cliErr, ok := result.(*Error)
 		if !ok {
 			t.Fatal("Expected result to be a *Error")
 		}
-		
+
 		foundSuggestion := false
 		for _, suggestion := range cliErr.Suggestions {
 			if suggestion == "Verify the pipeline slug is correct" {
@@ -85,7 +85,7 @@ func TestHandleHTTPError(t *testing.T) {
 				break
 			}
 		}
-		
+
 		if !foundSuggestion {
 			t.Error("Expected pipeline-specific suggestion for not found error")
 		}
@@ -99,19 +99,19 @@ func TestHandleHTTPError(t *testing.T) {
 			URL:        "https://api.buildkite.com/v2/user",
 			Body:       []byte(`{"message":"Unauthorized"}`),
 		}
-		
+
 		result := handleHTTPError(httpErr, "get user")
-		
+
 		if !IsAuthenticationError(result) {
 			t.Error("Expected result to be an authentication error")
 		}
-		
+
 		// Check for token suggestion
 		cliErr, ok := result.(*Error)
 		if !ok {
 			t.Fatal("Expected result to be a *Error")
 		}
-		
+
 		foundSuggestion := false
 		for _, suggestion := range cliErr.Suggestions {
 			if suggestion == "Check your API token in the configuration" {
@@ -119,7 +119,7 @@ func TestHandleHTTPError(t *testing.T) {
 				break
 			}
 		}
-		
+
 		if !foundSuggestion {
 			t.Error("Expected token-specific suggestion for unauthorized error")
 		}
@@ -133,9 +133,9 @@ func TestHandleHTTPError(t *testing.T) {
 			URL:        "https://api.buildkite.com/v2/builds",
 			Body:       []byte(`{"message":"Forbidden"}`),
 		}
-		
+
 		result := handleHTTPError(httpErr, "cancel build")
-		
+
 		if !IsPermissionDeniedError(result) {
 			t.Error("Expected result to be a permission denied error")
 		}
@@ -150,7 +150,7 @@ func TestHandleHTTPError(t *testing.T) {
 				"url":  "invalid format",
 			},
 		}
-		
+
 		body, _ := json.Marshal(apiErr)
 		httpErr := &httpClient.ErrorResponse{
 			StatusCode: 400,
@@ -158,19 +158,19 @@ func TestHandleHTTPError(t *testing.T) {
 			URL:        "https://api.buildkite.com/v2/pipelines",
 			Body:       body,
 		}
-		
+
 		result := handleHTTPError(httpErr, "create pipeline")
-		
+
 		if !IsValidationError(result) {
 			t.Error("Expected result to be a validation error")
 		}
-		
+
 		// Check that field errors are included in suggestions
 		cliErr, ok := result.(*Error)
 		if !ok {
 			t.Fatal("Expected result to be a *Error")
 		}
-		
+
 		foundNameError := false
 		foundURLError := false
 		for _, suggestion := range cliErr.Suggestions {
@@ -181,7 +181,7 @@ func TestHandleHTTPError(t *testing.T) {
 				foundURLError = true
 			}
 		}
-		
+
 		if !foundNameError || !foundURLError {
 			t.Error("Expected field-specific errors to be included in suggestions")
 		}
@@ -195,19 +195,19 @@ func TestHandleHTTPError(t *testing.T) {
 			URL:        "https://api.buildkite.com/v2/builds",
 			Body:       []byte(`{"message":"Internal server error"}`),
 		}
-		
+
 		result := handleHTTPError(httpErr, "list builds")
-		
+
 		if !IsAPIError(result) {
 			t.Error("Expected result to be an API error")
 		}
-		
+
 		// Check for server error suggestion
 		cliErr, ok := result.(*Error)
 		if !ok {
 			t.Fatal("Expected result to be a *Error")
 		}
-		
+
 		foundSuggestion := false
 		for _, suggestion := range cliErr.Suggestions {
 			if suggestion == "This appears to be a server-side error" {
@@ -215,7 +215,7 @@ func TestHandleHTTPError(t *testing.T) {
 				break
 			}
 		}
-		
+
 		if !foundSuggestion {
 			t.Error("Expected server error suggestion")
 		}

--- a/internal/errors/command.go
+++ b/internal/errors/command.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandErrorHandler provides error handling functionality for cobra commands
+type CommandErrorHandler struct {
+	handler *Handler
+}
+
+// NewCommandErrorHandler creates a new CommandErrorHandler
+func NewCommandErrorHandler() *CommandErrorHandler {
+	return &CommandErrorHandler{
+		handler: NewHandler(),
+	}
+}
+
+// WithVerbose sets the verbose flag
+func (c *CommandErrorHandler) WithVerbose(verbose bool) *CommandErrorHandler {
+	c.handler.WithVerbose(verbose)
+	return c
+}
+
+// HandleCommandError handles an error from a command
+func (c *CommandErrorHandler) HandleCommandError(cmd *cobra.Command, err error) {
+	if err == nil {
+		return
+	}
+
+	// Override writer to use command's error output
+	c.handler.WithWriter(cmd.ErrOrStderr())
+
+	// Get the command path for context
+	cmdPath := getCommandPath(cmd)
+
+	// Handle the error with command path as context
+	c.handler.HandleWithDetails(err, cmdPath)
+}
+
+// getCommandPath returns the full path of a command (e.g., "bk pipeline view")
+func getCommandPath(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+
+	names := []string{cmd.Name()}
+	parent := cmd.Parent()
+
+	for parent != nil {
+		names = append([]string{parent.Name()}, names...)
+		parent = parent.Parent()
+	}
+
+	return strings.Join(names, " ")
+}
+
+// ExecuteWithErrorHandling runs a cobra command with standardized error handling
+func ExecuteWithErrorHandling(cmd *cobra.Command, verbose bool) {
+	// Create an error handler
+	errorHandler := NewCommandErrorHandler().WithVerbose(verbose)
+
+	// Set the PersistentPostRun to handle errors
+	originalPersistentPostRun := cmd.PersistentPostRunE
+	cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+		if originalPersistentPostRun != nil {
+			return originalPersistentPostRun(cmd, args)
+		}
+		return nil
+	}
+
+	// Execute the command
+	err := cmd.Execute()
+	if err != nil {
+		errorHandler.HandleCommandError(cmd, err)
+		os.Exit(GetExitCodeForError(err))
+	}
+}
+
+// WrapRunE wraps a RunE function with standard error handling
+func WrapRunE(fn func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// Call the original function
+		err := fn(cmd, args)
+		if err != nil {
+			// For not found errors, add a suggestion to use --help
+			if IsNotFound(err) {
+				err = WithSuggestions(err, fmt.Sprintf("Try '%s --help' for more information", cmd.CommandPath()))
+			}
+
+			// For validation errors, add context about the command
+			if IsValidationError(err) {
+				err = WithDetails(err, fmt.Sprintf("When executing %s", cmd.CommandPath()))
+			}
+		}
+		return err
+	}
+}

--- a/internal/errors/command.go
+++ b/internal/errors/command.go
@@ -2,7 +2,6 @@ package errors
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -60,25 +59,22 @@ func getCommandPath(cmd *cobra.Command) string {
 }
 
 // ExecuteWithErrorHandling runs a cobra command with standardized error handling
-func ExecuteWithErrorHandling(cmd *cobra.Command, verbose bool) {
+func ExecuteWithErrorHandling(cmd *cobra.Command, verbose bool) int {
+	// Silence Cobra's error printing
+	cmd.SilenceErrors = true
+
 	// Create an error handler
 	errorHandler := NewCommandErrorHandler().WithVerbose(verbose)
-
-	// Set the PersistentPostRun to handle errors
-	originalPersistentPostRun := cmd.PersistentPostRunE
-	cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
-		if originalPersistentPostRun != nil {
-			return originalPersistentPostRun(cmd, args)
-		}
-		return nil
-	}
 
 	// Execute the command
 	err := cmd.Execute()
 	if err != nil {
+		// Handle the error
 		errorHandler.HandleCommandError(cmd, err)
-		os.Exit(GetExitCodeForError(err))
+		return GetExitCodeForError(err)
 	}
+
+	return ExitCodeSuccess
 }
 
 // WrapRunE wraps a RunE function with standard error handling

--- a/internal/errors/command.go
+++ b/internal/errors/command.go
@@ -47,6 +47,12 @@ func getCommandPath(cmd *cobra.Command) string {
 		return ""
 	}
 
+	// Use the command's CommandPath() function if available (more reliable)
+	if cmdPath := cmd.CommandPath(); cmdPath != "" {
+		return cmdPath
+	}
+
+	// Fallback to manually building the path
 	names := []string{cmd.Name()}
 	parent := cmd.Parent()
 

--- a/internal/errors/command_test.go
+++ b/internal/errors/command_test.go
@@ -1,0 +1,143 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("getCommandPath builds full command path", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a command hierarchy
+		childCmd := &cobra.Command{Use: "child"}
+		parentCmd := &cobra.Command{Use: "parent"}
+		rootCmd := &cobra.Command{Use: "root"}
+
+		// Set up command hierarchy
+		parentCmd.AddCommand(childCmd)
+		rootCmd.AddCommand(parentCmd)
+
+		path := getCommandPath(childCmd)
+		expected := "root parent child"
+
+		if path != expected {
+			t.Errorf("Expected command path %q, got %q", expected, path)
+		}
+	})
+
+	t.Run("HandleCommandError formats error with command context", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		cmd := &cobra.Command{
+			Use: "test",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return NewValidationError(nil, "Invalid input")
+			},
+		}
+		cmd.SetErr(&buf)
+
+		handler := NewCommandErrorHandler()
+		handler.HandleCommandError(cmd, NewValidationError(nil, "Invalid input"))
+
+		output := stripANSI(buf.String())
+		if !strings.Contains(output, "Validation Error:") {
+			t.Errorf("Expected output to contain error type, got: %q", output)
+		}
+		if !strings.Contains(output, "Invalid input") {
+			t.Errorf("Expected output to contain error message, got: %q", output)
+		}
+		if !strings.Contains(output, "test") {
+			t.Errorf("Expected output to contain command name, got: %q", output)
+		}
+	})
+
+	t.Run("WrapRunE adds context to errors", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name                 string
+			originalError        error
+			expectSuggestionHelp bool
+			expectCommandContext bool
+		}{
+			{
+				name:                 "resource not found error",
+				originalError:        NewResourceNotFoundError(nil, "Resource not found"),
+				expectSuggestionHelp: true,
+				expectCommandContext: false,
+			},
+			{
+				name:                 "validation error",
+				originalError:        NewValidationError(nil, "Invalid input"),
+				expectSuggestionHelp: false,
+				expectCommandContext: true,
+			},
+			{
+				name:                 "other error",
+				originalError:        fmt.Errorf("generic error"),
+				expectSuggestionHelp: false,
+				expectCommandContext: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Create a command with a wrapped RunE function
+				cmd := &cobra.Command{
+					Use: "test",
+					RunE: WrapRunE(func(cmd *cobra.Command, args []string) error {
+						return tc.originalError
+					}),
+				}
+
+				// Run the command
+				err := cmd.Execute()
+
+				// Check that the error is still returned
+				if err == nil {
+					t.Fatal("Expected error, got nil")
+				}
+
+				// Check for help suggestion
+				if tc.expectSuggestionHelp {
+					cliErr, ok := err.(*Error)
+					if !ok {
+						t.Fatal("Expected error to be a *Error")
+					}
+					foundHelpSuggestion := false
+					for _, suggestion := range cliErr.Suggestions {
+						if strings.Contains(suggestion, "--help") {
+							foundHelpSuggestion = true
+							break
+						}
+					}
+					if !foundHelpSuggestion {
+						t.Error("Expected help suggestion for not found error")
+					}
+				}
+
+				// Check for command context
+				if tc.expectCommandContext {
+					cliErr, ok := err.(*Error)
+					if !ok {
+						t.Fatal("Expected error to be a *Error")
+					}
+					if !strings.Contains(cliErr.Details, "When executing") {
+						t.Errorf("Expected details to contain command context, got: %q", cliErr.Details)
+					}
+				}
+			})
+		}
+	})
+}

--- a/internal/errors/command_test.go
+++ b/internal/errors/command_test.go
@@ -42,6 +42,10 @@ func TestCommandErrorHandler(t *testing.T) {
 				return NewValidationError(nil, "Invalid input")
 			},
 		}
+
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
 		cmd.SetErr(&buf)
 
 		handler := NewCommandErrorHandler()
@@ -100,6 +104,9 @@ func TestCommandErrorHandler(t *testing.T) {
 						return tc.originalError
 					}),
 				}
+
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
 
 				// Run the command
 				err := cmd.Execute()

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -57,10 +57,21 @@ func (e *Error) Error() string {
 		msg.WriteString(": ")
 	}
 
+	// First include the original error, if present
 	if e.Original != nil {
 		msg.WriteString(e.Original.Error())
-	} else if e.Details != "" {
-		msg.WriteString(e.Details)
+	}
+
+	// Then include details if present, regardless of whether Original is present
+	if e.Details != "" {
+		// Only add a separator if we've already written something
+		if e.Original != nil {
+			msg.WriteString(" (")
+			msg.WriteString(e.Details)
+			msg.WriteString(")")
+		} else {
+			msg.WriteString(e.Details)
+		}
 	}
 
 	return msg.String()
@@ -130,7 +141,7 @@ func WithSuggestions(err error, suggestions ...string) error {
 		cliErr.Suggestions = append(cliErr.Suggestions, suggestions...)
 		return cliErr
 	}
-	
+
 	// If it's not already a CLI error, create a new one
 	return NewError(err, nil, "", suggestions...)
 }
@@ -145,7 +156,7 @@ func WithDetails(err error, details string) error {
 		}
 		return cliErr
 	}
-	
+
 	// If it's not already a CLI error, create a new one
 	return NewError(err, nil, details)
 }
@@ -207,7 +218,7 @@ func IsAPIError(err error) bool {
 
 // IsAuthenticationError returns true if the error indicates an authentication failure
 func IsAuthenticationError(err error) bool {
-	return errors.Is(err, ErrAuthentication) 
+	return errors.Is(err, ErrAuthentication)
 }
 
 // IsPermissionDeniedError returns true if the error indicates a permission issue

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,226 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Standard error types that can be used to categorize errors
+var (
+	// ErrConfiguration indicates an error in the user's configuration
+	ErrConfiguration = errors.New("configuration error")
+
+	// ErrValidation indicates invalid input from the user
+	ErrValidation = errors.New("validation error")
+
+	// ErrAPI indicates an error from the Buildkite API
+	ErrAPI = errors.New("API error")
+
+	// ErrResourceNotFound indicates a requested resource was not found
+	ErrResourceNotFound = errors.New("resource not found")
+
+	// ErrPermissionDenied indicates the user lacks permission
+	ErrPermissionDenied = errors.New("permission denied")
+
+	// ErrAuthentication indicates an issue with authentication
+	ErrAuthentication = errors.New("authentication error")
+
+	// ErrInternal indicates an internal error in the CLI
+	ErrInternal = errors.New("internal error")
+
+	// ErrUserAborted indicates the user has canceled an operation
+	ErrUserAborted = errors.New("user aborted")
+)
+
+// Error represents a CLI error with context
+type Error struct {
+	// Original is the underlying error
+	Original error
+
+	// Category is the broad category of the error
+	Category error
+
+	// Details contains additional detail about the error
+	Details string
+
+	// Suggestions provides hints on how to fix the error
+	Suggestions []string
+}
+
+// Error implements the error interface
+func (e *Error) Error() string {
+	var msg strings.Builder
+
+	if e.Category != nil {
+		msg.WriteString(e.Category.Error())
+		msg.WriteString(": ")
+	}
+
+	if e.Original != nil {
+		msg.WriteString(e.Original.Error())
+	} else if e.Details != "" {
+		msg.WriteString(e.Details)
+	}
+
+	return msg.String()
+}
+
+// FormattedError returns a formatted multi-line error message suitable for display
+func (e *Error) FormattedError() string {
+	var msg strings.Builder
+
+	// Build the main error message
+	if e.Category != nil {
+		// Write category with uppercase first letter
+		category := e.Category.Error()
+		if len(category) > 0 {
+			msg.WriteString(strings.ToUpper(category[:1]) + category[1:])
+			msg.WriteString(": ")
+		}
+	}
+
+	if e.Original != nil {
+		msg.WriteString(e.Original.Error())
+	} else if e.Details != "" {
+		msg.WriteString(e.Details)
+	}
+
+	// Add detailed suggestions if available
+	if len(e.Suggestions) > 0 {
+		msg.WriteString("\n\n")
+		for i, suggestion := range e.Suggestions {
+			if i > 0 {
+				msg.WriteString("\n")
+			}
+			msg.WriteString("• ")
+			msg.WriteString(suggestion)
+		}
+	}
+
+	return msg.String()
+}
+
+// Unwrap implements the errors.Unwrap interface to allow using errors.Is and errors.As
+func (e *Error) Unwrap() error {
+	if e.Original != nil {
+		return e.Original
+	}
+	return e.Category
+}
+
+// Is implements the errors.Is interface to allow checking error types
+func (e *Error) Is(target error) bool {
+	return errors.Is(e.Category, target) || (e.Original != nil && errors.Is(e.Original, target))
+}
+
+// NewError creates a new Error with the given attributes
+func NewError(original error, category error, details string, suggestions ...string) *Error {
+	return &Error{
+		Original:    original,
+		Category:    category,
+		Details:     details,
+		Suggestions: suggestions,
+	}
+}
+
+// WithSuggestions adds suggestions to an existing error
+func WithSuggestions(err error, suggestions ...string) error {
+	if cliErr, ok := err.(*Error); ok {
+		cliErr.Suggestions = append(cliErr.Suggestions, suggestions...)
+		return cliErr
+	}
+	
+	// If it's not already a CLI error, create a new one
+	return NewError(err, nil, "", suggestions...)
+}
+
+// WithDetails adds details to an existing error
+func WithDetails(err error, details string) error {
+	if cliErr, ok := err.(*Error); ok {
+		if cliErr.Details == "" {
+			cliErr.Details = details
+		} else {
+			cliErr.Details = fmt.Sprintf("%s: %s", cliErr.Details, details)
+		}
+		return cliErr
+	}
+	
+	// If it's not already a CLI error, create a new one
+	return NewError(err, nil, details)
+}
+
+// NewConfigurationError creates a new configuration error
+func NewConfigurationError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrConfiguration, details, suggestions...)
+}
+
+// NewValidationError creates a new validation error
+func NewValidationError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrValidation, details, suggestions...)
+}
+
+// NewAPIError creates a new API error
+func NewAPIError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrAPI, details, suggestions...)
+}
+
+// NewResourceNotFoundError creates a new resource not found error
+func NewResourceNotFoundError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrResourceNotFound, details, suggestions...)
+}
+
+// NewPermissionDeniedError creates a new permission denied error
+func NewPermissionDeniedError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrPermissionDenied, details, suggestions...)
+}
+
+// NewAuthenticationError creates a new authentication error
+func NewAuthenticationError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrAuthentication, details, suggestions...)
+}
+
+// NewInternalError creates a new internal error
+func NewInternalError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrInternal, details, suggestions...)
+}
+
+// NewUserAbortedError creates a new user aborted error
+func NewUserAbortedError(err error, details string, suggestions ...string) error {
+	return NewError(err, ErrUserAborted, details, suggestions...)
+}
+
+// IsNotFound returns true if the error indicates a resource was not found
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrResourceNotFound)
+}
+
+// IsValidationError returns true if the error indicates a validation failure
+func IsValidationError(err error) bool {
+	return errors.Is(err, ErrValidation)
+}
+
+// IsAPIError returns true if the error indicates an API failure
+func IsAPIError(err error) bool {
+	return errors.Is(err, ErrAPI)
+}
+
+// IsAuthenticationError returns true if the error indicates an authentication failure
+func IsAuthenticationError(err error) bool {
+	return errors.Is(err, ErrAuthentication) 
+}
+
+// IsPermissionDeniedError returns true if the error indicates a permission issue
+func IsPermissionDeniedError(err error) bool {
+	return errors.Is(err, ErrPermissionDenied)
+}
+
+// IsConfigurationError returns true if the error indicates a configuration issue
+func IsConfigurationError(err error) bool {
+	return errors.Is(err, ErrConfiguration)
+}
+
+// IsUserAborted returns true if the error indicates the user aborted the operation
+func IsUserAborted(err error) bool {
+	return errors.Is(err, ErrUserAborted)
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,258 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestErrorInterface(t *testing.T) {
+	t.Parallel()
+
+	t.Run("implements error interface", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := fmt.Errorf("original error")
+		err := NewError(originalErr, ErrAPI, "additional details")
+
+		// Check that Error() returns a non-empty string
+		if err.Error() == "" {
+			t.Error("Error() should return a non-empty string")
+		}
+
+		// Check that the error string contains both the category and original error
+		errStr := err.Error()
+		if !strings.Contains(errStr, "API error") {
+			t.Errorf("Error string %q should contain category 'API error'", errStr)
+		}
+		if !strings.Contains(errStr, "original error") {
+			t.Errorf("Error string %q should contain original error message", errStr)
+		}
+	})
+
+	t.Run("formatted error includes suggestions", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := fmt.Errorf("resource not found")
+		suggestions := []string{"Check the resource name", "Verify you have access"}
+		err := NewError(originalErr, ErrResourceNotFound, "failed to get resource", suggestions...)
+
+		formatted := err.FormattedError()
+		for _, suggestion := range suggestions {
+			if !strings.Contains(formatted, suggestion) {
+				t.Errorf("Formatted error should contain suggestion %q, got: %q", suggestion, formatted)
+			}
+		}
+	})
+}
+
+func TestErrorCategorization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors.Is works with standard error types", func(t *testing.T) {
+		t.Parallel()
+
+		apiErr := NewAPIError(nil, "API request failed")
+		if !errors.Is(apiErr, ErrAPI) {
+			t.Error("errors.Is should identify API error category")
+		}
+
+		validationErr := NewValidationError(nil, "Invalid input")
+		if !errors.Is(validationErr, ErrValidation) {
+			t.Error("errors.Is should identify validation error category")
+		}
+	})
+
+	t.Run("error type checking functions work", func(t *testing.T) {
+		t.Parallel()
+
+		apiErr := NewAPIError(nil, "API request failed")
+		if !IsAPIError(apiErr) {
+			t.Error("IsAPIError should return true for API errors")
+		}
+
+		validationErr := NewValidationError(nil, "Invalid input")
+		if !IsValidationError(validationErr) {
+			t.Error("IsValidationError should return true for validation errors")
+		}
+
+		notFoundErr := NewResourceNotFoundError(nil, "Resource not found")
+		if !IsNotFound(notFoundErr) {
+			t.Error("IsNotFound should return true for not found errors")
+		}
+	})
+}
+
+func TestErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithSuggestions adds suggestions", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := NewValidationError(nil, "Invalid input")
+		errWithSuggestions := WithSuggestions(originalErr, "Try this instead", "Or this")
+
+		// Verify that it's still a validation error
+		if !IsValidationError(errWithSuggestions) {
+			t.Error("Error category should be preserved when adding suggestions")
+		}
+
+		// Verify suggestions were added
+		cliErr, ok := errWithSuggestions.(*Error)
+		if !ok {
+			t.Fatal("WithSuggestions should return a *Error")
+		}
+		if len(cliErr.Suggestions) != 2 {
+			t.Errorf("Expected 2 suggestions, got %d", len(cliErr.Suggestions))
+		}
+	})
+
+	t.Run("WithDetails adds details", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := NewAPIError(nil, "API request failed")
+		errWithDetails := WithDetails(originalErr, "Additional context")
+
+		// Verify that it's still an API error
+		if !IsAPIError(errWithDetails) {
+			t.Error("Error category should be preserved when adding details")
+		}
+
+		// Verify details were added
+		cliErr, ok := errWithDetails.(*Error)
+		if !ok {
+			t.Fatal("WithDetails should return a *Error")
+		}
+		if !strings.Contains(cliErr.Details, "Additional context") {
+			t.Errorf("Details should contain added context, got %q", cliErr.Details)
+		}
+	})
+
+	t.Run("Unwrap returns original error", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := fmt.Errorf("original error")
+		wrappedErr := NewAPIError(originalErr, "API request failed")
+
+		unwrappedErr := errors.Unwrap(wrappedErr)
+		if unwrappedErr != originalErr {
+			t.Errorf("Unwrap should return original error, got %v", unwrappedErr)
+		}
+	})
+
+	t.Run("Unwrap with nil original returns category", func(t *testing.T) {
+		t.Parallel()
+
+		wrappedErr := NewAPIError(nil, "API request failed")
+
+		unwrappedErr := errors.Unwrap(wrappedErr)
+		if unwrappedErr != ErrAPI {
+			t.Errorf("Unwrap should return category when original is nil, got %v", unwrappedErr)
+		}
+	})
+
+	t.Run("errors.Is works with original error", func(t *testing.T) {
+		t.Parallel()
+
+		originalErr := fmt.Errorf("not found: resource does not exist")
+		wrappedErr := NewResourceNotFoundError(originalErr, "Could not find resource")
+
+		// Should match both the category and the original error
+		if !errors.Is(wrappedErr, ErrResourceNotFound) {
+			t.Error("errors.Is should match error category")
+		}
+		if !errors.Is(wrappedErr, originalErr) {
+			t.Error("errors.Is should match original error")
+		}
+	})
+}
+
+func TestErrorCreationHelpers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		createFunc func(error, string, ...string) error
+		errorType  error
+		checkFunc  func(error) bool
+	}{
+		{
+			name:       "NewConfigurationError",
+			createFunc: NewConfigurationError,
+			errorType:  ErrConfiguration,
+			checkFunc:  IsConfigurationError,
+		},
+		{
+			name:       "NewValidationError",
+			createFunc: NewValidationError,
+			errorType:  ErrValidation,
+			checkFunc:  IsValidationError,
+		},
+		{
+			name:       "NewAPIError",
+			createFunc: NewAPIError,
+			errorType:  ErrAPI,
+			checkFunc:  IsAPIError,
+		},
+		{
+			name:       "NewResourceNotFoundError",
+			createFunc: NewResourceNotFoundError,
+			errorType:  ErrResourceNotFound,
+			checkFunc:  IsNotFound,
+		},
+		{
+			name:       "NewPermissionDeniedError",
+			createFunc: NewPermissionDeniedError,
+			errorType:  ErrPermissionDenied,
+			checkFunc:  IsPermissionDeniedError,
+		},
+		{
+			name:       "NewAuthenticationError",
+			createFunc: NewAuthenticationError,
+			errorType:  ErrAuthentication,
+			checkFunc:  IsAuthenticationError,
+		},
+		{
+			name:       "NewUserAbortedError",
+			createFunc: NewUserAbortedError,
+			errorType:  ErrUserAborted,
+			checkFunc:  IsUserAborted,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture test case value
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			originalErr := fmt.Errorf("some error")
+			details := "detailed error message"
+			suggestion := "helpful suggestion"
+
+			err := tc.createFunc(originalErr, details, suggestion)
+
+			// Check that the error has the right category
+			if !errors.Is(err, tc.errorType) {
+				t.Errorf("Error should be of type %v", tc.errorType)
+			}
+
+			// Check that the error type check function works
+			if !tc.checkFunc(err) {
+				t.Errorf("Type check function should return true")
+			}
+
+			// Check that details and suggestions are included
+			cliErr, ok := err.(*Error)
+			if !ok {
+				t.Fatal("Error should be a *Error")
+			}
+			if cliErr.Details != details {
+				t.Errorf("Expected details %q, got %q", details, cliErr.Details)
+			}
+			if len(cliErr.Suggestions) != 1 || cliErr.Suggestions[0] != suggestion {
+				t.Errorf("Expected suggestion %q, got %v", suggestion, cliErr.Suggestions)
+			}
+		})
+	}
+}

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -28,7 +28,6 @@ var (
 	errorStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true) // Red
 	warningStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // Yellow
 	suggestionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))            // Cyan
-	detailStyle     = lipgloss.NewStyle().Faint(true)                                // Faint
 )
 
 // Handler processes errors from commands and formats them appropriately

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -180,18 +180,22 @@ func (h *Handler) HandleWithDetails(err error, operation string) {
 	if operation != "" {
 		// Check if it's already a CLI error
 		if cliErr, ok := err.(*Error); ok {
-			// Create a copy to avoid modifying the original error
+			// Create a deep copy of the original error to avoid modifying it
+			newSuggestions := make([]string, len(cliErr.Suggestions))
+			copy(newSuggestions, cliErr.Suggestions)
+
 			newCliErr := &Error{
 				Original:    cliErr.Original,
 				Category:    cliErr.Category,
-				Suggestions: append([]string{}, cliErr.Suggestions...),
+				Suggestions: newSuggestions,
+				Details:     cliErr.Details,
 			}
 
 			// Add operation to details
-			if cliErr.Details == "" {
+			if newCliErr.Details == "" {
 				newCliErr.Details = fmt.Sprintf("failed during: %s", operation)
 			} else {
-				newCliErr.Details = fmt.Sprintf("%s (during: %s)", cliErr.Details, operation)
+				newCliErr.Details = fmt.Sprintf("%s (during: %s)", newCliErr.Details, operation)
 			}
 			contextualErr = newCliErr
 		} else {

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -1,10 +1,10 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -25,10 +25,10 @@ const (
 
 // Styling for error output
 var (
-	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true) // Red
-	warningStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // Yellow
+	errorStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true) // Red
+	warningStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // Yellow
 	suggestionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))            // Cyan
-	detailStyle    = lipgloss.NewStyle().Faint(true)                               // Faint
+	detailStyle     = lipgloss.NewStyle().Faint(true)                                // Faint
 )
 
 // Handler processes errors from commands and formats them appropriately

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -1,0 +1,227 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Exit codes for different error types
+const (
+	ExitCodeSuccess          = 0
+	ExitCodeGenericError     = 1
+	ExitCodeValidationError  = 2
+	ExitCodeAPIError         = 3
+	ExitCodeNotFoundError    = 4
+	ExitCodePermissionError  = 5
+	ExitCodeConfigError      = 6
+	ExitCodeAuthError        = 7
+	ExitCodeInternalError    = 8
+	ExitCodeUserAbortedError = 130 // Same as Ctrl+C in bash
+)
+
+// Styling for error output
+var (
+	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true) // Red
+	warningStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // Yellow
+	suggestionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))            // Cyan
+	detailStyle    = lipgloss.NewStyle().Faint(true)                               // Faint
+)
+
+// Handler processes errors from commands and formats them appropriately
+type Handler struct {
+	// Writer is where error messages will be written
+	Writer io.Writer
+	// ExitFunc is the function called to exit the program with a specific code
+	ExitFunc func(int)
+	// Verbose enables more detailed error messages
+	Verbose bool
+}
+
+// NewHandler creates a new Handler with default settings
+func NewHandler() *Handler {
+	return &Handler{
+		Writer:   os.Stderr,
+		ExitFunc: os.Exit,
+		Verbose:  false,
+	}
+}
+
+// WithWriter sets the writer for error output
+func (h *Handler) WithWriter(w io.Writer) *Handler {
+	h.Writer = w
+	return h
+}
+
+// WithExitFunc sets the exit function
+func (h *Handler) WithExitFunc(f func(int)) *Handler {
+	h.ExitFunc = f
+	return h
+}
+
+// WithVerbose sets the verbose flag
+func (h *Handler) WithVerbose(v bool) *Handler {
+	h.Verbose = v
+	return h
+}
+
+// Handle processes an error and outputs it appropriately
+func (h *Handler) Handle(err error) {
+	if err == nil {
+		return
+	}
+
+	// Get the exit code based on error type
+	exitCode := h.getExitCode(err)
+
+	// Format the error message
+	message := h.formatError(err)
+
+	// Write the error message
+	fmt.Fprintln(h.Writer, message)
+
+	// Call the exit function with the appropriate code
+	if h.ExitFunc != nil {
+		h.ExitFunc(exitCode)
+	}
+}
+
+// getExitCode determines the appropriate exit code based on the error type
+func (h *Handler) getExitCode(err error) int {
+	switch {
+	case IsValidationError(err):
+		return ExitCodeValidationError
+	case IsAPIError(err):
+		return ExitCodeAPIError
+	case IsNotFound(err):
+		return ExitCodeNotFoundError
+	case IsPermissionDeniedError(err):
+		return ExitCodePermissionError
+	case IsConfigurationError(err):
+		return ExitCodeConfigError
+	case IsAuthenticationError(err):
+		return ExitCodeAuthError
+	case IsUserAborted(err):
+		return ExitCodeUserAbortedError
+	case errors.Is(err, ErrInternal):
+		return ExitCodeInternalError
+	default:
+		return ExitCodeGenericError
+	}
+}
+
+// formatError creates a formatted error message based on the error type
+func (h *Handler) formatError(err error) string {
+	prefix := errorStyle.Render("Error:")
+
+	if cliErr, ok := err.(*Error); ok {
+		// For CLI errors, use the formatted error message
+		var message string
+
+		if cliErr.Category != nil {
+			// Get a more specific prefix based on the error category
+			prefix = h.getCategoryPrefix(cliErr.Category)
+		}
+
+		// If verbose mode is enabled, include more details
+		if h.Verbose {
+			message = cliErr.FormattedError()
+		} else {
+			// In non-verbose mode, include the main error message and the first suggestion
+			message = cliErr.Error()
+			if len(cliErr.Suggestions) > 0 {
+				message = fmt.Sprintf("%s\n%s", message,
+					suggestionStyle.Render(fmt.Sprintf("Tip: %s", cliErr.Suggestions[0])))
+			}
+		}
+
+		return fmt.Sprintf("%s %s", prefix, message)
+	}
+
+	// For regular errors, just return the error message
+	return fmt.Sprintf("%s %s", prefix, err.Error())
+}
+
+// getCategoryPrefix returns an appropriate prefix for the error category
+func (h *Handler) getCategoryPrefix(category error) string {
+	switch category {
+	case ErrValidation:
+		return errorStyle.Render("Validation Error:")
+	case ErrAPI:
+		return errorStyle.Render("API Error:")
+	case ErrResourceNotFound:
+		return errorStyle.Render("Not Found:")
+	case ErrPermissionDenied:
+		return errorStyle.Render("Permission Denied:")
+	case ErrConfiguration:
+		return errorStyle.Render("Configuration Error:")
+	case ErrAuthentication:
+		return errorStyle.Render("Authentication Error:")
+	case ErrUserAborted:
+		return warningStyle.Render("Aborted:")
+	case ErrInternal:
+		return errorStyle.Render("Internal Error:")
+	default:
+		return errorStyle.Render("Error:")
+	}
+}
+
+// HandleWithDetails processes an error with additional contextual details
+func (h *Handler) HandleWithDetails(err error, operation string) {
+	if err == nil {
+		return
+	}
+
+	// Add operation context to the error
+	var contextualErr error
+	if operation != "" {
+		// Check if it's already a CLI error
+		if cliErr, ok := err.(*Error); ok {
+			// Add operation to details
+			if cliErr.Details == "" {
+				cliErr.Details = fmt.Sprintf("failed during: %s", operation)
+			} else {
+				cliErr.Details = fmt.Sprintf("%s (during: %s)", cliErr.Details, operation)
+			}
+			contextualErr = cliErr
+		} else {
+			// Wrap in a new error with operation details
+			contextualErr = NewError(err, nil, fmt.Sprintf("failed during: %s", operation))
+		}
+	} else {
+		contextualErr = err
+	}
+
+	// Handle the contextual error
+	h.Handle(contextualErr)
+}
+
+// PrintWarning prints a warning message
+func (h *Handler) PrintWarning(format string, args ...interface{}) {
+	prefix := warningStyle.Render("Warning:")
+	message := fmt.Sprintf(format, args...)
+	fmt.Fprintf(h.Writer, "%s %s\n", prefix, message)
+}
+
+// MessageForError returns a formatted message for an error without exiting
+func MessageForError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	handler := NewHandler()
+	return handler.formatError(err)
+}
+
+// GetExitCodeForError returns the exit code for a given error
+func GetExitCodeForError(err error) int {
+	if err == nil {
+		return ExitCodeSuccess
+	}
+
+	handler := NewHandler()
+	return handler.getExitCode(err)
+}

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -180,13 +180,20 @@ func (h *Handler) HandleWithDetails(err error, operation string) {
 	if operation != "" {
 		// Check if it's already a CLI error
 		if cliErr, ok := err.(*Error); ok {
+			// Create a copy to avoid modifying the original error
+			newCliErr := &Error{
+				Original:    cliErr.Original,
+				Category:    cliErr.Category,
+				Suggestions: append([]string{}, cliErr.Suggestions...),
+			}
+			
 			// Add operation to details
 			if cliErr.Details == "" {
-				cliErr.Details = fmt.Sprintf("failed during: %s", operation)
+				newCliErr.Details = fmt.Sprintf("failed during: %s", operation)
 			} else {
-				cliErr.Details = fmt.Sprintf("%s (during: %s)", cliErr.Details, operation)
+				newCliErr.Details = fmt.Sprintf("%s (during: %s)", cliErr.Details, operation)
 			}
-			contextualErr = cliErr
+			contextualErr = newCliErr
 		} else {
 			// Wrap in a new error with operation details
 			contextualErr = NewError(err, nil, fmt.Sprintf("failed during: %s", operation))

--- a/internal/errors/handler.go
+++ b/internal/errors/handler.go
@@ -186,7 +186,7 @@ func (h *Handler) HandleWithDetails(err error, operation string) {
 				Category:    cliErr.Category,
 				Suggestions: append([]string{}, cliErr.Suggestions...),
 			}
-			
+
 			// Add operation to details
 			if cliErr.Details == "" {
 				newCliErr.Details = fmt.Sprintf("failed during: %s", operation)

--- a/internal/errors/handler_test.go
+++ b/internal/errors/handler_test.go
@@ -170,7 +170,8 @@ func TestHandler(t *testing.T) {
 			WithWriter(&buf).
 			WithExitFunc(func(int) {})
 
-		err := fmt.Errorf("something went wrong")
+		// Create a simple error that won't be shared with other tests
+		err := fmt.Errorf("test error: something went wrong")
 		operation := "fetching data"
 
 		handler.HandleWithDetails(err, operation)

--- a/internal/errors/handler_test.go
+++ b/internal/errors/handler_test.go
@@ -208,10 +208,10 @@ func TestHandler(t *testing.T) {
 
 		err := NewValidationError(nil, "Invalid input")
 		message := MessageForError(err)
-		
+
 		// Strip ANSI codes for testing
 		plainMessage := stripANSI(message)
-		
+
 		if !strings.Contains(plainMessage, "Validation Error:") {
 			t.Errorf("Expected message to contain error category, got: %q", plainMessage)
 		}

--- a/internal/errors/handler_test.go
+++ b/internal/errors/handler_test.go
@@ -193,7 +193,7 @@ func TestHandler(t *testing.T) {
 			WithWriter(&buf)
 
 		warningMsg := "Something might be wrong"
-		handler.PrintWarning(warningMsg)
+		handler.PrintWarning("%s", warningMsg)
 
 		output := stripANSI(buf.String())
 		if !strings.Contains(output, "Warning:") {

--- a/internal/errors/handler_test.go
+++ b/internal/errors/handler_test.go
@@ -1,0 +1,264 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// stripANSI removes ANSI color codes from a string for easier testing
+func stripANSI(s string) string {
+	r := strings.NewReplacer(
+		"\x1b[0m", "",
+		"\x1b[1m", "",
+		"\x1b[2m", "",
+		"\x1b[31m", "",
+		"\x1b[32m", "",
+		"\x1b[33m", "",
+		"\x1b[34m", "",
+		"\x1b[35m", "",
+		"\x1b[36m", "",
+		"\x1b[37m", "",
+		"\x1b[91m", "",
+		"\x1b[92m", "",
+		"\x1b[93m", "",
+		"\x1b[94m", "",
+		"\x1b[95m", "",
+		"\x1b[96m", "",
+		"\x1b[97m", "",
+	)
+	return r.Replace(s)
+}
+
+func TestHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("handles nil error", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		var exitCode int
+
+		handler := NewHandler().
+			WithWriter(&buf).
+			WithExitFunc(func(code int) { exitCode = code })
+
+		handler.Handle(nil)
+
+		if buf.Len() > 0 {
+			t.Errorf("Expected no output for nil error, got: %q", buf.String())
+		}
+		if exitCode != 0 {
+			t.Errorf("Expected exit code 0 for nil error, got: %d", exitCode)
+		}
+	})
+
+	t.Run("formats different error types", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name           string
+			err            error
+			expectedPrefix string
+			expectedCode   int
+		}{
+			{
+				name:           "validation error",
+				err:            NewValidationError(nil, "Invalid input"),
+				expectedPrefix: "Validation Error:",
+				expectedCode:   ExitCodeValidationError,
+			},
+			{
+				name:           "API error",
+				err:            NewAPIError(nil, "API request failed"),
+				expectedPrefix: "API Error:",
+				expectedCode:   ExitCodeAPIError,
+			},
+			{
+				name:           "not found error",
+				err:            NewResourceNotFoundError(nil, "Resource not found"),
+				expectedPrefix: "Not Found:",
+				expectedCode:   ExitCodeNotFoundError,
+			},
+			{
+				name:           "simple error",
+				err:            fmt.Errorf("simple error"),
+				expectedPrefix: "Error:",
+				expectedCode:   ExitCodeGenericError,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc // Capture range variable
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				var buf bytes.Buffer
+				var exitCode int
+
+				handler := NewHandler().
+					WithWriter(&buf).
+					WithExitFunc(func(code int) { exitCode = code })
+
+				handler.Handle(tc.err)
+
+				output := stripANSI(buf.String())
+				if !strings.Contains(output, tc.expectedPrefix) {
+					t.Errorf("Expected output to contain %q, got: %q", tc.expectedPrefix, output)
+				}
+
+				if exitCode != tc.expectedCode {
+					t.Errorf("Expected exit code %d, got: %d", tc.expectedCode, exitCode)
+				}
+			})
+		}
+	})
+
+	t.Run("includes suggestions in verbose mode", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := NewHandler().
+			WithWriter(&buf).
+			WithExitFunc(func(int) {}).
+			WithVerbose(true)
+
+		suggestion1 := "Try using a different name"
+		suggestion2 := "Check your spelling"
+		err := NewValidationError(nil, "Invalid name", suggestion1, suggestion2)
+
+		handler.Handle(err)
+
+		output := stripANSI(buf.String())
+		if !strings.Contains(output, suggestion1) {
+			t.Errorf("Expected output to contain suggestion %q, got: %q", suggestion1, output)
+		}
+		if !strings.Contains(output, suggestion2) {
+			t.Errorf("Expected output to contain suggestion %q, got: %q", suggestion2, output)
+		}
+	})
+
+	t.Run("includes one suggestion in non-verbose mode", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := NewHandler().
+			WithWriter(&buf).
+			WithExitFunc(func(int) {})
+
+		suggestion1 := "Try using a different name"
+		suggestion2 := "Check your spelling"
+		err := NewValidationError(nil, "Invalid name", suggestion1, suggestion2)
+
+		handler.Handle(err)
+
+		output := stripANSI(buf.String())
+		if !strings.Contains(output, suggestion1) {
+			t.Errorf("Expected output to contain first suggestion %q, got: %q", suggestion1, output)
+		}
+		if strings.Contains(output, suggestion2) {
+			t.Errorf("Expected output to NOT contain second suggestion in non-verbose mode, got: %q", output)
+		}
+	})
+
+	t.Run("handles errors with details", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := NewHandler().
+			WithWriter(&buf).
+			WithExitFunc(func(int) {})
+
+		err := fmt.Errorf("something went wrong")
+		operation := "fetching data"
+
+		handler.HandleWithDetails(err, operation)
+
+		output := stripANSI(buf.String())
+		if !strings.Contains(output, "something went wrong") {
+			t.Errorf("Expected output to contain error message, got: %q", output)
+		}
+		if !strings.Contains(output, operation) {
+			t.Errorf("Expected output to contain operation details %q, got: %q", operation, output)
+		}
+	})
+
+	t.Run("prints warnings", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := NewHandler().
+			WithWriter(&buf)
+
+		warningMsg := "Something might be wrong"
+		handler.PrintWarning(warningMsg)
+
+		output := stripANSI(buf.String())
+		if !strings.Contains(output, "Warning:") {
+			t.Errorf("Expected output to contain 'Warning:', got: %q", output)
+		}
+		if !strings.Contains(output, warningMsg) {
+			t.Errorf("Expected output to contain warning message %q, got: %q", warningMsg, output)
+		}
+	})
+
+	t.Run("MessageForError returns formatted message", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewValidationError(nil, "Invalid input")
+		message := MessageForError(err)
+		
+		// Strip ANSI codes for testing
+		plainMessage := stripANSI(message)
+		
+		if !strings.Contains(plainMessage, "Validation Error:") {
+			t.Errorf("Expected message to contain error category, got: %q", plainMessage)
+		}
+		if !strings.Contains(plainMessage, "Invalid input") {
+			t.Errorf("Expected message to contain error details, got: %q", plainMessage)
+		}
+	})
+
+	t.Run("GetExitCodeForError returns correct code", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name         string
+			err          error
+			expectedCode int
+		}{
+			{
+				name:         "nil error",
+				err:          nil,
+				expectedCode: ExitCodeSuccess,
+			},
+			{
+				name:         "validation error",
+				err:          NewValidationError(nil, ""),
+				expectedCode: ExitCodeValidationError,
+			},
+			{
+				name:         "API error",
+				err:          NewAPIError(nil, ""),
+				expectedCode: ExitCodeAPIError,
+			},
+			{
+				name:         "not found error",
+				err:          NewResourceNotFoundError(nil, ""),
+				expectedCode: ExitCodeNotFoundError,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				code := GetExitCodeForError(tc.err)
+				if code != tc.expectedCode {
+					t.Errorf("Expected exit code %d, got: %d", tc.expectedCode, code)
+				}
+			})
+		}
+	})
+}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -12,6 +12,28 @@ import (
 	"strings"
 )
 
+// ErrorResponse represents an error response from the API
+type ErrorResponse struct {
+	StatusCode int
+	Status     string
+	URL        string
+	Body       []byte
+}
+
+// Error implements the error interface
+func (e *ErrorResponse) Error() string {
+	msg := fmt.Sprintf("HTTP request failed: %d %s (%s)", e.StatusCode, e.Status, e.URL)
+	if len(e.Body) > 0 {
+		// Truncate body if it's very long for the error message
+		bodyStr := string(e.Body)
+		if len(bodyStr) > 200 {
+			bodyStr = bodyStr[:200] + "..."
+		}
+		msg += fmt.Sprintf(": %s", bodyStr)
+	}
+	return msg
+}
+
 // Client is an HTTP client that handles common operations for Buildkite API requests
 type Client struct {
 	baseURL   string
@@ -78,6 +100,31 @@ func (c *Client) Put(ctx context.Context, endpoint string, body interface{}, v i
 // Delete performs a DELETE request to the specified endpoint
 func (c *Client) Delete(ctx context.Context, endpoint string, v interface{}) error {
 	return c.Do(ctx, http.MethodDelete, endpoint, nil, v)
+}
+
+// IsNotFound returns true if the error is a 404 Not Found
+func (e *ErrorResponse) IsNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
+}
+
+// IsUnauthorized returns true if the error is a 401 Unauthorized
+func (e *ErrorResponse) IsUnauthorized() bool {
+	return e.StatusCode == http.StatusUnauthorized
+}
+
+// IsForbidden returns true if the error is a 403 Forbidden
+func (e *ErrorResponse) IsForbidden() bool {
+	return e.StatusCode == http.StatusForbidden
+}
+
+// IsBadRequest returns true if the error is a 400 Bad Request
+func (e *ErrorResponse) IsBadRequest() bool {
+	return e.StatusCode == http.StatusBadRequest
+}
+
+// IsServerError returns true if the error is a 5xx Server Error
+func (e *ErrorResponse) IsServerError() bool {
+	return e.StatusCode >= 500
 }
 
 // Do performs an HTTP request with the given method, endpoint, and body

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -1,4 +1,3 @@
-// Package http provides a common HTTP client with standardized headers and error handling
 package http
 
 import (
@@ -195,21 +194,4 @@ func (c *Client) Do(ctx context.Context, method, endpoint string, body interface
 	}
 
 	return nil
-}
-
-// ErrorResponse represents an error response from the API
-type ErrorResponse struct {
-	StatusCode int
-	Status     string
-	URL        string
-	Body       []byte
-}
-
-// Error implements the error interface
-func (e *ErrorResponse) Error() string {
-	msg := fmt.Sprintf("HTTP request failed: %d %s (%s)", e.StatusCode, e.Status, e.URL)
-	if len(e.Body) > 0 {
-		msg += fmt.Sprintf(": %s", e.Body)
-	}
-	return msg
 }

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -3,10 +3,8 @@ package build
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -58,7 +56,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 			tokenScopes := f.Config.GetTokenScopes()
 			if len(tokenScopes) == 0 {
 				return bkErrors.NewAuthenticationError(
-					nil, 
+					nil,
 					"no scopes found in token",
 					"Please ensure you're using a token with appropriate scopes",
 					"Run 'bk configure' to update your API token",
@@ -68,7 +66,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 			// Validate the scopes
 			if err := scopes.ValidateScopes(cmdScopes, tokenScopes); err != nil {
 				return bkErrors.NewPermissionDeniedError(
-					err, 
+					err,
 					"insufficient token permissions",
 					"Your API token needs the 'write_builds' scope to create builds",
 					"Create a new token with the required permissions in your Buildkite account settings",
@@ -90,7 +88,7 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 			}
 			if resolvedPipeline == nil {
 				return bkErrors.NewResourceNotFoundError(
-					nil, 
+					nil,
 					"could not resolve a pipeline",
 					"Specify a pipeline with --pipeline (-p)",
 					"Run 'bk pipeline list' to see available pipelines",
@@ -108,37 +106,37 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 					key, value, _ := strings.Cut(e, "=")
 					envMap[key] = value
 				}
-				
+
 				// Process environment file if specified
 				if envFile != "" {
 					file, err := os.Open(envFile)
 					if err != nil {
 						return bkErrors.NewValidationError(
-							err, 
+							err,
 							fmt.Sprintf("could not open environment file: %s", envFile),
 							"Check that the file exists and is readable",
 						)
 					}
 					defer file.Close()
-					
+
 					content := bufio.NewScanner(file)
 					for content.Scan() {
 						key, value, _ := strings.Cut(content.Text(), "=")
 						envMap[key] = value
 					}
-					
+
 					if err := content.Err(); err != nil {
 						return bkErrors.NewValidationError(
-							err, 
+							err,
 							"error reading environment file",
 							"Ensure the file contains valid environment variables in KEY=VALUE format",
 						)
 					}
 				}
-				
+
 				return newBuild(cmd.Context(), resolvedPipeline.Org, resolvedPipeline.Name, f, message, commit, branch, web, envMap, ignoreBranchFilters)
-			} 
-			
+			}
+
 			return nil // User chose not to proceed
 		}),
 	}
@@ -182,7 +180,7 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 				// Check if the pipeline has a default branch set
 				if p.DefaultBranch == "" {
 					actionErr = bkErrors.NewValidationError(
-						nil, 
+						nil,
 						fmt.Sprintf("No default branch set for pipeline %s", pipeline),
 						"Please specify a branch using --branch (-b)",
 						"Set a default branch in your pipeline settings on Buildkite",
@@ -218,7 +216,7 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 
 	if build.WebURL == "" {
 		return bkErrors.NewAPIError(
-			nil, 
+			nil,
 			"build was created but no URL was returned",
 			"This may be due to an API version mismatch",
 		)
@@ -229,7 +227,7 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 	if err := util.OpenInWebBrowser(web, build.WebURL); err != nil {
 		return bkErrors.NewInternalError(err, "failed to open web browser")
 	}
-	
+
 	return nil
 }
 

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -3,11 +3,14 @@ package build
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	"github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/internal/util"
@@ -47,65 +50,97 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 			$ bk build new -e "FOO=BAR" -e "BAR=BAZ"
 
 		`),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: bkErrors.WrapRunE(func(cmd *cobra.Command, args []string) error {
 			// Get the command's required and optional scopes
 			cmdScopes := scopes.GetCommandScopes(cmd)
 
 			// Get the token scopes from the factory
 			tokenScopes := f.Config.GetTokenScopes()
 			if len(tokenScopes) == 0 {
-				return fmt.Errorf("no scopes found in token. Please ensure you're using a token with appropriate scopes")
+				return bkErrors.NewAuthenticationError(
+					nil, 
+					"no scopes found in token",
+					"Please ensure you're using a token with appropriate scopes",
+					"Run 'bk configure' to update your API token",
+				)
 			}
 
 			// Validate the scopes
 			if err := scopes.ValidateScopes(cmdScopes, tokenScopes); err != nil {
-				return err
+				return bkErrors.NewPermissionDeniedError(
+					err, 
+					"insufficient token permissions",
+					"Your API token needs the 'write_builds' scope to create builds",
+					"Create a new token with the required permissions in your Buildkite account settings",
+				)
 			}
 
 			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		}),
+		RunE: bkErrors.WrapRunE(func(cmd *cobra.Command, args []string) error {
 			resolvers := resolver.NewAggregateResolver(
 				resolver.ResolveFromFlag(pipeline, f.Config),
 				resolver.ResolveFromConfig(f.Config, resolver.PickOne),
 				resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOne)),
 			)
 
-			pipeline, err := resolvers.Resolve(cmd.Context())
+			resolvedPipeline, err := resolvers.Resolve(cmd.Context())
 			if err != nil {
-				return err
+				return err // Already wrapped by resolver
 			}
-			if pipeline == nil {
-				return fmt.Errorf("could not resolve a pipeline")
+			if resolvedPipeline == nil {
+				return bkErrors.NewResourceNotFoundError(
+					nil, 
+					"could not resolve a pipeline",
+					"Specify a pipeline with --pipeline (-p)",
+					"Run 'bk pipeline list' to see available pipelines",
+				)
 			}
 
-			err = io.Confirm(&confirmed, fmt.Sprintf("Create new build on %s?", pipeline.Name))
+			err = io.Confirm(&confirmed, fmt.Sprintf("Create new build on %s?", resolvedPipeline.Name))
 			if err != nil {
-				return err
+				return bkErrors.NewUserAbortedError(err, "confirmation canceled")
 			}
 
 			if confirmed {
+				// Process environment variables
 				for _, e := range env {
 					key, value, _ := strings.Cut(e, "=")
 					envMap[key] = value
 				}
+				
+				// Process environment file if specified
 				if envFile != "" {
 					file, err := os.Open(envFile)
 					if err != nil {
-						return err
+						return bkErrors.NewValidationError(
+							err, 
+							fmt.Sprintf("could not open environment file: %s", envFile),
+							"Check that the file exists and is readable",
+						)
 					}
 					defer file.Close()
+					
 					content := bufio.NewScanner(file)
 					for content.Scan() {
 						key, value, _ := strings.Cut(content.Text(), "=")
 						envMap[key] = value
 					}
+					
+					if err := content.Err(); err != nil {
+						return bkErrors.NewValidationError(
+							err, 
+							"error reading environment file",
+							"Ensure the file contains valid environment variables in KEY=VALUE format",
+						)
+					}
 				}
-				return newBuild(cmd.Context(), pipeline.Org, pipeline.Name, f, message, commit, branch, web, envMap, ignoreBranchFilters)
-			} else {
-				return nil
-			}
-		},
+				
+				return newBuild(cmd.Context(), resolvedPipeline.Org, resolvedPipeline.Name, f, message, commit, branch, web, envMap, ignoreBranchFilters)
+			} 
+			
+			return nil // User chose not to proceed
+		}),
 	}
 
 	cmd.Annotations = map[string]string{
@@ -140,13 +175,18 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 			if len(branch) == 0 {
 				p, _, err := f.RestAPIClient.Pipelines.Get(ctx, org, pipeline)
 				if err != nil {
-					actionErr = fmt.Errorf("Error getting pipeline: %w", err)
+					actionErr = bkErrors.WrapAPIError(err, "fetching pipeline information")
 					return
 				}
 
 				// Check if the pipeline has a default branch set
 				if p.DefaultBranch == "" {
-					actionErr = fmt.Errorf("No default branch set for pipeline %s. Please specify a branch using --branch (-b)", pipeline)
+					actionErr = bkErrors.NewValidationError(
+						nil, 
+						fmt.Sprintf("No default branch set for pipeline %s", pipeline),
+						"Please specify a branch using --branch (-b)",
+						"Set a default branch in your pipeline settings on Buildkite",
+					)
 					return
 				}
 				branch = p.DefaultBranch
@@ -163,13 +203,13 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 			var err error
 			build, _, err = f.RestAPIClient.Builds.Create(ctx, org, pipeline, newBuild)
 			if err != nil {
-				actionErr = fmt.Errorf("Error creating build: %w", err)
+				actionErr = bkErrors.WrapAPIError(err, "creating build")
 				return
 			}
 		}).
 		Run()
 	if spinErr != nil {
-		return spinErr
+		return bkErrors.NewInternalError(spinErr, "error in spinner UI")
 	}
 
 	if actionErr != nil {
@@ -177,12 +217,20 @@ func newBuild(ctx context.Context, org string, pipeline string, f *factory.Facto
 	}
 
 	if build.WebURL == "" {
-		return fmt.Errorf("no build was created")
+		return bkErrors.NewAPIError(
+			nil, 
+			"build was created but no URL was returned",
+			"This may be due to an API version mismatch",
+		)
 	}
 
 	fmt.Printf("%s\n", renderResult(fmt.Sprintf("Build created: %s", build.WebURL)))
 
-	return util.OpenInWebBrowser(web, build.WebURL)
+	if err := util.OpenInWebBrowser(web, build.WebURL); err != nil {
+		return bkErrors.NewInternalError(err, "failed to open web browser")
+	}
+	
+	return nil
 }
 
 func normaliseFlags(pf *pflag.FlagSet, name string) pflag.NormalizedName {

--- a/pkg/cmd/build/new.go
+++ b/pkg/cmd/build/new.go
@@ -135,9 +135,11 @@ func NewCmdBuildNew(f *factory.Factory) *cobra.Command {
 				}
 
 				return newBuild(cmd.Context(), resolvedPipeline.Org, resolvedPipeline.Name, f, message, commit, branch, web, envMap, ignoreBranchFilters)
+			} else {
+				// User chose not to proceed - provide feedback
+				fmt.Fprintf(cmd.OutOrStdout(), "Build creation canceled\n")
+				return nil
 			}
-
-			return nil // User chose not to proceed
 		}),
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -7,7 +7,6 @@ import (
 	agentCmd "github.com/buildkite/cli/v3/pkg/cmd/agent"
 	apiCmd "github.com/buildkite/cli/v3/pkg/cmd/api"
 	artifactsCmd "github.com/buildkite/cli/v3/pkg/cmd/artifacts"
-	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	buildCmd "github.com/buildkite/cli/v3/pkg/cmd/build"
 	clusterCmd "github.com/buildkite/cli/v3/pkg/cmd/cluster"
 	configureCmd "github.com/buildkite/cli/v3/pkg/cmd/configure"

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	agentCmd "github.com/buildkite/cli/v3/pkg/cmd/agent"
 	apiCmd "github.com/buildkite/cli/v3/pkg/cmd/api"
 	artifactsCmd "github.com/buildkite/cli/v3/pkg/cmd/artifacts"
+	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	buildCmd "github.com/buildkite/cli/v3/pkg/cmd/build"
 	clusterCmd "github.com/buildkite/cli/v3/pkg/cmd/cluster"
 	configureCmd "github.com/buildkite/cli/v3/pkg/cmd/configure"
@@ -23,6 +24,8 @@ import (
 )
 
 func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
+	var verbose bool
+
 	cmd := &cobra.Command{
 		Use:          "bk <command> <subcommand> [flags]",
 		Short:        "Buildkite CLI",
@@ -43,6 +46,11 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 			// If --version flag is not used, show help
 			_ = cmd.Help()
 		},
+		// This function will run after command execution and handle any errors
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// This will be overridden by ExecuteWithErrorHandling
+			return nil
+		},
 	}
 
 	cmd.AddCommand(agentCmd.NewCmdAgent(f))
@@ -61,6 +69,7 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 	cmd.AddCommand(versionCmd.NewCmdVersion(f))
 
 	cmd.Flags().BoolP("version", "v", false, "Print the version number")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false, "Enable verbose error output")
 
 	return cmd, nil
 }


### PR DESCRIPTION
# Better error handling in the CLI

Currently the CLI exits with API errors, no colour and a general lack of context.

## Changes
- Implements an internal `errors` package
- Wraps our `main` function in that package so we can have nicer error output
- We can add tips to our errors to better help the user
- We use terminal colours for more visual hints (errors are red)

![CleanShot 2025-03-03 at 11 43 22](https://github.com/user-attachments/assets/ebf5cc18-d507-4b19-9307-d446524ed9f3)

## Testing
- There are a lot of tests for this already, but feel free to test locally
