### PR TITLE
Add agent pause/resume and build list commands

### DIFF
--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   golangci-lint:
-    image: golangci/golangci-lint:v2.0.2
+    image: golangci/golangci-lint:v2.4.0
     working_dir: /app
     volumes:
       - ..:/app

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   golangci-lint:
-    image: golangci/golangci-lint:v2.4.0
+    image: golangci/golangci-lint:v2.0.2
     working_dir: /app
     volumes:
       - ..:/app

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/cli/v3
 
-go 1.25
+go 1.24
 
-toolchain go1.25.0
+toolchain go1.24.3
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/buildkite/cli/v3
 
-go 1.24
+go 1.25
 
-toolchain go1.24.3
+toolchain go1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/buildkite/go-buildkite/v4 v4.5.1
+	github.com/buildkite/go-buildkite/v4 v4.7.0
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v4 v4.5.1 h1:45Vgtua5PlZwaaHiI0i7Zz9icOS8PTHkW1YIetpf7Xs=
-github.com/buildkite/go-buildkite/v4 v4.5.1/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
+github.com/buildkite/go-buildkite/v4 v4.7.0 h1:/uYw/zhUyFZphwHCWOf3eAI70PvhvLcA51eIGmtdZbQ=
+github.com/buildkite/go-buildkite/v4 v4.7.0/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -17,11 +17,17 @@ func NewCmdAgent(f *factory.Factory) *cobra.Command {
 		Short: "Manage agents",
 		Long:  "Work with Buildkite agents.",
 		Example: heredoc.Doc(`
-			# To stop an agent
-			$ bk agent stop buildkite/018a2b90-ba7f-4220-94ca-4903fa0ba410
-			# To view agent details
-			$ bk agent view 018a2b90-ba7f-4220-94ca-4903fa0ba410
-		`),
+		       # To stop an agent
+		       $ bk agent stop 018a2b90-ba7f-4220-94ca-4903fa0ba410
+		       # To view agent details
+		       $ bk agent view 018a2b90-ba7f-4220-94ca-4903fa0ba410
+		       # To pause an agent
+		       $ bk agent pause 018a2b90-ba7f-4220-94ca-4903fa0ba410
+			   # To pause an agent with a note for a specific time-frame
+			   $ bk agent pause 018a2b90-ba7f-4220-94ca-4903fa0ba410 --note "too many llamas" --timeout-in-minutes 60
+		       # To resume an agent
+		       $ bk agent resume 018a2b90-ba7f-4220-94ca-4903fa0ba410
+	       `),
 		PersistentPreRunE: validation.CheckValidConfiguration(f.Config),
 		Annotations: map[string]string{
 			"help:arguments": heredoc.Doc(`
@@ -36,6 +42,8 @@ func NewCmdAgent(f *factory.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdAgentList(f))
 	cmd.AddCommand(NewCmdAgentStop(f))
 	cmd.AddCommand(NewCmdAgentView(f))
+	cmd.AddCommand(NewCmdAgentPause(f))
+	cmd.AddCommand(NewCmdAgentResume(f))
 
 	return &cmd
 }

