### PR TITLE
⚡️ perf: optimize pipeline filtering by repository in API calls

### DIFF
--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -52,30 +52,33 @@ func filterPipelines(ctx context.Context, repoURLs []string, org string, client 
 	var currentPipelines []pipeline.Pipeline
 	page := 1
 	per_page := 30
-	for more_pipelines := true; more_pipelines; {
-		opts := buildkite.PipelineListOptions{
-			ListOptions: buildkite.ListOptions{
-				Page:    page,
-				PerPage: per_page,
-			},
-		}
+	for _, repoURL := range repoURLs {
+		for more_pipelines := true; more_pipelines; {
+			opts := buildkite.PipelineListOptions{
+				ListOptions: buildkite.ListOptions{
+					Page:    page,
+					PerPage: per_page,
+				},
+				Repository: repoURL,
+			}
 
-		pipelines, resp, err := client.Pipelines.List(ctx, org, &opts)
-		if err != nil {
-			return nil, err
-		}
-		for _, p := range pipelines {
-			for _, u := range repoURLs {
-				gitUrl := u[strings.LastIndex(u, "/")+1:]
-				if strings.Contains(p.Repository, gitUrl) {
-					currentPipelines = append(currentPipelines, pipeline.Pipeline{Name: p.Slug, Org: org})
+			pipelines, resp, err := client.Pipelines.List(ctx, org, &opts)
+			if err != nil {
+				return nil, err
+			}
+			for _, p := range pipelines {
+				for _, u := range repoURLs {
+					gitUrl := u[strings.LastIndex(u, "/")+1:]
+					if strings.Contains(p.Repository, gitUrl) {
+						currentPipelines = append(currentPipelines, pipeline.Pipeline{Name: p.Slug, Org: org})
+					}
 				}
 			}
-		}
-		if resp.NextPage == 0 {
-			more_pipelines = false
-		} else {
-			page = resp.NextPage
+			if resp.NextPage == 0 {
+				more_pipelines = false
+			} else {
+				page = resp.NextPage
+			}
 		}
 	}
 	return currentPipelines, nil


### PR DESCRIPTION
Replace local filtering with repository-specific API requests to reduce data transfer and improve performance when filtering pipelines by repository URLs.

I have absolutely no idea if this is a good thing or not in the grand scheme of things, but as it stands now, `bk build view` is useless to me as it tries to enumerate every pipeline we own at our organization, which is... a lot. This leverages the repo url of the current repository to filter what's being listed, which makes it a LOT faster.

I can view this as being problematic if the use case involves forks? But I figured I'd throw this up there in case it sounds interesting to anyone.