### PR TITLE
Fix build download command required scopes

### DIFF
--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -102,7 +102,7 @@ func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
 	}
 
 	cmd.Annotations = map[string]string{
-		"requiredScopes": fmt.Sprint(string(scopes.ReadBuilds), string(scopes.ReadArtifacts), string(scopes.ReadBuildLogs)),
+		"requiredScopes": scopes.NewScopes(scopes.ReadBuilds, scopes.ReadArtifacts, scopes.ReadBuildLogs).String(),
 	}
 
 	cmd.Flags().BoolVarP(&mine, "mine", "m", false, "Filter builds to only my user.")


### PR DESCRIPTION
# Description

Hello, as I was trying to download the logs from one of my pipeline build, I encountered the following error:

```
❯ bk build download --pipeline my_pipeline build_number
Error: missing required scopes: read_buildsread_artifactsread_build_logs
```

After checking my token scopes and digging around, I found that the `"requiredScopes"` annotation of the `build download` command was missing the `,` separator.

As the fix was straightforward (and successfully downloaded my logs with this fix), I did not open any issue.
Let me know if you want me to add anything.