### PR TITLE
Add job reprioritization support

### DIFF
--- a/cmd/job/reprioritize.go
+++ b/cmd/job/reprioritize.go
@@ -1,0 +1,98 @@
+package job
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	buildResolver "github.com/buildkite/cli/v3/internal/build/resolver"
+	"github.com/buildkite/cli/v3/internal/build/resolver/options"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type ReprioritizeCmd struct {
+	JobID       string `arg:"" help:"Job UUID to reprioritize"`
+	Priority    int    `arg:"" help:"New priority value for the job"`
+	Pipeline    string `help:"The pipeline to use. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}" short:"p"`
+	BuildNumber string `help:"The build number" short:"b"`
+}
+
+func (c *ReprioritizeCmd) Help() string {
+	return `
+Examples:
+  # Reprioritize a job (requires --pipeline and --build)
+  $ bk job reprioritize 0190046e-e199-453b-a302-a21a4d649d31 1 -p my-pipeline -b 123
+
+  # If inside a git repository with a configured pipeline
+  $ bk job reprioritize 0190046e-e199-453b-a302-a21a4d649d31 1 -b 123
+`
+}
+
+func (c *ReprioritizeCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	pipelineRes := pipelineResolver.NewAggregateResolver(
+		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
+		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+	)
+
+	optionsResolver := options.AggregateResolver{
+		options.ResolveBranchFromRepository(f.GitRepository),
+	}
+
+	args := []string{}
+	if c.BuildNumber != "" {
+		args = []string{c.BuildNumber}
+	}
+	buildRes := buildResolver.NewAggregateResolver(
+		buildResolver.ResolveFromPositionalArgument(args, 0, pipelineRes.Resolve, f.Config),
+		buildResolver.ResolveBuildWithOpts(f, pipelineRes.Resolve, optionsResolver...),
+	)
+
+	bld, err := buildRes.Resolve(ctx)
+	if err != nil {
+		return err
+	}
+	if bld == nil {
+		return fmt.Errorf("no build found")
+	}
+
+	var job buildkite.Job
+	err = bkIO.SpinWhile(f, "Reprioritizing job", func() {
+		job, _, err = f.RestAPIClient.Jobs.ReprioritizeJob(
+			ctx,
+			bld.Organization,
+			bld.Pipeline,
+			fmt.Sprint(bld.BuildNumber),
+			c.JobID,
+			&buildkite.JobReprioritizationOptions{
+				Priority: c.Priority,
+			},
+		)
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Job reprioritized to %d: %s\n", c.Priority, job.WebURL)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -99,11 +99,12 @@ type (
 		Delete secret.DeleteCmd `cmd:"" help:"Delete a cluster secret." aliases:"rm"`
 	}
 	JobCmd struct {
-		Cancel  job.CancelCmd  `cmd:"" help:"Cancel a job."`
-		List    job.ListCmd    `cmd:"" help:"List jobs." aliases:"ls"`
-		Log     job.LogCmd     `cmd:"" help:"Get logs for a job."`
-		Retry   job.RetryCmd   `cmd:"" help:"Retry a job."`
-		Unblock job.UnblockCmd `cmd:"" help:"Unblock a job."`
+		Cancel       job.CancelCmd       `cmd:"" help:"Cancel a job."`
+		List         job.ListCmd         `cmd:"" help:"List jobs." aliases:"ls"`
+		Log          job.LogCmd          `cmd:"" help:"Get logs for a job."`
+		Reprioritize job.ReprioritizeCmd `cmd:"" help:"Reprioritize a job." aliases:"priority"`
+		Retry        job.RetryCmd        `cmd:"" help:"Retry a job."`
+		Unblock      job.UnblockCmd      `cmd:"" help:"Unblock a job."`
 	}
 	OrganizationCmd struct {
 		List organization.ListCmd `cmd:"" help:"List configured organizations." aliases:"ls"`


### PR DESCRIPTION
### Description

Adds support for setting a new priority on a job via `job reprioritize` or `job priority`

### Changes

- adds a subcommand to `job` for reprioritizing a job in a running build

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
