### PR TITLE
Don't render emojis in text mode

### DIFF
--- a/cmd/preflight/job_presenter.go
+++ b/cmd/preflight/job_presenter.go
@@ -41,11 +41,11 @@ func (p jobPresenter) failParts(j buildkite.Job) (symbol, name, detail string) {
 
 func (p jobPresenter) Line(j buildkite.Job) string {
 	symbol, name, detail := p.failParts(j)
-	return fmt.Sprintf("%s %s %s", symbol, emoji.Render(name), detail)
+	return fmt.Sprintf("%s %s %s", symbol, name, detail)
 }
 
 func (p jobPresenter) PassedLine(j buildkite.Job) string {
-	name := emoji.Render(watch.NewFormattedJob(j).DisplayName())
+	name := watch.NewFormattedJob(j).DisplayName()
 	return fmt.Sprintf("✔ %s", name)
 }
 

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -74,10 +74,15 @@ func (m ttyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case EventBuildSummary:
-			// Store the summary on the model so View() renders it as the
-			// final frame when the program quits via Close().
+			// Print the summary via Printf (which scrolls it above the
+			// view) instead of rendering it through View(). Inline-image
+			// escape sequences from emoji.Render confuse Bubbletea's
+			// cursor tracking, causing lines to vanish on re-render.
 			m.summary = &msg
-			return m, nil
+			return m, tea.Sequence(
+				tea.Printf("%s", buildSummaryView(msg)),
+				tea.Quit,
+			)
 
 		case EventTestFailure:
 			if len(msg.TestFailures) > 0 {
@@ -129,10 +134,6 @@ func (m ttyModel) hardwrapLine(s string) string {
 func (m ttyModel) render() string {
 	separator := ttyBorderStyle.Render("─────────────────────────────────────────────")
 
-	if m.summary != nil {
-		return buildSummaryView(*m.summary)
-	}
-
 	statusLine := fmt.Sprintf("  %s %s", m.spinner.View(), ttyStatusStyle.Render(m.statusText()))
 
 	if m.latest.Jobs == nil {
@@ -161,6 +162,11 @@ func (m ttyModel) render() string {
 }
 
 func (m ttyModel) View() string {
+	if m.summary != nil {
+		// Summary was already printed via tea.Printf; return empty
+		// so Bubbletea clears the spinner area on exit.
+		return ""
+	}
 	return m.hardwrapLine(m.render())
 }
 


### PR DESCRIPTION
### Description

Don't render emojis when `--text` is used, instead use their `:` format

### Changes

- no longer renders emojis in text format
- fixes an issue with a disappearing line in summary view

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