--- a/pkg/cmd/agent/pause.go
+++ b/pkg/cmd/agent/pause.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+	"github.com/spf13/cobra"
+)
+
+type AgentPauseOptions struct {
+	note             string
+	timeoutInMinutes int
+	f                *factory.Factory
+}
+
+func NewCmdAgentPause(f *factory.Factory) *cobra.Command {
+	options := AgentPauseOptions{
+		f: f,
+	}
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "pause <agent-id>",
+		Args:                  cobra.ExactArgs(1),
+		Short:                 "Pause a Buildkite agent",
+		Long: heredoc.Doc(`
+			Pause a Buildkite agent with an optional note and timeout.
+
+			When an agent is paused, it will stop accepting new jobs but will continue
+			running any jobs it has already started. You can optionally provide a note
+			explaining why the agent is being paused and set a timeout for automatic resumption.
+		`),
+		Example: heredoc.Doc(`
+			# Pause an agent
+			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45
+
+			# Pause an agent with a note
+			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45 --note "Maintenance scheduled"
+
+			# Pause an agent with a note and 60 minute timeout
+			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45 --note "too many llamas" --timeout-in-minutes 60
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunPause(cmd, args, &options)
+		},
+	}
+
+	cmd.Flags().StringVar(&options.note, "note", "", "A descriptive note to record why the agent is paused")
+	cmd.Flags().IntVar(&options.timeoutInMinutes, "timeout-in-minutes", 0, "Timeout after which the agent is automatically resumed, in minutes (default: 0 = no timeout)")
+
+	return &cmd
+}
+
+func RunPause(cmd *cobra.Command, args []string, opts *AgentPauseOptions) error {
+	agentID := args[0]
+
+	var pauseOpts *buildkite.AgentPauseOptions
+	if opts.note != "" || opts.timeoutInMinutes > 0 {
+		pauseOpts = &buildkite.AgentPauseOptions{
+			Note:             opts.note,
+			TimeoutInMinutes: opts.timeoutInMinutes,
+		}
+	}
+
+	_, err := opts.f.RestAPIClient.Agents.Pause(cmd.Context(), opts.f.Config.OrganizationSlug(), agentID, pauseOpts)
+	if err != nil {
+		return fmt.Errorf("failed to pause agent: %w", err)
+	}
+
+	fmt.Printf("Agent %s paused successfully\n", agentID)
+	return nil
+}

--- a/pkg/cmd/agent/pause.go
+++ b/pkg/cmd/agent/pause.go
@@ -31,9 +31,12 @@ func NewCmdAgentPause(f *factory.Factory) *cobra.Command {
 			When an agent is paused, it will stop accepting new jobs but will continue
 			running any jobs it has already started. You can optionally provide a note
 			explaining why the agent is being paused and set a timeout for automatic resumption.
+
+			The timeout must be between 1 and 1440 minutes (24 hours). If no timeout is
+			specified, the agent will pause for 5 minutes by default.
 		`),
 		Example: heredoc.Doc(`
-			# Pause an agent
+			# Pause an agent for 5 minutes (default)
 			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45
 
 			# Pause an agent with a note
@@ -41,6 +44,9 @@ func NewCmdAgentPause(f *factory.Factory) *cobra.Command {
 
 			# Pause an agent with a note and 60 minute timeout
 			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45 --note "too many llamas" --timeout-in-minutes 60
+
+			# Pause for a short time (15 minutes) during deployment
+			$ bk agent pause 0198d108-a532-4a62-9bd7-b2e744bf5c45 --note "Deploy in progress" --timeout-in-minutes 15
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunPause(cmd, args, &options)

--- a/pkg/cmd/agent/pause.go
+++ b/pkg/cmd/agent/pause.go
@@ -69,6 +69,6 @@ func RunPause(cmd *cobra.Command, args []string, opts *AgentPauseOptions) error 
 		return fmt.Errorf("failed to pause agent: %w", err)
 	}
 
-	fmt.Printf("Agent %s paused successfully\n", agentID)
+	fmt.Fprintf(cmd.OutOrStdout(), "Agent %s paused successfully\n", agentID)
 	return nil
 }

--- a/pkg/cmd/agent/pause_test.go
+++ b/pkg/cmd/agent/pause_test.go
@@ -36,10 +36,9 @@ func TestCmdAgentPause(t *testing.T) {
 		t.Parallel()
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/v2/organizations/test/agents/123/pause" && r.Method == "PUT" {
+			if r.Method == "PUT" && strings.Contains(r.URL.Path, "/agents/123/pause") {
 				w.WriteHeader(http.StatusOK)
 			} else {
-				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
 				w.WriteHeader(http.StatusNotFound)
 			}
 		}))

--- a/pkg/cmd/agent/pause_test.go
+++ b/pkg/cmd/agent/pause_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -109,6 +110,93 @@ func TestCmdAgentPause(t *testing.T) {
 		want := "failed to pause agent"
 		if !strings.Contains(got, want) {
 			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+
+	t.Run("it validates negative timeout", func(t *testing.T) {
+		t.Parallel()
+
+		factory := &factory.Factory{}
+		cmd := agent.NewCmdAgentPause(factory)
+		cmd.SetArgs([]string{"123", "--timeout-in-minutes", "-1"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected validation error for negative timeout")
+		}
+
+		got := err.Error()
+		want := "timeout-in-minutes must be 1 or more"
+		if !strings.Contains(got, want) {
+			t.Errorf("Expected error message %q, got %q", want, got)
+		}
+	})
+
+	t.Run("it validates excessively large timeout", func(t *testing.T) {
+		t.Parallel()
+
+		factory := &factory.Factory{}
+		cmd := agent.NewCmdAgentPause(factory)
+		cmd.SetArgs([]string{"123", "--timeout-in-minutes", "1000000"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Error("Expected validation error for large timeout")
+		}
+
+		got := err.Error()
+		want := "timeout-in-minutes cannot exceed"
+		if !strings.Contains(got, want) {
+			t.Errorf("Expected error message containing %q, got %q", want, got)
+		}
+	})
+
+	t.Run("it handles pause with note and timeout", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "PUT" && strings.Contains(r.URL.Path, "/agents/123/pause") {
+				// Verify the request body contains note and timeout
+				body, _ := io.ReadAll(r.Body)
+				if !strings.Contains(string(body), `"note":"test note"`) ||
+					!strings.Contains(string(body), `"timeout_in_minutes":60`) {
+					t.Errorf("Request body missing expected fields: %s", string(body))
+				}
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test", true)
+
+		factory := &factory.Factory{
+			Config:        conf,
+			RestAPIClient: apiClient,
+		}
+
+		cmd := agent.NewCmdAgentPause(factory)
+		cmd.SetArgs([]string{"123", "--note", "test note", "--timeout-in-minutes", "60"})
+
+		var b bytes.Buffer
+		cmd.SetOut(&b)
+
+		err = cmd.Execute()
+		if err != nil {
+			t.Error(err)
+		}
+
+		got := b.String()
+		want := "Agent 123 paused successfully with note: test note (auto-resume in 60 minutes)"
+		if !strings.Contains(got, want) {
+			t.Errorf("Expected output %q, got %q", want, got)
 		}
 	})
 }

--- a/pkg/cmd/agent/pause_test.go
+++ b/pkg/cmd/agent/pause_test.go
@@ -1,0 +1,115 @@
+package agent_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/pkg/cmd/agent"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+	"github.com/spf13/afero"
+)
+
+func TestCmdAgentPause(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it reports an error when no agent supplied", func(t *testing.T) {
+		t.Parallel()
+
+		factory := &factory.Factory{}
+		cmd := agent.NewCmdAgentPause(factory)
+
+		err := cmd.Execute()
+
+		got := err.Error()
+		want := "accepts 1 arg"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+
+	t.Run("it handles successful pause", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/v2/organizations/test/agents/123/pause" && r.Method == "PUT" {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test", true)
+
+		factory := &factory.Factory{
+			Config:        conf,
+			RestAPIClient: apiClient,
+		}
+
+		cmd := agent.NewCmdAgentPause(factory)
+		cmd.SetArgs([]string{"123"})
+
+		var b bytes.Buffer
+		cmd.SetOut(&b)
+
+		err = cmd.Execute()
+		if err != nil {
+			t.Error(err)
+		}
+
+		got := b.String()
+		want := "Agent 123 paused successfully"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+
+	t.Run("it handles API error", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test", true)
+
+		factory := &factory.Factory{
+			Config:        conf,
+			RestAPIClient: apiClient,
+		}
+
+		cmd := agent.NewCmdAgentPause(factory)
+		cmd.SetArgs([]string{"123"})
+
+		var b bytes.Buffer
+		cmd.SetOut(&b)
+
+		err = cmd.Execute()
+		if err == nil {
+			t.Error("Expected to return an error")
+		}
+
+		got := err.Error()
+		want := "failed to pause agent"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+}

--- a/pkg/cmd/agent/resume.go
+++ b/pkg/cmd/agent/resume.go
@@ -47,6 +47,6 @@ func RunResume(cmd *cobra.Command, args []string, opts *AgentResumeOptions) erro
 		return fmt.Errorf("failed to resume agent: %w", err)
 	}
 
-	fmt.Printf("Agent %s resumed successfully\n", agentID)
+	fmt.Fprintf(cmd.OutOrStdout(), "Agent %s resumed successfully\n", agentID)
 	return nil
 }

--- a/pkg/cmd/agent/resume.go
+++ b/pkg/cmd/agent/resume.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/spf13/cobra"
+)
+
+type AgentResumeOptions struct {
+	f *factory.Factory
+}
+
+func NewCmdAgentResume(f *factory.Factory) *cobra.Command {
+	options := AgentResumeOptions{
+		f: f,
+	}
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "resume <agent-id>",
+		Args:                  cobra.ExactArgs(1),
+		Short:                 "Resume a Buildkite agent",
+		Long: heredoc.Doc(`
+			Resume a paused Buildkite agent.
+
+			When an agent is resumed, it will start accepting new jobs again.
+		`),
+		Example: heredoc.Doc(`
+			# Resume an agent
+			$ bk agent resume 0198d108-a532-4a62-9bd7-b2e744bf5c45
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunResume(cmd, args, &options)
+		},
+	}
+
+	return &cmd
+}
+
+func RunResume(cmd *cobra.Command, args []string, opts *AgentResumeOptions) error {
+	agentID := args[0]
+
+	_, err := opts.f.RestAPIClient.Agents.Resume(cmd.Context(), opts.f.Config.OrganizationSlug(), agentID)
+	if err != nil {
+		return fmt.Errorf("failed to resume agent: %w", err)
+	}
+
+	fmt.Printf("Agent %s resumed successfully\n", agentID)
+	return nil
+}

