### PR TITLE
chore: add lefthook 🥊

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,16 @@
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: "*.go"
+      run: |
+        if command -v gofumpt >/dev/null 2>&1; then
+          gofumpt -w {staged_files}
+        else
+          gofmt -w {staged_files}
+        fi
+      stage_fixed: true
+    lint:
+      glob: "*.go"
+      run: golangci-lint run --fix {staged_files}
+      stage_fixed: true


### PR DESCRIPTION
### Description

I've seen a few PRs fail on linting and formatting, so adding a `lefthook.yml` should help with that and reduce toil.

### Changes

- adds a `lefthook.yml` file which uses `gofumpt` if available, else falls back to `gofmt`

### Disclosures / Credits

I got Amp to write this: https://ampcode.com/threads/T-019b26e0-c241-755a-b429-8ed10f3e4221
