### PR TITLE
Add a testutil package

### DIFF
--- a/internal/pipeline/resolver/cli_test.go
+++ b/internal/pipeline/resolver/cli_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/internal/testutil"
 	"github.com/spf13/afero"
 )
 
@@ -41,15 +42,10 @@ func TestParsePipelineArg(t *testing.T) {
 			conf.SelectOrganization("testing")
 			f := resolver.ResolveFromPositionalArgument([]string{testcase.url}, 0, conf)
 			pipeline, err := f(context.Background())
-			if err != nil {
-				t.Error(err)
-			}
-			if pipeline.Org != testcase.org {
-				t.Error("parsed organization slug did not match expected")
-			}
-			if pipeline.Name != testcase.pipeline {
-				t.Error("parsed pipeline name did not match expected")
-			}
+
+			testutil.AssertNoError(t, err)
+			testutil.AssertEqual(t, pipeline.Org, testcase.org, "organization slug")
+			testutil.AssertEqual(t, pipeline.Name, testcase.pipeline, "pipeline name")
 		})
 	}
 
@@ -60,11 +56,8 @@ func TestParsePipelineArg(t *testing.T) {
 		conf.SelectOrganization("testing")
 		f := resolver.ResolveFromPositionalArgument([]string{"https://buildkite.com/"}, 0, conf)
 		pipeline, err := f(context.Background())
-		if err == nil {
-			t.Error("Should have failed parsing pipeline")
-		}
-		if pipeline != nil {
-			t.Error("No pipeline should be returned")
-		}
+
+		testutil.AssertEqual(t, err != nil, true, "expected error")
+		testutil.AssertEqual(t, pipeline == nil, true, "expected nil pipeline")
 	})
 }

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -1,15 +1,9 @@
 package resolver
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/buildkite/cli/v3/internal/config"
-	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	"github.com/buildkite/go-buildkite/v4"
-	"github.com/go-git/go-git/v5"
-	"github.com/spf13/afero"
+	"github.com/buildkite/cli/v3/internal/testutil"
 )
 
 func TestResolvePipelinesFromPath(t *testing.T) {
@@ -18,105 +12,56 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 	t.Run("no pipelines found", func(t *testing.T) {
 		t.Parallel()
 		// mock a response that doesn't match the current repository url
-		s := mockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
+		s := testutil.MockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/test.git"}]`)
 		t.Cleanup(s.Close)
 
-		f := testFactory(t, s.URL, "testOrg", testRepository())
+		f := testutil.CreateFactory(t, s.URL, "testOrg", testutil.GitRepository())
 		pipelines, err := resolveFromRepository(f)
-		if err != nil {
-			t.Errorf("Error: %s", err)
-		}
-		if len(pipelines) != 0 {
-			t.Errorf("Expected 0 pipeline, got %d", len(pipelines))
-		}
+		testutil.AssertNoError(t, err)
+		testutil.AssertEqual(t, len(pipelines), 0, "Number of pipelines")
 	})
 
 	t.Run("one pipeline", func(t *testing.T) {
 		t.Parallel()
 		// mock an http client response with a single pipeline matching the current repo url
-		s := mockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)
+		s := testutil.MockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}]`)
 		t.Cleanup(s.Close)
 
-		f := testFactory(t, s.URL, "testOrg", testRepository())
+		f := testutil.CreateFactory(t, s.URL, "testOrg", testutil.GitRepository())
 		pipelines, err := resolveFromRepository(f)
-		if err != nil {
-			t.Errorf("Error: %s", err)
-		}
-		if len(pipelines) != 1 {
-			t.Errorf("Expected 1 pipeline, got %d", len(pipelines))
-		}
+		testutil.AssertNoError(t, err)
+		testutil.AssertEqual(t, len(pipelines), 1, "Number of pipelines")
 	})
 
 	t.Run("multiple pipelines", func(t *testing.T) {
 		t.Parallel()
 		// mock an http client response with 2 pipelines matching the current repo url
-		s := mockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}, {"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)
+		s := testutil.MockHTTPServer(`[{"slug": "my-pipeline", "repository": "git@github.com:buildkite/cli.git"}, {"slug": "my-pipeline-2", "repository": "git@github.com:buildkite/cli.git"}]`)
 		t.Cleanup(s.Close)
 
-		f := testFactory(t, s.URL, "testOrg", testRepository())
+		f := testutil.CreateFactory(t, s.URL, "testOrg", testutil.GitRepository())
 		pipelines, err := resolveFromRepository(f)
-		if err != nil {
-			t.Errorf("Error: %s", err)
-		}
-		if len(pipelines) != 2 {
-			t.Errorf("Expected 2 pipeline, got %d", len(pipelines))
-		}
+		testutil.AssertNoError(t, err)
+		testutil.AssertEqual(t, len(pipelines), 2, "Number of pipelines")
 	})
 
 	t.Run("no repository found", func(t *testing.T) {
-		s := mockHTTPServer(`[{"slug": "", "repository": ""}]`)
+		s := testutil.MockHTTPServer(`[{"slug": "", "repository": ""}]`)
 		t.Cleanup(s.Close)
 
-		f := testFactory(t, s.URL, "testOrg", nil)
+		f := testutil.CreateFactory(t, s.URL, "testOrg", nil)
 		pipelines, err := resolveFromRepository(f)
-		if pipelines != nil {
-			t.Errorf("Expected nil, got %v", pipelines)
-		}
-		if err != nil {
-			t.Errorf("Expected nil, got error: %s", err)
-		}
+		testutil.AssertEqual(t, pipelines == nil, true, "Expected nil pipelines")
+		testutil.AssertNoError(t, err)
 	})
 
 	t.Run("no remote repository found", func(t *testing.T) {
-		s := mockHTTPServer(`[{"slug": "", "repository": ""}]`)
+		s := testutil.MockHTTPServer(`[{"slug": "", "repository": ""}]`)
 		t.Cleanup(s.Close)
 
-		f := testFactory(t, s.URL, "testOrg", testRepository())
+		f := testutil.CreateFactory(t, s.URL, "testOrg", testutil.GitRepository())
 		pipelines, err := resolveFromRepository(f)
-		if pipelines != nil {
-			t.Errorf("Expected nil, got %v", pipelines)
-		}
-		if err != nil {
-			t.Errorf("Expected nil, got error: %s", err)
-		}
+		testutil.AssertEqual(t, pipelines == nil, true, "Expected nil pipelines")
+		testutil.AssertNoError(t, err)
 	})
-}
-
-func testRepository() *git.Repository {
-	repo, _ := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
-	return repo
-}
-
-func testFactory(t *testing.T, serverURL string, org string, repo *git.Repository) *factory.Factory {
-	t.Helper()
-
-	bkClient, err := buildkite.NewOpts(buildkite.WithBaseURL(serverURL))
-	if err != nil {
-		t.Errorf("Error creating buildkite client: %s", err)
-	}
-
-	conf := config.New(afero.NewMemMapFs(), nil)
-	conf.SelectOrganization(org)
-	return &factory.Factory{
-		Config:        conf,
-		RestAPIClient: bkClient,
-		GitRepository: repo,
-	}
-}
-
-func mockHTTPServer(response string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
-	}))
 }

--- a/internal/testutil/README.md
+++ b/internal/testutil/README.md
@@ -1,0 +1,95 @@
+# Test Utilities
+
+This package provides reusable test helpers for the CLI, allowing for more consistent and easier testing across the codebase.
+
+## Overview
+
+The test utilities are organized into several categories:
+
+1. **Factory Helpers** - `factory.go`
+   - Create test factories for common test scenarios
+
+2. **HTTP Server Mocks** - `http.go`
+   - Mock HTTP servers for testing API interactions
+
+3. **Command Testing** - `command.go`
+   - Utilities for testing Cobra commands
+
+4. **TUI Testing** - `tea.go`
+   - Utilities for testing Bubble Tea TUI components
+
+5. **Assertions** - `assert.go`
+   - Common assertion helpers
+
+## Usage Examples
+
+### Creating a Test Factory
+
+```go
+// Create a test factory with a mock HTTP server
+s := testutil.MockHTTPServer(`[{"slug": "my-pipeline"}]`)
+defer s.Close()
+
+f := testutil.CreateFactory(t, s.URL, "testOrg", testutil.GitRepository())
+```
+
+### Testing Command Execution
+
+```go
+// Create and execute a test command
+cmd, err := testutil.CreateCommand(t, testutil.CommandInput{
+    TestServerURL: server.URL,
+    Flags:         map[string]string{"flag": "value"},
+    Args:          []string{"arg1", "arg2"},
+    NewCmd:        pkg.NewCommand,
+})
+
+err = cmd.Execute()
+testutil.AssertNoError(t, err)
+```
+
+### Testing TUI Components
+
+```go
+// Test simple TUI output
+model := NewModel()
+testutil.AssertTeaOutput(t, model, "Expected output")
+
+// Test complex TUI interactions
+opts := testutil.DefaultTeaTestOptions()
+testModel := teatest.NewTestModel(t, model)
+testutil.TestTeaModel(t, model, "Initial output", opts)
+
+// Send events
+testModel.Send(someEvent)
+
+// Wait for output
+teatest.WaitFor(t, testModel.Output(), func(bts []byte) bool {
+    return testutil.Contains(bts, "Expected output after event")
+})
+```
+
+### Using Assertions
+
+```go
+// Assert no error
+testutil.AssertNoError(t, err)
+
+// Assert error contains text
+testutil.AssertErrorContains(t, err, "expected message")
+
+// Assert error type
+testutil.AssertErrorIs(t, err, ErrExpectedError)
+
+// Assert equality
+testutil.AssertEqual(t, result, expected, "Result value")
+```
+
+## Contributing
+
+When adding new test helpers:
+
+1. Place them in the appropriate file based on their function
+2. Add comprehensive documentation
+3. Follow existing patterns for consistency
+4. Consider writing tests for complex helpers

--- a/internal/testutil/assert.go
+++ b/internal/testutil/assert.go
@@ -1,0 +1,53 @@
+package testutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// AssertErrorContains checks if an error contains expected text
+func AssertErrorContains(t *testing.T, err error, expected string) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("Expected an error containing %q, but got nil", expected)
+		return
+	}
+
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected error to contain %q, got %q", expected, err.Error())
+	}
+}
+
+// AssertErrorIs checks if an error matches the expected error
+func AssertErrorIs(t *testing.T, err error, expected error) {
+	t.Helper()
+
+	if err == nil {
+		t.Errorf("Expected an error of type %v, but got nil", expected)
+		return
+	}
+
+	if !errors.Is(err, expected) {
+		t.Errorf("Expected error of type %v, got %v", expected, err)
+	}
+}
+
+// AssertEqual checks if two values are equal
+func AssertEqual[T comparable](t *testing.T, actual, expected T, message string) {
+	t.Helper()
+
+	if actual != expected {
+		t.Errorf("%s: expected %v, got %v", message, expected, actual)
+	}
+}
+
+// AssertNoError asserts that no error was returned
+func AssertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+}

--- a/internal/testutil/command.go
+++ b/internal/testutil/command.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"io"
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+// CommandInput contains the configuration for a test command
+type CommandInput struct {
+	TestServerURL string
+	Flags         map[string]string
+	Args          []string
+	Stdin         io.Reader
+	Factory       *factory.Factory
+	NewCmd        func(*factory.Factory) *cobra.Command
+}
+
+// CreateCommand creates a test command with the given configuration
+func CreateCommand(t *testing.T, input CommandInput) (*cobra.Command, error) {
+	t.Helper()
+
+	if input.Factory == nil {
+		// Create default factory if none provided
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(input.TestServerURL))
+		if err != nil {
+			return nil, err
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test")
+
+		input.Factory = &factory.Factory{Config: conf, RestAPIClient: client}
+	}
+
+	cmd := input.NewCmd(input.Factory)
+
+	args := []string{}
+	for k, v := range input.Flags {
+		args = append(args, "--"+k, v)
+	}
+
+	args = append(args, input.Args...)
+	cmd.SetArgs(args)
+
+	if input.Stdin != nil {
+		cmd.SetIn(input.Stdin)
+	}
+
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	return cmd, nil
+}

--- a/internal/testutil/command.go
+++ b/internal/testutil/command.go
@@ -33,7 +33,10 @@ func CreateCommand(t *testing.T, input CommandInput) (*cobra.Command, error) {
 		}
 
 		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SelectOrganization("test")
+		err = conf.SelectOrganization("test")
+		if err != nil {
+			t.Errorf("Error selecting organization: %s", err)
+		}
 
 		input.Factory = &factory.Factory{Config: conf, RestAPIClient: client}
 	}

--- a/internal/testutil/factory.go
+++ b/internal/testutil/factory.go
@@ -21,7 +21,10 @@ func CreateFactory(t *testing.T, serverURL, org string, repo *git.Repository) *f
 	}
 
 	conf := config.New(afero.NewMemMapFs(), nil)
-	conf.SelectOrganization(org)
+	err = conf.SelectOrganization(org)
+	if err != nil {
+		t.Errorf("Error selecting organization: %s", err)
+	}
 	return &factory.Factory{
 		Config:        conf,
 		RestAPIClient: bkClient,

--- a/internal/testutil/factory.go
+++ b/internal/testutil/factory.go
@@ -1,0 +1,36 @@
+// Package testutil provides reusable test helpers for the CLI
+package testutil
+
+import (
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/afero"
+)
+
+// CreateFactory creates a Factory with a mock configuration and API client
+func CreateFactory(t *testing.T, serverURL, org string, repo *git.Repository) *factory.Factory {
+	t.Helper()
+
+	bkClient, err := buildkite.NewOpts(buildkite.WithBaseURL(serverURL))
+	if err != nil {
+		t.Errorf("Error creating buildkite client: %s", err)
+	}
+
+	conf := config.New(afero.NewMemMapFs(), nil)
+	conf.SelectOrganization(org)
+	return &factory.Factory{
+		Config:        conf,
+		RestAPIClient: bkClient,
+		GitRepository: repo,
+	}
+}
+
+// GitRepository creates a test git repository
+func GitRepository() *git.Repository {
+	repo, _ := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: true})
+	return repo
+}

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
 )
@@ -9,7 +10,10 @@ import (
 func MockHTTPServer(response string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			log.Fatalf("error writing response: %v", err)
+		}
 	}))
 }
 

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// MockHTTPServer creates a test HTTP server that returns the specified response
+func MockHTTPServer(response string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+}
+
+// MockHTTPServerWithHandler creates a test HTTP server with a custom handler
+func MockHTTPServerWithHandler(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}

--- a/internal/testutil/tea.go
+++ b/internal/testutil/tea.go
@@ -1,0 +1,58 @@
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+// TeaTestOptions contains configuration options for testing tea models
+type TeaTestOptions struct {
+	Timeout time.Duration
+}
+
+// DefaultTeaTestOptions provides default options for testing tea models
+func DefaultTeaTestOptions() TeaTestOptions {
+	return TeaTestOptions{
+		Timeout: time.Second,
+	}
+}
+
+// TestTeaModel creates a test model and runs common assertions
+func TestTeaModel(t *testing.T, model tea.Model, expected string, opts TeaTestOptions) {
+	t.Helper()
+
+	testModel := teatest.NewTestModel(t, model)
+
+	// Wait for expected output
+	teatest.WaitFor(t, testModel.Output(), func(bts []byte) bool {
+		return bytes.Contains(bts, []byte(expected))
+	})
+
+	// Wait for model to finish with timeout
+	testModel.WaitFinished(t, teatest.WithFinalTimeout(opts.Timeout))
+}
+
+// AssertTeaOutput creates a test model and asserts that the final output contains the expected string
+func AssertTeaOutput(t *testing.T, model tea.Model, expected string) {
+	t.Helper()
+
+	testModel := teatest.NewTestModel(t, model)
+	out, err := io.ReadAll(testModel.FinalOutput(t))
+	if err != nil {
+		t.Errorf("Failed to get stdout: %v", err)
+	}
+
+	if !bytes.Contains(out, []byte(expected)) {
+		t.Errorf("Expected output to contain %q, got %q", expected, out)
+	}
+}
+
+// Contains checks if a byte slice contains a string
+func Contains(bts []byte, s string) bool {
+	return bytes.Contains(bts, []byte(s))
+}


### PR DESCRIPTION
# Implement a `testutil` package

Currently we replicate setup code across a few packages/commands, eg.

- internal/pipeline/resolver/repository_test.go
- internal/pipeline/resolver/cli_test.go 
- internal/agent/stoppable_test.go
- pkg/cmd/pkg/push_test.go

These all use some kind of generic set up, but they don't need to.

## Changes

This PR introduces a `testutil` package to our `/internal` directory, for use with tests.

We can use this in both `/internal` and `/pkg` files (note the `pkg/push_test.go` changes).

## Documentation

In the interest of making contributions to the CLI easier, we've added a `README` to this package to guide folks on how to best use it when creating tests, or when creating new utility files that we can use elsewhere.

## Testing

Our standard testing commands should still pass, functionality has been moved and improved, we shouldn't see any failures.

```bash
go test ./... -v
```
