### PR TITLE
fix: handle block steps correctly

### DIFF
--- a/internal/build/models/view.go
+++ b/internal/build/models/view.go
@@ -412,6 +412,11 @@ func NewBuildView(build *buildkite.Build, artifacts []buildkite.Artifact, annota
 
 	// Convert jobs
 	for _, job := range build.Jobs {
+		var createdAt time.Time
+		if job.CreatedAt != nil {
+			createdAt = job.CreatedAt.Time
+		}
+
 		jobView := JobView{
 			ID:              job.ID,
 			GraphQLID:       job.GraphQLID,
@@ -426,7 +431,7 @@ func NewBuildView(build *buildkite.Build, artifacts []buildkite.Artifact, annota
 			RawLogURL:       job.RawLogsURL,
 			SoftFailed:      job.SoftFailed,
 			ArtifactPaths:   job.ArtifactPaths,
-			CreatedAt:       job.CreatedAt.Time,
+			CreatedAt:       createdAt,
 			Retried:         job.Retried,
 			RetriesCount:    job.RetriesCount,
 			Matrix:          nil, // Matrix field not available in buildkite library


### PR DESCRIPTION
## Description

`block` steps don't have a `createdAt` time, so handling that will cause a segfault

## Changes

- Adds a conditional to check if `createdAt` is `nil` and handles it correctly; setting to `nil` instead of parsing a time from a nil value
