### PR TITLE
Add --output option for `bk pipeline create` 

### DIFF
--- a/cmd/pipeline/create.go
+++ b/cmd/pipeline/create.go
@@ -40,7 +40,7 @@ Examples:
   $ bk pipeline create "My Pipeline" --description "My pipeline description" --repository "git@github.com:org/repo.git"
 
   # Create a new pipeline and view the created pipeline in JSON format
-  $ bk pipeline create "My Pipeline" --description "My pipeline description" --repository "git@github.com:org/repo.git"
+  $ bk pipeline create "My Pipeline" --description "My pipeline description" --repository "git@github.com:org/repo.git" --output json
 
   # Create a pipeline with a cluster (by name)
   $ bk pipeline create "My Pipeline" -d "Description" -r "git@github.com:org/repo.git" -c "my-cluster"


### PR DESCRIPTION
### Description

Currently, `bk pipeline create` just returns the pipeline url of the created pipeline. This PR allows the user to output the created pipeline with either json or yaml formats as options using the `--output` flag.  

### Changes
 The following options are added to the `bk pipeline create` 

### Example
```
$ bk pipeline create "My Pipeline" -d "Description" -r "git@github.com:org/repo.git" --dry-run --output yaml
$ bk pipeline create "My Pipeline" -d "Description" -r "git@github.com:org/repo.git"  --output json
```
 
  