### PR TITLE
fix: prepend leading slash to endpoints to prevent malformed URLs

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -59,6 +59,28 @@ Examples:
 `
 }
 
+// buildFullEndpoint constructs the full API endpoint path with organization prefix
+func buildFullEndpoint(endpoint, orgSlug string, isAnalytics bool) string {
+	// Default to root if empty
+	if endpoint == "" {
+		endpoint = "/"
+	}
+
+	// Ensure endpoint starts with a leading slash
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+
+	var endpointPrefix string
+	if isAnalytics {
+		endpointPrefix = fmt.Sprintf("v2/analytics/organizations/%s", orgSlug)
+	} else {
+		endpointPrefix = fmt.Sprintf("v2/organizations/%s", orgSlug)
+	}
+
+	return endpointPrefix + endpoint
+}
+
 func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	f, err := factory.New()
 	if err != nil {
@@ -88,19 +110,7 @@ func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return c.handleGraphQLQuery(context.Background(), f)
 	}
 
-	endpoint := c.Endpoint
-	if endpoint == "" {
-		endpoint = "/"
-	}
-
-	var endpointPrefix string
-	if c.Analytics {
-		endpointPrefix = fmt.Sprintf("v2/analytics/organizations/%s", f.Config.OrganizationSlug())
-	} else {
-		endpointPrefix = fmt.Sprintf("v2/organizations/%s", f.Config.OrganizationSlug())
-	}
-
-	fullEndpoint := endpointPrefix + endpoint
+	fullEndpoint := buildFullEndpoint(c.Endpoint, f.Config.OrganizationSlug(), c.Analytics)
 
 	// Create an HTTP client with appropriate configuration
 	client := httpClient.NewClient(
@@ -117,7 +127,7 @@ func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		}
 	}
 
-	var requestData interface{}
+	var requestData any
 	if c.Data != "" {
 		// Try to parse as JSON first
 		if err := json.Unmarshal([]byte(c.Data), &requestData); err != nil {
@@ -126,7 +136,7 @@ func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		}
 	}
 
-	var response interface{}
+	var response any
 
 	switch method {
 	case "GET":

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestBuildFullEndpoint(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		endpoint     string
+		orgSlug      string
+		isAnalytics  bool
+		wantEndpoint string
+	}{
+		"endpoint with leading slash": {
+			endpoint:     "/pipelines/dummy/builds/5085",
+			orgSlug:      "test-org",
+			isAnalytics:  false,
+			wantEndpoint: "v2/organizations/test-org/pipelines/dummy/builds/5085",
+		},
+		"endpoint without leading slash": {
+			endpoint:     "pipelines/dummy/builds/5085",
+			orgSlug:      "test-org",
+			isAnalytics:  false,
+			wantEndpoint: "v2/organizations/test-org/pipelines/dummy/builds/5085",
+		},
+		"empty endpoint": {
+			endpoint:     "",
+			orgSlug:      "test-org",
+			isAnalytics:  false,
+			wantEndpoint: "v2/organizations/test-org/",
+		},
+		"root endpoint": {
+			endpoint:     "/",
+			orgSlug:      "test-org",
+			isAnalytics:  false,
+			wantEndpoint: "v2/organizations/test-org/",
+		},
+		"analytics endpoint with leading slash": {
+			endpoint:     "/suites",
+			orgSlug:      "test-org",
+			isAnalytics:  true,
+			wantEndpoint: "v2/analytics/organizations/test-org/suites",
+		},
+		"analytics endpoint without leading slash": {
+			endpoint:     "suites",
+			orgSlug:      "test-org",
+			isAnalytics:  true,
+			wantEndpoint: "v2/analytics/organizations/test-org/suites",
+		},
+		"pipeline endpoint without leading slash": {
+			endpoint:     "pipelines",
+			orgSlug:      "acme-inc",
+			isAnalytics:  false,
+			wantEndpoint: "v2/organizations/acme-inc/pipelines",
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildFullEndpoint(tc.endpoint, tc.orgSlug, tc.isAnalytics)
+
+			if got != tc.wantEndpoint {
+				t.Errorf("buildFullEndpoint(%q, %q, %v) = %q, want %q",
+					tc.endpoint, tc.orgSlug, tc.isAnalytics, got, tc.wantEndpoint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Stumbled upon the issue while looking at the https://github.com/buildkite/cli/issues/613. 
While the issue from #613 doesn't seem to be present anymore (tested using latest version 3.17.2), I discovered a different issue.
When using `bk api` without a leading slash (e.g., `bk api "pipelines/dummy/builds/5085"`), the endpoint was concatenated directly to the organization prefix, resulting in malformed URLs like `v2/organizations/org-slugpipelines/dummy/builds/5085` instead of `v2/organizations/org-slug/pipelines/dummy/builds/5085`.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

- Extract endpoint building logic into `buildFullEndpoint()` function
- Prepend `/` to endpoints that don't start with one
- Add tests covering a few endpoint formats (with/without slash, analytics endpoints, empty endpoints, .etc.)

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->

I did not use "AI" tools at all.