### PR TITLE
Add whoami command

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,4 +1,4 @@
 # This uses the upstream image without any changes intentionally.
 # This allows dependabot to keep this version up-to-date for us automatically, since it does not work with
 # docker-compose directly
-FROM goreleaser/goreleaser-pro:v2.6.1-pro@sha256:4e5bb022b63f99880ec048b071b05e5e71a0187520d72ebb9cfc9d958b06a533
+FROM goreleaser/goreleaser-pro:v2.11.0-pro@sha256:6969d4cf07de22789fd9781ee2663fa79f4eed2c0d3422651a16e1e863fa3188

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/buildkite/cli/v3
 
-go 1.23.0
+go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.3
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/buildkite/go-buildkite/v4 v4.1.0
+	github.com/buildkite/go-buildkite/v4 v4.5.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/huh v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v4 v4.1.0 h1:n1f3EAe8/64ju9QjSWJYMjD8++mn1pOLK/tZscD5DKo=
-github.com/buildkite/go-buildkite/v4 v4.1.0/go.mod h1:xlYVIETMCk46KUkmfRoztoIf888KwdY5uZXNinZ1PX0=
+github.com/buildkite/go-buildkite/v4 v4.5.0 h1:Jxouc8M/2+a8VImUchgNC5nuGCNKqxRvU94Q4/E4EUU=
+github.com/buildkite/go-buildkite/v4 v4.5.0/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	useCmd "github.com/buildkite/cli/v3/pkg/cmd/use"
 	"github.com/buildkite/cli/v3/pkg/cmd/user"
 	versionCmd "github.com/buildkite/cli/v3/pkg/cmd/version"
+	"github.com/buildkite/cli/v3/pkg/cmd/whoami"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,7 @@ func NewCmdRoot(f *factory.Factory) (*cobra.Command, error) {
 	cmd.AddCommand(promptCmd.NewCmdPrompt(f))
 	cmd.AddCommand(useCmd.NewCmdUse(f))
 	cmd.AddCommand(user.CommandUser(f))
+	cmd.AddCommand(whoami.NewCmdWhoami(f))
 	cmd.AddCommand(versionCmd.NewCmdVersion(f))
 
 	cmd.Flags().BoolP("version", "v", false, "Print the version number")

--- a/pkg/cmd/whoami/whoami.go
+++ b/pkg/cmd/whoami/whoami.go
@@ -1,0 +1,77 @@
+package whoami
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/spf13/cobra"
+)
+
+const (
+	formatPlain = "plain"
+	formatJSON  = "json"
+)
+
+func NewCmdWhoami(f *factory.Factory) *cobra.Command {
+	output := "plain"
+
+	cmd := &cobra.Command{
+		Use:   "whoami",
+		Short: "Print the current user and organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !slices.Contains([]string{formatPlain, formatJSON}, output) {
+				return fmt.Errorf("invalid output: %s, must be one of: %s, %s", output, formatPlain, formatJSON)
+			}
+
+			orgSlug := f.Config.OrganizationSlug()
+			if orgSlug == "" {
+				orgSlug = "<None>"
+			}
+
+			token, _, err := f.RestAPIClient.AccessTokens.Get(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to get access token: %w", err)
+			}
+
+			if output == formatJSON {
+				type whoami struct {
+					OrganizationSlug string                `json:"organization_slug"`
+					Token            buildkite.AccessToken `json:"token"`
+				}
+
+				whoamiInfo := whoami{
+					OrganizationSlug: orgSlug,
+					Token:            token,
+				}
+
+				err := json.NewEncoder(cmd.OutOrStdout()).Encode(whoamiInfo)
+				if err != nil {
+					return fmt.Errorf("failed to encode whoami info to JSON: %w", err)
+				}
+
+				return nil
+			}
+
+			b := strings.Builder{}
+
+			b.WriteString(fmt.Sprintf("Current organization: %s\n", orgSlug))
+			b.WriteRune('\n')
+			b.WriteString(fmt.Sprintf("API Token Description: %s\n", token.Description))
+			b.WriteString(fmt.Sprintf("API Token Scopes: %v\n", token.Scopes))
+			b.WriteRune('\n')
+			b.WriteString(fmt.Sprintf("API Token user name: %s\n", token.User.Name))
+			b.WriteString(fmt.Sprintf("API Token user email: %s\n", token.User.Email))
+
+			fmt.Fprint(cmd.OutOrStdout(), b.String())
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&output, "output", "o", output, "Output format (plain (default) or json)")
+	return cmd
+}

