### PR TITLE
Fix bk build view command crashed

### DIFF
--- a/internal/build/view/view.go
+++ b/internal/build/view/view.go
@@ -60,9 +60,11 @@ func BuildSummaryWithJobs(b *buildkite.Build, organization, pipeline string) str
 	var sb strings.Builder
 	sb.WriteString(buildSummary(b, organization, pipeline))
 
-	if jobs := renderJobs(b.Jobs); jobs != "" {
-		sb.WriteString("\n\n")
-		sb.WriteString(jobs)
+	if b != nil {
+		if jobs := renderJobs(b.Jobs); jobs != "" {
+			sb.WriteString("\n\n")
+			sb.WriteString(jobs)
+		}
 	}
 
 	return sb.String()
@@ -78,6 +80,10 @@ func (v *BuildView) Render() string {
 	var sb strings.Builder
 
 	sb.WriteString(buildSummary(v.Build, v.Organization, v.Pipeline))
+
+	if v.Build == nil {
+		return sb.String()
+	}
 
 	if jobs := renderJobs(v.Build.Jobs); jobs != "" {
 		sb.WriteString("\n\n")
@@ -100,6 +106,10 @@ func (v *BuildView) Render() string {
 }
 
 func buildSummary(b *buildkite.Build, organization, pipeline string) string {
+	if b == nil {
+		return fmt.Sprintf("Build %s/%s (no data available)\n", output.ValueOrDash(organization), output.ValueOrDash(pipeline))
+	}
+
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "Build %s/%s #%d (%s)\n\n", output.ValueOrDash(organization), output.ValueOrDash(pipeline), b.Number, b.State)
@@ -202,6 +212,9 @@ func filterScriptJobs(jobs []buildkite.Job) []buildkite.Job {
 }
 
 func creatorName(build *buildkite.Build) string {
+	if build == nil {
+		return "Unknown"
+	}
 	if build.Creator.ID != "" {
 		return build.Creator.Name
 	}

--- a/internal/build/view/view_test.go
+++ b/internal/build/view/view_test.go
@@ -1,0 +1,164 @@
+package view
+
+import (
+	"strings"
+	"testing"
+
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+func TestBuildSummary_NilBuild(t *testing.T) {
+	result := BuildSummary(nil, "my-org", "my-pipeline")
+
+	if !strings.Contains(result, "my-org") {
+		t.Errorf("Expected result to contain organization, got: %s", result)
+	}
+	if !strings.Contains(result, "my-pipeline") {
+		t.Errorf("Expected result to contain pipeline, got: %s", result)
+	}
+	if !strings.Contains(result, "no data available") {
+		t.Errorf("Expected result to indicate no data available, got: %s", result)
+	}
+}
+
+func TestBuildSummary_ValidBuild(t *testing.T) {
+	build := &buildkite.Build{
+		Number:  123,
+		State:   "passed",
+		Message: "Test build",
+		Branch:  "main",
+	}
+
+	result := BuildSummary(build, "my-org", "my-pipeline")
+
+	if !strings.Contains(result, "#123") {
+		t.Errorf("Expected result to contain build number, got: %s", result)
+	}
+	if !strings.Contains(result, "passed") {
+		t.Errorf("Expected result to contain state, got: %s", result)
+	}
+}
+
+func TestBuildSummaryWithJobs_NilBuild(t *testing.T) {
+	result := BuildSummaryWithJobs(nil, "my-org", "my-pipeline")
+
+	if !strings.Contains(result, "my-org") {
+		t.Errorf("Expected result to contain organization, got: %s", result)
+	}
+	if !strings.Contains(result, "no data available") {
+		t.Errorf("Expected result to indicate no data available, got: %s", result)
+	}
+}
+
+func TestBuildSummaryWithJobs_ValidBuild(t *testing.T) {
+	build := &buildkite.Build{
+		Number:  456,
+		State:   "running",
+		Message: "Test build with jobs",
+		Jobs: []buildkite.Job{
+			{Type: "script", Name: "Test Job", State: "passed"},
+		},
+	}
+
+	result := BuildSummaryWithJobs(build, "my-org", "my-pipeline")
+
+	if !strings.Contains(result, "#456") {
+		t.Errorf("Expected result to contain build number, got: %s", result)
+	}
+	if !strings.Contains(result, "Jobs") {
+		t.Errorf("Expected result to contain jobs section, got: %s", result)
+	}
+}
+
+func TestBuildView_Render_NilBuild(t *testing.T) {
+	view := NewBuildView(nil, nil, nil, "my-org", "my-pipeline")
+	result := view.Render()
+
+	if !strings.Contains(result, "my-org") {
+		t.Errorf("Expected result to contain organization, got: %s", result)
+	}
+	if !strings.Contains(result, "no data available") {
+		t.Errorf("Expected result to indicate no data available, got: %s", result)
+	}
+}
+
+func TestBuildView_Render_ValidBuild(t *testing.T) {
+	build := &buildkite.Build{
+		Number:  789,
+		State:   "passed",
+		Message: "Test build",
+		Jobs: []buildkite.Job{
+			{Type: "script", Name: "Build", State: "passed"},
+		},
+	}
+	artifacts := []buildkite.Artifact{
+		{ID: "art-1", Path: "dist/app.js", FileSize: 1024},
+	}
+	annotations := []buildkite.Annotation{
+		{Style: "info", Context: "test-context"},
+	}
+
+	view := NewBuildView(build, artifacts, annotations, "my-org", "my-pipeline")
+	result := view.Render()
+
+	if !strings.Contains(result, "#789") {
+		t.Errorf("Expected result to contain build number, got: %s", result)
+	}
+	if !strings.Contains(result, "Jobs") {
+		t.Errorf("Expected result to contain jobs section, got: %s", result)
+	}
+	if !strings.Contains(result, "Artifacts") {
+		t.Errorf("Expected result to contain artifacts section, got: %s", result)
+	}
+	if !strings.Contains(result, "Annotations") {
+		t.Errorf("Expected result to contain annotations section, got: %s", result)
+	}
+}
+
+func TestCreatorName_NilBuild(t *testing.T) {
+	result := creatorName(nil)
+
+	if result != "Unknown" {
+		t.Errorf("Expected 'Unknown' for nil build, got: %s", result)
+	}
+}
+
+func TestCreatorName_WithCreator(t *testing.T) {
+	build := &buildkite.Build{
+		Creator: buildkite.Creator{
+			ID:   "user-123",
+			Name: "John Doe",
+		},
+	}
+
+	result := creatorName(build)
+
+	if result != "John Doe" {
+		t.Errorf("Expected 'John Doe', got: %s", result)
+	}
+}
+
+func TestCreatorName_WithAuthor(t *testing.T) {
+	build := &buildkite.Build{
+		Author: buildkite.Author{
+			Username: "janedoe",
+			Name:     "Jane Doe",
+		},
+	}
+
+	result := creatorName(build)
+
+	if result != "Jane Doe" {
+		t.Errorf("Expected 'Jane Doe', got: %s", result)
+	}
+}
+
+func TestCreatorName_NoCreatorOrAuthor(t *testing.T) {
+	build := &buildkite.Build{}
+
+	result := creatorName(build)
+
+	if result != "Unknown" {
+		t.Errorf("Expected 'Unknown', got: %s", result)
+	}
+}


### PR DESCRIPTION
Add defensive nil checks to prevent panics when build data is unexpectedly nil in the view rendering functions.

### Description

I was using bk build view buildkite/deploy/23008 to check a build and it failed with

```
bk build view buildkite/deploy/23008
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x101535b74]

goroutine 1 [running]:
github.com/buildkite/cli/v3/internal/build/models.NewBuildView(0x14000135d40, {0x10226cf60, 0x0, 0x101b87ed0?}, {0x140001fc320, 0x1, 0x0?})
        /go/src/github.com/buildkite/cli/internal/build/models/view.go:429 +0xd14
github.com/buildkite/cli/v3/pkg/cmd/build.NewCmdBuildView.func1(0x14000202308, {0x140003506d0, 0x1, 0x1})
        /go/src/github.com/buildkite/cli/pkg/cmd/build/view.go:181 +0x898
github.com/spf13/cobra.(*Command).execute(0x14000202308, {0x14000350610, 0x1, 0x1})
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x14000278c08)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.mainRun()
        /go/src/github.com/buildkite/cli/cmd/bk/main.go:57 +0x348
main.main()
        /go/src/github.com/buildkite/cli/cmd/bk/main.go:14 +0x1c
```

The root cause was that build view rendering functions accessed fields on the *buildkite.Build pointer without nil checks. When the API returns unexpected data, these functions could panic.

### Changes

- Add nil check in creatorName() - returns "Unknown" if build is nil
- Add nil check in buildSummary() - returns graceful message if build is nil
- Add nil check in Render() - early return after header if build is nil
- Add nil check in BuildSummaryWithJobs() - skips job rendering if build is nil

### Testing

- [x] test added and passed
- [x] I manually verified that the fix resolved the panic:

```
$ bk build view buildkite/deploy/23008 > /dev/null; echo $?
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1034b5b74]

goroutine 1 [running]:
github.com/buildkite/cli/v3/internal/build/models.NewBuildView(0x140000bbd40, {0x1041ecf60, 0x0, 0x103b07ed0?}, {0x140005545a0, 0x1, 0x0?})
        /go/src/github.com/buildkite/cli/internal/build/models/view.go:429 +0xd14
github.com/buildkite/cli/v3/pkg/cmd/build.NewCmdBuildView.func1(0x14000200308, {0x14000268230, 0x1, 0x1})
        /go/src/github.com/buildkite/cli/pkg/cmd/build/view.go:181 +0x898
github.com/spf13/cobra.(*Command).execute(0x14000200308, {0x140002681e0, 0x1, 0x1})
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x14000156c08)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.mainRun()
        /go/src/github.com/buildkite/cli/cmd/bk/main.go:57 +0x348
main.main()
        /go/src/github.com/buildkite/cli/cmd/bk/main.go:14 +0x1c
2


$ bk-dev build view buildkite/deploy/23008 > /dev/null; echo $?
0
```

where `bk-dev` is the executable from this PR branch.

### Disclosures / Credits

Claude Code diagnosed the root cause by analyzing the crash log and go-buildkite library types, then implemented the defensive nil checks and the unit test.