### PR TITLE
Parse source commit and branch in preflight builds

### DIFF
--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -81,6 +81,15 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 	startedAt := time.Now()
 
+	sourceContext, err := preflight.ResolveSourceContext(repoRoot, globals.EnableDebug())
+	if err != nil {
+		return bkErrors.NewValidationError(
+			err,
+			"failed to resolve preflight source git context",
+			"Ensure the repository has at least one commit",
+		)
+	}
+
 	renderer := newRenderer(os.Stdout, c.JSON, c.Text, stop)
 
 	rlTransport.OnRateLimit = func(attempt int, delay time.Duration) {
@@ -120,14 +129,20 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Creating build on %s/%s...", resolvedPipeline.Org, resolvedPipeline.Name)})
 
+	env := map[string]string{
+		"PREFLIGHT":               "true",
+		"BUILDKITE_PREFLIGHT":     "true", // deprecated
+		"PREFLIGHT_SOURCE_COMMIT": sourceContext.Commit,
+	}
+	if sourceContext.Branch != "" {
+		env["PREFLIGHT_SOURCE_BRANCH"] = sourceContext.Branch
+	}
+
 	build, _, err := f.RestAPIClient.Builds.Create(ctx, resolvedPipeline.Org, resolvedPipeline.Name, buildkite.CreateBuild{
 		Message: fmt.Sprintf("Preflight %s", preflightID),
 		Commit:  result.Commit,
 		Branch:  result.Branch,
-		Env: map[string]string{
-			"PREFLIGHT":           "true",
-			"BUILDKITE_PREFLIGHT": "true", // deprecated
-		},
+		Env:     env,
 	})
 	if err != nil {
 		return bkErrors.WrapAPIError(err, "creating preflight build")

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -109,6 +109,9 @@ func TestRunCmd_Run(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		expectedSourceBranch := runGit(t, worktree, "branch", "--show-current")
+		expectedSourceCommit := runGit(t, worktree, "rev-parse", "HEAD")
+
 		cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: false, Interval: 2}
 		err := cmd.Run(nil, stubGlobals{})
 		if err != nil {
@@ -130,11 +133,61 @@ func TestRunCmd_Run(t *testing.T) {
 		if gotReq.Env["BUILDKITE_PREFLIGHT"] != "true" {
 			t.Errorf("expected BUILDKITE_PREFLIGHT=true (deprecated), got %#v", gotReq.Env)
 		}
+		if gotReq.Env["PREFLIGHT_SOURCE_BRANCH"] != expectedSourceBranch {
+			t.Errorf("expected PREFLIGHT_SOURCE_BRANCH=%q, got %#v", expectedSourceBranch, gotReq.Env)
+		}
+		if gotReq.Env["PREFLIGHT_SOURCE_COMMIT"] != expectedSourceCommit {
+			t.Errorf("expected PREFLIGHT_SOURCE_COMMIT=%q, got %#v", expectedSourceCommit, gotReq.Env)
+		}
 		if !strings.Contains(gotUserAgent, buildkite.DefaultUserAgent) {
 			t.Errorf("expected User-Agent to contain %q, got %q", buildkite.DefaultUserAgent, gotUserAgent)
 		}
 		if !strings.Contains(gotUserAgent, "buildkite-cli-preflight/") {
 			t.Errorf("expected User-Agent to contain preflight token, got %q", gotUserAgent)
+		}
+	})
+
+	t.Run("omits source branch env when git HEAD is detached", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		var gotReq buildkite.CreateBuild
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && strings.Contains(r.URL.Path, "/builds") {
+				json.NewDecoder(r.Body).Decode(&gotReq)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "scheduled",
+					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
+				})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		expectedSourceCommit := runGit(t, worktree, "rev-parse", "HEAD")
+		runGit(t, worktree, "checkout", expectedSourceCommit)
+
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: false, Interval: 2}
+		err := cmd.Run(nil, stubGlobals{})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		if _, ok := gotReq.Env["PREFLIGHT_SOURCE_BRANCH"]; ok {
+			t.Errorf("expected PREFLIGHT_SOURCE_BRANCH to be omitted in detached HEAD, got %#v", gotReq.Env)
+		}
+		if gotReq.Env["PREFLIGHT_SOURCE_COMMIT"] != expectedSourceCommit {
+			t.Errorf("expected PREFLIGHT_SOURCE_COMMIT=%q, got %#v", expectedSourceCommit, gotReq.Env)
 		}
 	})
 

--- a/internal/preflight/git.go
+++ b/internal/preflight/git.go
@@ -48,6 +48,27 @@ func RepositoryRoot(dir string, debug bool) (string, error) {
 	return gitOutput(dir, nil, debug, "rev-parse", "--show-toplevel")
 }
 
+// SourceContext describes the original git state that preflight was created from.
+type SourceContext struct {
+	Branch string
+	Commit string
+}
+
+// ResolveSourceContext returns the current branch name (if any) and HEAD commit.
+func ResolveSourceContext(dir string, debug bool) (SourceContext, error) {
+	branch, err := gitOutput(dir, nil, debug, "branch", "--show-current")
+	if err != nil {
+		return SourceContext{}, err
+	}
+
+	commit, err := gitOutput(dir, nil, debug, "rev-parse", "HEAD")
+	if err != nil {
+		return SourceContext{}, err
+	}
+
+	return SourceContext{Branch: branch, Commit: commit}, nil
+}
+
 // tempIndexEnv returns a copy of the current environment with GIT_INDEX_FILE
 // set to path, stripping any existing GIT_INDEX_FILE entry. This is used to
 // direct git commands at a temporary index without affecting the real one.


### PR DESCRIPTION
### Description

Supports the passing of `BUILDKITE_PREFLIGHT_SOURCE_COMMIT` to preflight builds, as well as `BUILDKITE_PREFLIGHT_SOURCE_BRANCH` when not in a detached `HEAD` state.

### Changes

- Resolves the git context from the original state that a preflight build was created from
- Expands the build env to always include `BUILDKITE_PREFLIGHT_SOURCE_COMMIT` in preflight builds
- When not in detached `HEAD`, we will also set `BUILDKITE_PREFLIGHT_SOURCE_BRANCH`, where the source branch can be resolved

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

