### PR TITLE
preflight: if the repo has no remote, skip push & cleanup

### DIFF
--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -111,6 +111,9 @@ func (c *PreflightCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error
 			snapshotDetail += fmt.Sprintf("\n %s %s", file.StatusSymbol(), file.Path)
 		}
 	}
+	if result.PushSkipped {
+		snapshotDetail += "\nWarning: no remote \"origin\" found; push skipped"
+	}
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: "Pushed snapshot of working tree...", Detail: snapshotDetail})
 
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Creating build on %s/%s...", resolvedPipeline.Org, resolvedPipeline.Name)})
@@ -168,7 +171,7 @@ func (c *PreflightCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error
 	buildResult := NewResult(finalBuild)
 	finalErr := buildResult.Error()
 
-	if !c.NoCleanup {
+	if !c.NoCleanup && !result.PushSkipped {
 		_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Cleaning up remote branch %s...", result.Branch)})
 		if cleanupErr := preflight.Cleanup(repoRoot, result.Ref, globals.EnableDebug()); cleanupErr != nil {
 			_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Warning: failed to delete remote branch %s: %v", result.Ref, cleanupErr)})

--- a/internal/preflight/snapshot.go
+++ b/internal/preflight/snapshot.go
@@ -16,10 +16,11 @@ type FileChange struct {
 
 // SnapshotResult holds the output of a successful snapshot operation.
 type SnapshotResult struct {
-	Commit string
-	Ref    string
-	Branch string
-	Files  []FileChange
+	Commit      string
+	Ref         string
+	Branch      string
+	Files       []FileChange
+	PushSkipped bool
 }
 
 func (r SnapshotResult) ShortCommit() string {
@@ -110,17 +111,23 @@ func Snapshot(dir string, preflightID uuid.UUID, opts ...SnapshotOption) (*Snaps
 		return nil, err
 	}
 
-	// Push the commit to the remote branch.
-	refspec := fmt.Sprintf("%s:%s", commit, ref)
-	if err := gitRun(dir, env, cfg.debug, "push", "origin", refspec); err != nil {
-		return nil, err
+	var pushSkipped bool
+	if _, err := gitOutput(dir, env, cfg.debug, "remote", "get-url", "origin"); err != nil {
+		pushSkipped = true
+	} else {
+		// Push the commit to the remote branch.
+		refspec := fmt.Sprintf("%s:%s", commit, ref)
+		if err := gitRun(dir, env, cfg.debug, "push", "origin", refspec); err != nil {
+			return nil, err
+		}
 	}
 
 	return &SnapshotResult{
-		Commit: commit,
-		Ref:    ref,
-		Branch: branch,
-		Files:  files,
+		Commit:      commit,
+		Ref:         ref,
+		Branch:      branch,
+		Files:       files,
+		PushSkipped: pushSkipped,
 	}, nil
 }
 

--- a/internal/preflight/snapshot_test.go
+++ b/internal/preflight/snapshot_test.go
@@ -364,6 +364,33 @@ func TestDiffFiles(t *testing.T) {
 	}
 }
 
+func TestSnapshot_NoRemote(t *testing.T) {
+	worktree := initTestRepo(t)
+
+	// Remove the origin remote.
+	runGit(t, worktree, "remote", "remove", "origin")
+
+	// Add a change so we exercise the commit path too.
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("# changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	preflightID := uuid.MustParse("00000000-0000-0000-0000-000000000010")
+	result, err := Snapshot(worktree, preflightID)
+	if err != nil {
+		t.Fatalf("Snapshot() error: %v", err)
+	}
+
+	if !result.PushSkipped {
+		t.Error("expected PushSkipped to be true when no remote exists")
+	}
+
+	// The commit should still be valid.
+	if len(result.Commit) != 40 {
+		t.Errorf("expected 40-char SHA, got %q", result.Commit)
+	}
+}
+
 func TestSnapshot_CleanWorktree(t *testing.T) {
 	worktree := initTestRepo(t)
 


### PR DESCRIPTION
When a git repo has no remote, preflight would previously do this:

```
Error: snapshot error: git push origin 3f6b6eaf03a0d2eaf7be4a02ede2ab34740b29cc:refs/heads/bk/preflight/019d4313-4222-730d-9669-98483dc2e507: exit status 128 (failed to create preflight snapshot)
```

There are useful workflows where a buildkite-agent runs on the same machine as a git repo, with the pipeline configured with a repository of `/path/to/codebase/.git`. Changes to the that git repo don't need to be pushed anywhere for the agent/build/preflight to use them.

Emit a warning in this case, because it could also be an accidental misconfiguration.