--- a/pkg/cmd/whoami/whoami.go
+++ b/pkg/cmd/whoami/whoami.go
@@ -1,30 +1,43 @@
 package whoami
 
 import (
-	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/output"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/spf13/cobra"
 )
 
-const (
-	formatPlain = "plain"
-	formatJSON  = "json"
-)
+type whoamiOutput struct {
+	OrganizationSlug string                `json:"organization_slug"`
+	Token            buildkite.AccessToken `json:"token"`
+}
+
+func (w whoamiOutput) TextOutput() string {
+	b := strings.Builder{}
+
+	b.WriteString(fmt.Sprintf("Current organization: %s\n", w.OrganizationSlug))
+	b.WriteRune('\n')
+	b.WriteString(fmt.Sprintf("API Token UUID:        %s\n", w.Token.UUID))
+	b.WriteString(fmt.Sprintf("API Token Description: %s\n", w.Token.Description))
+	b.WriteString(fmt.Sprintf("API Token Scopes:      %v\n", w.Token.Scopes))
+	b.WriteRune('\n')
+	b.WriteString(fmt.Sprintf("API Token user name:  %s\n", w.Token.User.Name))
+	b.WriteString(fmt.Sprintf("API Token user email: %s\n", w.Token.User.Email))
+
+	return b.String()
+}
 
 func NewCmdWhoami(f *factory.Factory) *cobra.Command {
-	output := "plain"
-
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Print the current user and organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !slices.Contains([]string{formatPlain, formatJSON}, output) {
-				return fmt.Errorf("invalid output: %s, must be one of: %s, %s", output, formatPlain, formatJSON)
+			format, err := output.GetFormat(cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("failed to get output format: %w", err)
 			}
 
 			orgSlug := f.Config.OrganizationSlug()
@@ -37,41 +50,20 @@ func NewCmdWhoami(f *factory.Factory) *cobra.Command {
 				return fmt.Errorf("failed to get access token: %w", err)
 			}
 
-			if output == formatJSON {
-				type whoami struct {
-					OrganizationSlug string                `json:"organization_slug"`
-					Token            buildkite.AccessToken `json:"token"`
-				}
-
-				whoamiInfo := whoami{
-					OrganizationSlug: orgSlug,
-					Token:            token,
-				}
-
-				err := json.NewEncoder(cmd.OutOrStdout()).Encode(whoamiInfo)
-				if err != nil {
-					return fmt.Errorf("failed to encode whoami info to JSON: %w", err)
-				}
-
-				return nil
+			w := whoamiOutput{
+				OrganizationSlug: orgSlug,
+				Token:            token,
 			}
 
-			b := strings.Builder{}
-
-			b.WriteString(fmt.Sprintf("Current organization: %s\n", orgSlug))
-			b.WriteRune('\n')
-			b.WriteString(fmt.Sprintf("API Token Description: %s\n", token.Description))
-			b.WriteString(fmt.Sprintf("API Token Scopes: %v\n", token.Scopes))
-			b.WriteRune('\n')
-			b.WriteString(fmt.Sprintf("API Token user name: %s\n", token.User.Name))
-			b.WriteString(fmt.Sprintf("API Token user email: %s\n", token.User.Email))
-
-			fmt.Fprint(cmd.OutOrStdout(), b.String())
+			err = output.Write(cmd.OutOrStdout(), w, format)
+			if err != nil {
+				return fmt.Errorf("failed to write output: %w", err)
+			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVarP(&output, "output", "o", output, "Output format (plain (default) or json)")
+	output.AddFlags(cmd.Flags())
 	return cmd
 }


### PR DESCRIPTION
This PR adds a new command to the cli, `whoami`. It looks like this:
```
$ bk whoami
Current organization: a-real-test-org

API Token Description: Benno's Cool Token
API Token Scopes: [read_teams read_pipelines write_pipelines graphql]

API Token user name: Benno Moskovitz
API Token user email: ben.m@buildkite.com
```

it also has a JSON output mode:
```
$ bk whoami --output json
{
  "organization_slug": "a-real-test-org",
  "token": {
    "uuid": "00000000-0000-0000-0000-000000000000",
    "scopes": [
      "read_teams",
      "read_pipelines",
      "write_pipelines",
      "graphql"
    ],
    "description": "Benno's Cool Token",
    "created_at": "2022-05-20T02:09:18Z",
    "user": {
      "name": "Benno Moskovitz",
      "email": "ben.m@buildkite.com"
    }
  }
}
```

very happy to take notes on the output format -- it was basically just what first came into my head, i'm sure there are better ways to show this information.
