### PR TITLE
chore: rename migrate to convert

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ type (
 		Copy     pipeline.CopyCmd     `cmd:"" help:"Copy an existing pipeline." aliases:"cp"`
 		Create   pipeline.CreateCmd   `cmd:"" help:"Create a new pipeline."`
 		List     pipeline.ListCmd     `cmd:"" help:"List pipelines." aliases:"ls"`
-		Migrate  pipeline.MigrateCmd  `cmd:"" help:"Migrate a CI/CD pipeline configuration to Buildkite format."`
+		Convert  pipeline.ConvertCmd  `cmd:"" help:"Convert a CI/CD pipeline configuration to Buildkite format." aliases:"migrate"`
 		Validate pipeline.ValidateCmd `cmd:"" help:"Validate a pipeline YAML file."`
 		View     pipeline.ViewCmd     `cmd:"" help:"View a pipeline."`
 	}


### PR DESCRIPTION
### Description

The _migration_ tool is actually a _conversion_ tool.

### Changes

- changes all instances of `migrate` to `convert`
- adjusts the `migrate` command to be `convert`
- updates tests
- updates structs and types
- adds an `alias` on the `convert` command so `migrate` still works and maintain backwards compatibility

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
