### PR TITLE
remove the renovate dashboard from issues tab

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":disableDependencyDashboard",
     ":semanticCommits",
     ":automergeMinor",
     "schedule:nonOfficeHours"


### PR DESCRIPTION
### Description

I think the dependency dashboard is an artifact from an initial Renovate install and isn't at all used, but maintains a single open issue on the project, which might be annoying.

