### PR TITLE
Fixed the shebang in the release script to use the correct path

### DIFF
--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   golangci-lint:
     image: golangci/golangci-lint:v2.8.0

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # This script is used to build a release of the CLI and publish it to multiple registries on Buildkite


### PR DESCRIPTION
### Description

The current shebang is invalid, causing the agent to fallback to using dash and thus error on the use of `[[`.

Also remove the `version` from the compose file as that's so 2024

