### PR TITLE
SUP-4182: Add --author flag to bk build new command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # Changelog
 
 ## Unreleased
+- SUP-4182: Add --author flag to bk build new command by [[PR #510](https://github.com/buildkite/cli/pull/510)] @Mykematt
 - SUP-1693 Bind "s" to stop agent by [[PR #188](https://github.com/buildkite/cli/pull/188)] @jradtilbrook
 - SUP-1698: Keybind for viewing agent data within `bk agent list` by [[PR #192](https://github.com/buildkite/cli/pull/192)] @james2791
 - Fix runtime error introduced in SUP-1695 by [[PR #194](https://github.com/buildkite/cli/pull/194)] @lizrabuya


### PR DESCRIPTION
- Add --author/-a flag to allow specifying build author
- Pass author parameter through newBuild function
- Set Author.Name field in CreateBuild struct