### PR TITLE
fix: preserve commas in env var and metadata values

### DIFF
--- a/cmd/build/create.go
+++ b/cmd/build/create.go
@@ -25,8 +25,8 @@ type CreateCmd struct {
 	Author              string   `help:"Author of the build. Supports: \"Name <email>\", \"email@domain.com\", \"Full Name\", or \"username\"" short:"a"`
 	Web                 bool     `help:"Open the build in a web browser after it has been created." short:"w"`
 	Pipeline            string   `help:"The pipeline to use. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}." short:"p"`
-	Env                 []string `help:"Set environment variables for the build (KEY=VALUE)" short:"e"`
-	Metadata            []string `help:"Set metadata for the build (KEY=VALUE)" short:"M"`
+	Env                 []string `help:"Set environment variables for the build (KEY=VALUE)" short:"e" sep:"none"`
+	Metadata            []string `help:"Set metadata for the build (KEY=VALUE)" short:"M" sep:"none"`
 	IgnoreBranchFilters bool     `help:"Ignore branch filters for the pipeline" short:"i"`
 	EnvFile             string   `help:"Set the environment variables for the build via an environment file" short:"f"`
 }


### PR DESCRIPTION


### Description

I noticed that the `bk build create` behavior differed from the web UI with regards to environment variables.

This works:
```
$ bk build create -e "STACKS=terraform/stack-1" -b main --pipeline org/repo --yes

Build created: https://buildkite.com/org/repo/builds/68509
```

This fails:
```
$ bk build create -e "STACKS=terraform/stack-1,terraform/stack-2" -b main --pipeline org/repo --yes

Error: API error: POST https://api.buildkite.com/v2/organizations/org/pipelines/repo/builds: 422 "terraform/stack-2" is not a valid environment variable name (only a-z, A-Z, 0-9 and underscores are allowed) (API request failed during: creating build)
```

However, the env var `STACKS=terraform/stack-1,terraform/stack-2` is valid and accepted in the web console.

### Changes

Kong's default behavior for []string fields splits input on commas. When passing `-e "STACKS=path1,path2,path3"`, Kong was splitting this into three separate entries: "STACKS=path1", "path2", "path3". The parsing code then treated "path2" and "path3" as keys (no "=" found), sending them to the API which rejected them as invalid env var names.

Adding `sep:"none"` tells Kong to preserve the entire value without splitting on any separator.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

The bug was identified and fixed by Claude code. I reviewed and tested the code fixed the original issue I ran into.

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
