### PR TITLE
fix: empty build list should return [], not string error

### DIFF
--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -171,8 +171,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	if len(builds) == 0 {
-		fmt.Println("No builds found matching the specified criteria.")
-		return nil
+		return output.Write(os.Stdout, []buildkite.Build{}, format)
 	}
 
 	return displayBuilds(builds, format, os.Stdout)

--- a/cmd/build/list_test.go
+++ b/cmd/build/list_test.go
@@ -1,9 +1,12 @@
 package build
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildkite/cli/v3/pkg/output"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
@@ -56,6 +59,32 @@ func TestBuildListOptions_EmptyMetaData(t *testing.T) {
 
 	if len(opts.MetaData.MetaData) != 0 {
 		t.Errorf("Expected empty meta-data, got %d entries", len(opts.MetaData.MetaData))
+	}
+}
+
+func TestDisplayBuilds_EmptyJSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := displayBuilds([]buildkite.Build{}, output.FormatJSON, &buf)
+	if err != nil {
+		t.Fatalf("displayBuilds failed: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Errorf("Expected empty JSON array '[]', got %q", got)
+	}
+}
+
+func TestDisplayBuilds_EmptyYAML(t *testing.T) {
+	var buf bytes.Buffer
+	err := displayBuilds([]buildkite.Build{}, output.FormatYAML, &buf)
+	if err != nil {
+		t.Fatalf("displayBuilds failed: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Errorf("Expected empty YAML array '[]', got %q", got)
 	}
 }
 

--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -173,6 +173,9 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	if len(jobs) == 0 {
+		if format != output.FormatText {
+			return output.Write(os.Stdout, []buildkite.Job{}, format)
+		}
 		fmt.Println("No jobs found matching the specified criteria.")
 		return nil
 	}

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -1,11 +1,40 @@
 package job
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildkite/cli/v3/pkg/output"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
+
+func TestDisplayJobs_EmptyJSON(t *testing.T) {
+	var buf bytes.Buffer
+	err := displayJobs([]buildkite.Job{}, output.FormatJSON, &buf)
+	if err != nil {
+		t.Fatalf("displayJobs failed: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Errorf("Expected empty JSON array '[]', got %q", got)
+	}
+}
+
+func TestDisplayJobs_EmptyYAML(t *testing.T) {
+	var buf bytes.Buffer
+	err := displayJobs([]buildkite.Job{}, output.FormatYAML, &buf)
+	if err != nil {
+		t.Fatalf("displayJobs failed: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "[]" {
+		t.Errorf("Expected empty YAML array '[]', got %q", got)
+	}
+}
 
 func TestFilterJobs(t *testing.T) {
 	now := time.Now()


### PR DESCRIPTION
### Description

Currently we're printing a string error when `json` is expected, we should instead return `[]` when no builds match a set of filters.

Fixes https://github.com/buildkite/cli/issues/634

### Changes

- returns the correct JSON response type where no builds found for filters `[]`
- fixes the same issue in `job list`
- adds tests to ensure result matches output set (`[]` or `nil`)

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

