### PR TITLE
chore: pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+### Description
+
+<!--
+- What problem are you trying to solve, and how are you solving it?
+- What alternatives did you consider?
+-->
+
+### Changes
+
+<!--
+List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.
+
+Can skip if changes are simple or clear from the commit messages.
+-->
+
+### Testing
+- [ ] Tests have run locally (with `go test ./...`)
+- [ ] Code is formatted (with `go fmt ./...`)
+
+
+### Disclosures / Credits
+
+<!--
+If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
+Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.
+
+Examples:
+ - "Claude Code wrote the unit tests, then I implemented the rest of the change"
+ - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
+ - "I used Gemini to write the code and Midjourney to produce the diagrams"
+ - "Special thanks to the Wikipedia page on ANSI escape codes"
+ - "I did not use AI tools at all"
+-->


### PR DESCRIPTION
## Description

We don't currently have a PR template and we're getting an increasing number of contributions, so indicating the requirements would be beneficial

## Changes

- Adds a PR template for folks to use when submitting code

## Context

The PR template follows that of the Buildkite Agent PR template
