### PR TITLE
Set JSON as a default output format

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -65,7 +65,7 @@ func writeText(w io.Writer, v interface{}) error {
 
 // AddFlags adds format flag to the command flags
 func AddFlags(flags *pflag.FlagSet) {
-	flags.StringP("output", "o", "text", "Output format. One of: json, yaml, text")
+	flags.StringP("output", "o", "json", "Output format. One of: json, yaml, text")
 }
 
 // GetFormat gets the format from command flags


### PR DESCRIPTION
As decided for the CLI overhaul, JSON is meant to be a default output format.
Other formats like `YAML` or `text` can be selected by choosing `-[-o]utput  text|yaml`.