### PR TITLE
Remove unnecessary git requirements

### DIFF
--- a/cmd/artifacts/list.go
+++ b/cmd/artifacts/list.go
@@ -73,7 +73,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	// We resolve a build an optional argument or positional argument

--- a/cmd/build/cancel.go
+++ b/cmd/build/cancel.go
@@ -50,7 +50,7 @@ func (c *CancelCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	args := []string{c.BuildNumber}

--- a/cmd/build/create.go
+++ b/cmd/build/create.go
@@ -65,7 +65,7 @@ func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	resolvers := resolver.NewAggregateResolver(
 		resolver.ResolveFromFlag(c.Pipeline, f.Config),
 		resolver.ResolveFromConfig(f.Config, resolver.PickOneWithFactory(f)),
-		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f))),
 	)
 
 	resolvedPipeline, err := resolvers.Resolve(ctx)

--- a/cmd/build/download.go
+++ b/cmd/build/download.go
@@ -68,7 +68,7 @@ func (c *DownloadCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error 
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	// we resolve a build based on the following rules:

--- a/cmd/build/rebuild.go
+++ b/cmd/build/rebuild.go
@@ -70,7 +70,7 @@ func (c *RebuildCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	// we resolve a build based on the following rules:

--- a/cmd/build/view.go
+++ b/cmd/build/view.go
@@ -85,7 +85,7 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(opts.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	// Resolve build options

--- a/cmd/build/watch.go
+++ b/cmd/build/watch.go
@@ -78,7 +78,7 @@ func (c *WatchCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	optionsResolver := options.AggregateResolver{

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -62,15 +62,5 @@ func (c *SetCmd) Run() error {
 		return err
 	}
 
-	conf := f.Config
-	inGitRepo := f.GitRepository != nil
-
-	if c.Local && !inGitRepo {
-		return fmt.Errorf("--local requires being in a git repository")
-	}
-
-	// Determine where to save (default to user config unless --local)
-	saveLocal := c.Local && inGitRepo
-
-	return SetConfigValue(conf, key, c.Value, saveLocal)
+	return SetConfigValue(f.Config, key, c.Value, c.Local)
 }

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -41,15 +41,5 @@ func (c *UnsetCmd) Run() error {
 		return err
 	}
 
-	conf := f.Config
-	inGitRepo := f.GitRepository != nil
-
-	if c.Local && !inGitRepo {
-		return fmt.Errorf("--local requires being in a git repository")
-	}
-
-	// Determine where to unset (default to user config unless --local)
-	unsetLocal := c.Local && inGitRepo
-
-	return SetConfigValue(conf, key, "", unsetLocal)
+	return SetConfigValue(f.Config, key, "", c.Local)
 }

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -84,11 +84,6 @@ func ConfigureWithCredentials(f *factory.Factory, org, token string) error {
 }
 
 func ConfigureRun(f *factory.Factory, org string) error {
-	// Check if we're in a Git repository
-	if f.GitRepository == nil {
-		return errors.New("not in a Git repository - bk should be configured at the root of a Git repository")
-	}
-
 	if org == "" {
 		// Get organization slug
 		inputOrg, err := promptForInput("Organization slug: ", false)

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -124,34 +124,3 @@ func TestConfigureTokenReuse(t *testing.T) {
 		}
 	})
 }
-
-func TestConfigureRequiresGitRepository(t *testing.T) {
-	t.Parallel()
-
-	t.Run("fails when not in a git repository", func(t *testing.T) {
-		t.Parallel()
-		fs := afero.NewMemMapFs()
-		conf := config.New(fs, nil)
-
-		// Create a factory with nil GitRepository (simulating not being in a git repo)
-		f := &factory.Factory{Config: conf, GitRepository: nil}
-
-		err := ConfigureRun(f, "test-org")
-
-		if err == nil {
-			t.Error("expected error when not in a git repository, got nil")
-		}
-
-		expectedErr := "not in a Git repository - bk should be configured at the root of a Git repository"
-		if err.Error() != expectedErr {
-			t.Errorf("expected error message %q, got %q", expectedErr, err.Error())
-		}
-	})
-
-	t.Run("succeeds when in a git repository", func(t *testing.T) {
-		// Skip this test because we can't easily mock the interactive prompts
-		// In a real implementation, we would need to mock the promptForInput function
-		// or restructure the code to allow for testing without interactive input
-		t.Skip("skipping test that requires interactive input")
-	})
-}

--- a/cmd/job/log.go
+++ b/cmd/job/log.go
@@ -56,7 +56,7 @@ func (c *LogCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	optionsResolver := options.AggregateResolver{

--- a/cmd/job/reprioritize.go
+++ b/cmd/job/reprioritize.go
@@ -52,7 +52,7 @@ func (c *ReprioritizeCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) er
 	pipelineRes := pipelineResolver.NewAggregateResolver(
 		pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config),
 		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
-		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
 	)
 
 	optionsResolver := options.AggregateResolver{

--- a/cmd/pipeline/copy.go
+++ b/cmd/pipeline/copy.go
@@ -131,7 +131,7 @@ func (c *CopyCmd) resolveSourcePipeline(ctx context.Context, f *factory.Factory)
 	pipelineRes := resolver.NewAggregateResolver(
 		resolver.ResolveFromPositionalArgument(args, 0, f.Config),
 		resolver.ResolveFromConfig(f.Config, resolver.PickOneWithFactory(f)),
-		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f))),
 	)
 
 	p, err := pipelineRes.Resolve(ctx)

--- a/cmd/pipeline/view.go
+++ b/cmd/pipeline/view.go
@@ -66,7 +66,7 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	pipelineRes := resolver.NewAggregateResolver(
 		resolver.ResolveFromPositionalArgument(args, 0, f.Config),
 		resolver.ResolveFromConfig(f.Config, resolver.PickOneWithFactory(f)),
-		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f), f.GitRepository != nil)),
+		resolver.ResolveFromRepository(f, resolver.CachedPicker(f.Config, resolver.PickOneWithFactory(f))),
 	)
 
 	pipeline, err := pipelineRes.Resolve(ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -332,14 +332,10 @@ func (conf *Config) PreferredPipelines() []pipeline.Pipeline {
 }
 
 // SetPreferredPipelines will write the provided list of pipelines to local configuration
-func (conf *Config) SetPreferredPipelines(pipelines []pipeline.Pipeline, inGitRepo bool) error {
+func (conf *Config) SetPreferredPipelines(pipelines []pipeline.Pipeline) error {
 	// only save pipelines if they are present
 	if len(pipelines) == 0 {
 		return nil
-	}
-
-	if !inGitRepo {
-		return fmt.Errorf("cannot save preferred pipelines: not in a git repository")
 	}
 
 	names := make([]string, len(pipelines))

--- a/internal/pipeline/resolver/config_test.go
+++ b/internal/pipeline/resolver/config_test.go
@@ -32,7 +32,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 
 		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SetPreferredPipelines(pipelines, true)
+		conf.SetPreferredPipelines(pipelines)
 		resolve := ResolveFromConfig(conf, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {
@@ -53,7 +53,7 @@ func TestResolvePipelineFromConfig(t *testing.T) {
 
 		pipelines := []pipeline.Pipeline{{Name: "pipeline1"}, {Name: "pipeline2"}, {Name: "pipeline3"}}
 		conf := config.New(afero.NewMemMapFs(), nil)
-		conf.SetPreferredPipelines(pipelines, true)
+		conf.SetPreferredPipelines(pipelines)
 		resolve := ResolveFromConfig(conf, PassthruPicker)
 		selected, err := resolve(context.Background())
 		if err != nil {

--- a/internal/pipeline/resolver/picker.go
+++ b/internal/pipeline/resolver/picker.go
@@ -57,7 +57,7 @@ func PickOneWithFactory(f *factory.Factory) PipelinePicker {
 
 // CachedPicker returns a PipelinePicker that saves the given pipelines to local config as well as running the provider
 // picker.
-func CachedPicker(conf *config.Config, picker PipelinePicker, inGitRepo bool) PipelinePicker {
+func CachedPicker(conf *config.Config, picker PipelinePicker) PipelinePicker {
 	return func(pipelines []pipeline.Pipeline) *pipeline.Pipeline {
 		// run the picker first because we want to put the chosen on at the top of the saved list
 		chosen := picker(pipelines)
@@ -76,11 +76,8 @@ func CachedPicker(conf *config.Config, picker PipelinePicker, inGitRepo bool) Pi
 		})
 		pipelines[0], pipelines[index] = tmp, pipelines[0]
 
-		// save the pipelines to local config before passing to the picker
-		err := conf.SetPreferredPipelines(pipelines, inGitRepo)
-		if err != nil {
-			return nil
-		}
+		// best-effort: cache the selection if possible
+		_ = conf.SetPreferredPipelines(pipelines)
 
 		return &tmp
 	}

--- a/internal/pipeline/resolver/picker_test.go
+++ b/internal/pipeline/resolver/picker_test.go
@@ -47,7 +47,7 @@ func TestPickers(t *testing.T) {
 		pipelines := []pipeline.Pipeline{
 			{Name: "pipeline", Org: "org"},
 		}
-		picked := resolver.CachedPicker(conf, resolver.PassthruPicker, true)(pipelines)
+		picked := resolver.CachedPicker(conf, resolver.PassthruPicker)(pipelines)
 
 		if picked == nil {
 			t.Fatal("Should not have received nil from picker")
@@ -66,7 +66,7 @@ func TestPickers(t *testing.T) {
 		conf := config.New(fs, nil)
 
 		pipelines := []pipeline.Pipeline{}
-		resolver.CachedPicker(conf, func(p []pipeline.Pipeline) *pipeline.Pipeline { return nil }, true)(pipelines)
+		resolver.CachedPicker(conf, func(p []pipeline.Pipeline) *pipeline.Pipeline { return nil })(pipelines)
 
 		b, _ := afero.ReadFile(fs, ".bk.yaml")
 		expected := ""
@@ -86,7 +86,7 @@ func TestPickers(t *testing.T) {
 			{Name: "second"},
 			{Name: "third"},
 		}
-		resolver.CachedPicker(conf, func(p []pipeline.Pipeline) *pipeline.Pipeline { return &p[1] }, true)(pipelines)
+		resolver.CachedPicker(conf, func(p []pipeline.Pipeline) *pipeline.Pipeline { return &p[1] })(pipelines)
 
 		saved := readSavedConfig(t, fs)
 		expected := []string{"second", "first", "third"}


### PR DESCRIPTION
### Description

For some reason, to run simple commands like `bk configure`, we have a hard dependency that the user is in a `.git` initialised dir. Why?

This also removes the need for such a condition when using `--local` to set configs, and removes failures if caching is not successful.

We've basically almost entirely removed the `isGitRepo` check from the workflow.

### Changes

- removed a lot of the `inGitRepo` checks as they weren't needed for function of the CLI
- `bk configure` will no longer fail (lol) if the dir doesn't have a `.git`
- setting configs (`bk config set --local`) won't fail without a `.git`

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

### Caveats

If anyone suggests a good reason to have these in then I'm all ears, but not being able to set `bk configure` up with tokens unless you were in a Git repo seems odd

