### PR TITLE
Fix use of TODO context

### DIFF
--- a/internal/build/resolver/options/options.go
+++ b/internal/build/resolver/options/options.go
@@ -58,13 +58,13 @@ func ResolveUserFromFlag(user string) OptionsFn {
 }
 
 // ResolveCurrentUser returns a function that is used to add a user filter to a build list options
-func ResolveCurrentUser(f *factory.Factory) OptionsFn {
+func ResolveCurrentUser(ctx context.Context, f *factory.Factory) OptionsFn {
 	return func(options *buildkite.BuildsListOptions) error {
 		// if creator filter already applied, dont apply another
 		if options.Creator != "" {
 			return nil
 		}
-		user, _, err := f.RestAPIClient.User.CurrentUser(context.TODO())
+		user, _, err := f.RestAPIClient.User.CurrentUser(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -33,7 +33,7 @@ func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.
 			}
 		}
 
-		builds, _, err := f.RestAPIClient.Builds.ListByPipeline(context.TODO(), f.Config.OrganizationSlug(), pipeline.Name, opts)
+		builds, _, err := f.RestAPIClient.Builds.ListByPipeline(ctx, f.Config.OrganizationSlug(), pipeline.Name, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -22,7 +22,7 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 		spinErr := spinner.New().
 			Title("Resolving pipeline").
 			Action(func() {
-				pipelines, err = resolveFromRepository(f)
+				pipelines, err = resolveFromRepository(ctx, f)
 			}).
 			Run()
 		if spinErr != nil {
@@ -43,15 +43,15 @@ func ResolveFromRepository(f *factory.Factory, picker PipelinePicker) PipelineRe
 	}
 }
 
-func resolveFromRepository(f *factory.Factory) ([]pipeline.Pipeline, error) {
+func resolveFromRepository(ctx context.Context, f *factory.Factory) ([]pipeline.Pipeline, error) {
 	repos, err := getRepoURLs(f.GitRepository)
 	if err != nil {
 		return nil, err
 	}
-	return filterPipelines(repos, f.Config.OrganizationSlug(), f.RestAPIClient)
+	return filterPipelines(ctx, repos, f.Config.OrganizationSlug(), f.RestAPIClient)
 }
 
-func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([]pipeline.Pipeline, error) {
+func filterPipelines(ctx context.Context, repoURLs []string, org string, client *buildkite.Client) ([]pipeline.Pipeline, error) {
 	var currentPipelines []pipeline.Pipeline
 	page := 1
 	per_page := 30
@@ -63,7 +63,7 @@ func filterPipelines(repoURLs []string, org string, client *buildkite.Client) ([
 			},
 		}
 
-		pipelines, resp, err := client.Pipelines.List(context.TODO(), org, &opts)
+		pipelines, resp, err := client.Pipelines.List(ctx, org, &opts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,7 @@ import (
 
 func TestResolvePipelinesFromPath(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	t.Run("no pipelines found", func(t *testing.T) {
 		t.Parallel()
@@ -22,7 +24,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		f := testFactory(t, s.URL, "testOrg", testRepository())
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -38,7 +40,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		f := testFactory(t, s.URL, "testOrg", testRepository())
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -54,7 +56,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		f := testFactory(t, s.URL, "testOrg", testRepository())
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if err != nil {
 			t.Errorf("Error: %s", err)
 		}
@@ -68,7 +70,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		f := testFactory(t, s.URL, "testOrg", nil)
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if pipelines != nil {
 			t.Errorf("Expected nil, got %v", pipelines)
 		}
@@ -82,7 +84,7 @@ func TestResolvePipelinesFromPath(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		f := testFactory(t, s.URL, "testOrg", testRepository())
-		pipelines, err := resolveFromRepository(f)
+		pipelines, err := resolveFromRepository(ctx, f)
 		if pipelines != nil {
 			t.Errorf("Expected nil, got %v", pipelines)
 		}

--- a/pkg/cmd/build/download.go
+++ b/pkg/cmd/build/download.go
@@ -68,7 +68,7 @@ func NewCmdBuildDownload(f *factory.Factory) *cobra.Command {
 				options.ResolveUserFromFlag(user),
 			).WithResolverWhen(
 				mine || user == "",
-				options.ResolveCurrentUser(f),
+				options.ResolveCurrentUser(cmd.Context(), f),
 			)
 			buildRes := buildResolver.NewAggregateResolver(
 				buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),

--- a/pkg/cmd/build/rebuild.go
+++ b/pkg/cmd/build/rebuild.go
@@ -70,7 +70,7 @@ func NewCmdBuildRebuild(f *factory.Factory) *cobra.Command {
 				options.ResolveUserFromFlag(user),
 			).WithResolverWhen(
 				mine || user == "",
-				options.ResolveCurrentUser(f),
+				options.ResolveCurrentUser(cmd.Context(), f),
 			)
 			buildRes := buildResolver.NewAggregateResolver(
 				buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),

--- a/pkg/cmd/build/view.go
+++ b/pkg/cmd/build/view.go
@@ -66,7 +66,7 @@ func NewCmdBuildView(f *factory.Factory) *cobra.Command {
 				options.ResolveUserFromFlag(user),
 			).WithResolverWhen(
 				mine || user == "",
-				options.ResolveCurrentUser(f),
+				options.ResolveCurrentUser(cmd.Context(), f),
 			)
 
 			// Resolve build


### PR DESCRIPTION
## Changes

We had a number of usages of `context.TODO()`, this fixes those by properly using the context from the command or the running function.
