### PR TITLE
fix: brew path should be in Formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ brews:
     ids:
       - macos-archive
       - linux-archive
-    directory: .
+    directory: Formula
     homepage: https://github.com/buildkite/cli
     description: Work with Buildkite from the command-line
     license: MIT


### PR DESCRIPTION
## Description

Currently we have duplicate `rb` files in the homebrew dir because we push to root, but also have some in `Formula`. Having them in the latter is the best practise, though.

## Changes

- Points GoReleaser to the `Formula` directory for `brew` releases

## Rollback

Safe. Just revert the change.