--- a/pkg/cmd/agent/resume_test.go
+++ b/pkg/cmd/agent/resume_test.go
@@ -36,10 +36,9 @@ func TestCmdAgentResume(t *testing.T) {
 		t.Parallel()
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/v2/organizations/test/agents/123/resume" && r.Method == "PUT" {
+			if r.Method == "PUT" && strings.Contains(r.URL.Path, "/agents/123/resume") {
 				w.WriteHeader(http.StatusOK)
 			} else {
-				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
 				w.WriteHeader(http.StatusNotFound)
 			}
 		}))

--- a/pkg/cmd/agent/resume_test.go
+++ b/pkg/cmd/agent/resume_test.go
@@ -1,0 +1,115 @@
+package agent_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/pkg/cmd/agent"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+	"github.com/spf13/afero"
+)
+
+func TestCmdAgentResume(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it reports an error when no agent supplied", func(t *testing.T) {
+		t.Parallel()
+
+		factory := &factory.Factory{}
+		cmd := agent.NewCmdAgentResume(factory)
+
+		err := cmd.Execute()
+
+		got := err.Error()
+		want := "accepts 1 arg"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+
+	t.Run("it handles successful resume", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/v2/organizations/test/agents/123/resume" && r.Method == "PUT" {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test", true)
+
+		factory := &factory.Factory{
+			Config:        conf,
+			RestAPIClient: apiClient,
+		}
+
+		cmd := agent.NewCmdAgentResume(factory)
+		cmd.SetArgs([]string{"123"})
+
+		var b bytes.Buffer
+		cmd.SetOut(&b)
+
+		err = cmd.Execute()
+		if err != nil {
+			t.Error(err)
+		}
+
+		got := b.String()
+		want := "Agent 123 resumed successfully"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+
+	t.Run("it handles API error", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		apiClient, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("test", true)
+
+		factory := &factory.Factory{
+			Config:        conf,
+			RestAPIClient: apiClient,
+		}
+
+		cmd := agent.NewCmdAgentResume(factory)
+		cmd.SetArgs([]string{"123"})
+
+		var b bytes.Buffer
+		cmd.SetOut(&b)
+
+		err = cmd.Execute()
+		if err == nil {
+			t.Error("Expected to return an error")
+		}
+
+		got := err.Error()
+		want := "failed to resume agent"
+		if !strings.Contains(got, want) {
+			t.Errorf("Output error did not contain expected string. %s != %s", got, want)
+		}
+	})
+}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -29,6 +29,7 @@ func NewCmdBuild(f *factory.Factory) *cobra.Command {
 
 	cmd.AddCommand(NewCmdBuildCancel(f))
 	cmd.AddCommand(NewCmdBuildDownload(f))
+	cmd.AddCommand(NewCmdBuildList(f))
 	cmd.AddCommand(NewCmdBuildNew(f))
 	cmd.AddCommand(NewCmdBuildRebuild(f))
 	cmd.AddCommand(NewCmdBuildView(f))

--- a/pkg/cmd/build/list.go
+++ b/pkg/cmd/build/list.go
@@ -1,0 +1,366 @@
+package build
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/buildkite/cli/v3/internal/io"
+	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/internal/validation/scopes"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+type buildListOptions struct {
+	pipeline string
+	since    string
+	until    string
+	duration string
+	state    []string
+	branch   []string
+	creator  string
+	commit   string
+	message  string
+	limit    int
+}
+
+func NewCmdBuildList(f *factory.Factory) *cobra.Command {
+	var opts buildListOptions
+
+	cmd := cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "list [flags]",
+		Short:                 "List builds",
+		Long: heredoc.Doc(`
+			List builds with optional filtering.
+		`),
+		Example: heredoc.Doc(`
+			# List recent builds
+			$ bk build list
+
+			# List builds from the last hour
+			$ bk build list --since 1h (s, m, h)
+
+			# List failed builds
+			$ bk build list --state failed
+
+			# List builds on main branch
+			$ bk build list --branch main
+
+			# List builds by alice
+			$ bk build list --creator alice@company.com
+
+			# List builds that took longer than 20 minutes
+			$ bk build list --duration ">20m"
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			cmdScopes := scopes.GetCommandScopes(cmd)
+			tokenScopes := f.Config.GetTokenScopes()
+			if len(tokenScopes) == 0 {
+				return fmt.Errorf("no scopes found in token. Please ensure you're using a token with appropriate scopes")
+			}
+
+			if err := scopes.ValidateScopes(cmdScopes, tokenScopes); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := output.GetFormat(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			listOpts, err := buildListOptionsFromFlags(&opts)
+			if err != nil {
+				return err
+			}
+
+			org := f.Config.OrganizationSlug()
+			var builds []buildkite.Build
+
+			if opts.pipeline != "" {
+				pipelineRes := pipelineResolver.NewAggregateResolver(
+					pipelineResolver.ResolveFromFlag(opts.pipeline, f.Config),
+					pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOne),
+				)
+
+				pipeline, err := pipelineRes.Resolve(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("failed to resolve pipeline: %w", err)
+				}
+
+				err = io.SpinWhile("Loading builds", func() {
+					builds, _, err = f.RestAPIClient.Builds.ListByPipeline(
+						cmd.Context(),
+						org,
+						pipeline.Name,
+						listOpts,
+					)
+				})
+				if err != nil {
+					return fmt.Errorf("failed to list builds: %w", err)
+				}
+			} else {
+				err = io.SpinWhile("Loading builds", func() {
+					builds, _, err = f.RestAPIClient.Builds.ListByOrg(cmd.Context(), org, listOpts)
+				})
+				if err != nil {
+					return fmt.Errorf("failed to list builds: %w", err)
+				}
+			}
+
+			if opts.duration != "" || opts.message != "" {
+				builds, err = applyClientSideFilters(builds, opts)
+				if err != nil {
+					return fmt.Errorf("failed to apply filters: %w", err)
+				}
+			}
+
+			if len(builds) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No builds found matching the specified criteria.")
+				return nil
+			}
+
+			return displayBuilds(cmd, builds, format)
+		},
+	}
+
+	cmd.Annotations = map[string]string{
+		"requiredScopes": string(scopes.ReadBuilds),
+	}
+
+	cmd.Flags().StringVarP(&opts.pipeline, "pipeline", "p", "", "Filter by pipeline slug")
+	cmd.Flags().StringVar(&opts.since, "since", "", "Filter builds created since this time (e.g. 1h, 30m)")
+	cmd.Flags().StringVar(&opts.until, "until", "", "Filter builds created before this time (e.g. 1h, 30m)")
+	cmd.Flags().StringVar(&opts.duration, "duration", "", "Filter by duration (e.g. >5m, <10m, 20m)")
+	cmd.Flags().StringSliceVar(&opts.state, "state", []string{}, "Filter by build state")
+	cmd.Flags().StringSliceVar(&opts.branch, "branch", []string{}, "Filter by branch name")
+	cmd.Flags().StringVar(&opts.creator, "creator", "", "Filter by creator")
+	cmd.Flags().StringVar(&opts.commit, "commit", "", "Filter by commit SHA")
+	cmd.Flags().StringVar(&opts.message, "message", "", "Filter by message content")
+	cmd.Flags().IntVar(&opts.limit, "limit", 50, "Maximum number of builds to return")
+
+	output.AddFlags(cmd.Flags())
+	cmd.Flags().SortFlags = false
+
+	return &cmd
+}
+
+func buildListOptionsFromFlags(opts *buildListOptions) (*buildkite.BuildsListOptions, error) {
+	listOpts := &buildkite.BuildsListOptions{
+		ListOptions: buildkite.ListOptions{
+			PerPage: opts.limit,
+		},
+	}
+
+	if opts.since != "" {
+		duration, err := parseDuration(opts.since)
+		if err != nil {
+			return nil, fmt.Errorf("invalid since duration '%s': %w", opts.since, err)
+		}
+		listOpts.CreatedFrom = time.Now().Add(-duration)
+	}
+
+	if opts.until != "" {
+		duration, err := parseDuration(opts.until)
+		if err != nil {
+			return nil, fmt.Errorf("invalid until duration '%s': %w", opts.until, err)
+		}
+		listOpts.CreatedTo = time.Now().Add(-duration)
+	}
+
+	if len(opts.state) > 0 {
+		listOpts.State = opts.state
+	}
+
+	if len(opts.branch) > 0 {
+		listOpts.Branch = opts.branch
+	}
+
+	if opts.creator != "" {
+		listOpts.Creator = opts.creator
+	}
+
+	if opts.commit != "" {
+		listOpts.Commit = opts.commit
+	}
+
+	return listOpts, nil
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	return time.ParseDuration(s)
+}
+
+func applyClientSideFilters(builds []buildkite.Build, opts buildListOptions) ([]buildkite.Build, error) {
+	if opts.duration == "" && opts.message == "" {
+		return builds, nil
+	}
+
+	var durationFilter struct {
+		op       string
+		duration time.Duration
+	}
+
+	if opts.duration != "" {
+		op, durStr := ">= ", opts.duration
+		if strings.HasPrefix(opts.duration, "<") {
+			op, durStr = "<", opts.duration[1:]
+		} else if strings.HasPrefix(opts.duration, ">") {
+			op, durStr = ">", opts.duration[1:]
+		}
+
+		d, err := time.ParseDuration(durStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration format: %w", err)
+		}
+		durationFilter.op = op
+		durationFilter.duration = d
+	}
+
+	var messageFilter string
+	if opts.message != "" {
+		messageFilter = strings.ToLower(opts.message)
+	}
+
+	var result []buildkite.Build
+	for _, build := range builds {
+		if opts.duration != "" {
+			if build.StartedAt == nil {
+				continue
+			}
+
+			var elapsed time.Duration
+			if build.FinishedAt != nil {
+				elapsed = build.FinishedAt.Time.Sub(build.StartedAt.Time)
+			} else {
+				elapsed = time.Since(build.StartedAt.Time)
+			}
+
+			switch durationFilter.op {
+			case "<":
+				if elapsed >= durationFilter.duration {
+					continue
+				}
+			case ">":
+				if elapsed <= durationFilter.duration {
+					continue
+				}
+			default: // ">="
+				if elapsed < durationFilter.duration {
+					continue
+				}
+			}
+		}
+
+		if messageFilter != "" {
+			if !strings.Contains(strings.ToLower(build.Message), messageFilter) {
+				continue
+			}
+		}
+
+		result = append(result, build)
+	}
+
+	return result, nil
+}
+
+func displayBuilds(cmd *cobra.Command, builds []buildkite.Build, format output.Format) error {
+	if format != output.FormatText {
+		return output.Write(cmd.OutOrStdout(), builds, format)
+	}
+
+	const (
+		maxMessageLength = 22
+		truncatedLength  = 19
+		tableWidth       = 120
+		timeFormat       = "2006-01-02T15:04:05Z"
+	)
+
+	var buf strings.Builder
+
+	header := lipgloss.NewStyle().Bold(true).Underline(true).Render("Builds")
+	buf.WriteString(header)
+	buf.WriteString("\n\n")
+
+	headerRow := fmt.Sprintf("%-8s %-12s %-25s %-20s %-20s %-12s %s",
+		"Number", "State", "Message", "Started (UTC)", "Finished (UTC)", "Duration", "URL")
+	buf.WriteString(lipgloss.NewStyle().Bold(true).Render(headerRow))
+	buf.WriteString("\n")
+	buf.WriteString(strings.Repeat("-", tableWidth))
+	buf.WriteString("\n")
+
+	for _, build := range builds {
+		message := build.Message
+		if len(message) > maxMessageLength {
+			message = message[:truncatedLength] + "..."
+		}
+
+		startedAt := "-"
+		if build.StartedAt != nil {
+			startedAt = build.StartedAt.Time.Format(timeFormat)
+		}
+
+		finishedAt := "-"
+		duration := "-"
+		if build.FinishedAt != nil {
+			finishedAt = build.FinishedAt.Time.Format(timeFormat)
+			if build.StartedAt != nil {
+				dur := build.FinishedAt.Time.Sub(build.StartedAt.Time)
+				duration = formatDuration(dur)
+			}
+		} else if build.StartedAt != nil {
+			dur := time.Since(build.StartedAt.Time)
+			duration = formatDuration(dur) + " (running)"
+		}
+
+		stateColor := getStateColor(build.State)
+		coloredState := stateColor.Render(build.State)
+
+		row := fmt.Sprintf("%-8d %-12s %-25s %-20s %-20s %-12s %s",
+			build.Number, coloredState, message, startedAt, finishedAt, duration, build.WebURL)
+		buf.WriteString(row)
+		buf.WriteString("\n")
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), buf.String())
+	return nil
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%.0fs", d.Seconds())
+	}
+	if d < time.Hour {
+		minutes := d / time.Minute
+		seconds := (d % time.Minute) / time.Second
+		return fmt.Sprintf("%dm%ds", minutes, seconds)
+	}
+	hours := d / time.Hour
+	minutes := (d % time.Hour) / time.Minute
+	return fmt.Sprintf("%dh%dm", hours, minutes)
+}
+
+func getStateColor(state string) lipgloss.Style {
+	switch state {
+	case "passed":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // Green
+	case "failed":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // Red
+	case "running":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // Yellow
+	case "canceled", "cancelled":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("8")) // Gray
+	case "scheduled":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("4")) // Blue
+	default:
+		return lipgloss.NewStyle()
+	}
+}

--- a/pkg/cmd/build/list.go
+++ b/pkg/cmd/build/list.go
@@ -239,7 +239,7 @@ func applyClientSideFilters(builds []buildkite.Build, opts buildListOptions) ([]
 
 			var elapsed time.Duration
 			if build.FinishedAt != nil {
-				elapsed = build.FinishedAt.Time.Sub(build.StartedAt.Time)
+				elapsed = build.FinishedAt.Sub(build.StartedAt.Time)
 			} else {
 				elapsed = time.Since(build.StartedAt.Time)
 			}
@@ -305,15 +305,15 @@ func displayBuilds(cmd *cobra.Command, builds []buildkite.Build, format output.F
 
 		startedAt := "-"
 		if build.StartedAt != nil {
-			startedAt = build.StartedAt.Time.Format(timeFormat)
+			startedAt = build.StartedAt.Format(timeFormat)
 		}
 
 		finishedAt := "-"
 		duration := "-"
 		if build.FinishedAt != nil {
-			finishedAt = build.FinishedAt.Time.Format(timeFormat)
+			finishedAt = build.FinishedAt.Format(timeFormat)
 			if build.StartedAt != nil {
-				dur := build.FinishedAt.Time.Sub(build.StartedAt.Time)
+				dur := build.FinishedAt.Sub(build.StartedAt.Time)
 				duration = formatDuration(dur)
 			}
 		} else if build.StartedAt != nil {

--- a/pkg/cmd/build/list_test.go
+++ b/pkg/cmd/build/list_test.go
@@ -1,0 +1,46 @@
+package build
+
+import (
+	"testing"
+	"time"
+
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+func TestFilterBuilds(t *testing.T) {
+	now := time.Now()
+	builds := []buildkite.Build{
+		{
+			Number:     1,
+			Message:    "Fast build",
+			StartedAt:  &buildkite.Timestamp{Time: now.Add(-5 * time.Minute)},
+			FinishedAt: &buildkite.Timestamp{Time: now.Add(-4 * time.Minute)}, // 1 minute
+		},
+		{
+			Number:     2,
+			Message:    "Long build",
+			StartedAt:  &buildkite.Timestamp{Time: now.Add(-30 * time.Minute)},
+			FinishedAt: &buildkite.Timestamp{Time: now.Add(-10 * time.Minute)}, // 20 minutes
+		},
+	}
+
+	opts := buildListOptions{duration: "10m"}
+	filtered, err := applyClientSideFilters(builds, opts)
+	if err != nil {
+		t.Fatalf("applyClientSideFilters failed: %v", err)
+	}
+
+	if len(filtered) != 1 {
+		t.Errorf("Expected 1 build >= 10m, got %d", len(filtered))
+	}
+
+	opts = buildListOptions{message: "Fast"}
+	filtered, err = applyClientSideFilters(builds, opts)
+	if err != nil {
+		t.Fatalf("applyClientSideFilters failed: %v", err)
+	}
+
+	if len(filtered) != 1 {
+		t.Errorf("Expected 1 build with 'Fast', got %d", len(filtered))
+	}
+}

--- a/pkg/cmd/cluster/list.go
+++ b/pkg/cmd/cluster/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/buildkite/cli/v3/internal/cluster"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/output"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 	"github.com/spf13/cobra"
 )
@@ -23,9 +24,18 @@ func NewCmdClusterList(f *factory.Factory) *cobra.Command {
       List the clusters for an organization.
     `),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := output.GetFormat(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
 			clusters, err := listClusters(cmd.Context(), f)
 			if err != nil {
 				return err
+			}
+
+			if format != output.FormatText {
+				return output.Write(cmd.OutOrStdout(), clusters, format)
 			}
 
 			summary := cluster.ClusterViewTable(clusters...)
@@ -35,6 +45,7 @@ func NewCmdClusterList(f *factory.Factory) *cobra.Command {
 		},
 	}
 
+	output.AddFlags(cmd.Flags())
 	return &cmd
 }
 

--- a/pkg/cmd/job/retry.go
+++ b/pkg/cmd/job/retry.go
@@ -37,6 +37,11 @@ func NewCmdJobRetry(f *factory.Factory) *cobra.Command {
 				return spinErr
 			}
 
+			// fixes segfault when error is returned, e.g. "Jobs from canceled builds cannot be retried"
+			if err != nil {
+				return err
+			}
+
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Successfully retried job: "+j.JobTypeCommandRetry.JobTypeCommand.Url)
 
 			return err


### PR DESCRIPTION
- Add agent pause/resume commands with note and timeout options
- Add build list command with duration and message filtering
- Update go-buildkite to v4.7.0 to support pause/resume
- Fix job retry segfault on API errors
- Include tests for all new functionality
- Adding some quick win output formatting, the rest look quite comprehensive (such as the bubbletea view) and unnecessary for action items (e.g. pause/resume/download, etc)

Fixes: #519
Fixes: #521
Fixes: #522
Fixes: #523