### PR TITLE
fix: keep diagnostics off stdout for structured output

### DIFF
--- a/cmd/artifacts/list.go
+++ b/cmd/artifacts/list.go
@@ -93,8 +93,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return err
 	}
 	if bld == nil {
-		fmt.Println("No build found.")
-		return nil
+		return output.WriteTextOrStructured(os.Stdout, format, []buildkite.Artifact{}, "No build found.")
 	}
 
 	var buildArtifacts []buildkite.Artifact

--- a/cmd/build/view.go
+++ b/cmd/build/view.go
@@ -87,6 +87,7 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	ctx := context.Background()
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 
 	var opts view.ViewOptions
 	opts.Pipeline = c.Pipeline
@@ -126,8 +127,7 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return err
 	}
 	if bld == nil {
-		fmt.Println("No build found.")
-		return nil
+		return output.WriteTextOrStructured(os.Stdout, format, nil, "No build found.")
 	}
 
 	opts.Organization = bld.Organization
@@ -229,7 +229,6 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		},
 	}
 
-	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 	if format == output.FormatText {
 		writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
 		defer func() { _ = cleanup() }()

--- a/cmd/organization/list.go
+++ b/cmd/organization/list.go
@@ -41,10 +41,10 @@ func (c *ListCmd) Run(globals cli.GlobalFlags) error {
 
 	f.NoPager = f.NoPager || globals.DisablePager()
 
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 	orgs := f.Config.ConfiguredOrganizations()
 	if len(orgs) == 0 {
-		fmt.Println("No organizations configured. Run `bk configure` to add one.")
-		return nil
+		return output.WriteTextOrStructured(os.Stdout, format, []Organization{}, "No organizations configured. Run `bk configure` to add one.")
 	}
 
 	slices.Sort(orgs)
@@ -57,8 +57,6 @@ func (c *ListCmd) Run(globals cli.GlobalFlags) error {
 			Selected: org == selectedOrg,
 		}
 	}
-
-	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 
 	if format != output.FormatText {
 		return output.Write(os.Stdout, organizations, format)

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -99,9 +99,9 @@ func (c *ListCmd) runPipelineList(ctx context.Context, f *factory.Factory) error
 		return fmt.Errorf("failed to list pipelines: %w", err)
 	}
 
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 	if len(pipelines) == 0 {
-		fmt.Fprintln(os.Stdout, "No pipelines found matching the specified criteria.")
-		return nil
+		return output.WriteTextOrStructured(os.Stdout, format, []buildkite.Pipeline{}, "No pipelines found matching the specified criteria.")
 	}
 
 	return c.displayPipelines(pipelines, f)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/browser"
@@ -21,7 +22,7 @@ func OpenInWebBrowser(openInWeb bool, webUrl string) error {
 	if openInWeb {
 		err := browser.OpenURL(webUrl)
 		if err != nil {
-			fmt.Println("Error opening browser: ", err)
+			fmt.Fprintf(os.Stderr, "Error opening browser: %v\n", err)
 			return err
 		}
 	}

--- a/pkg/cmd/validation/config.go
+++ b/pkg/cmd/validation/config.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/buildkite/cli/v3/internal/config"
@@ -58,7 +59,7 @@ func validateConfiguration(conf *config.Config, commandPath, orgOverride string)
 		return errors.New("you are not authenticated. Run bk auth login to authenticate")
 	// an organization may not be present if the user is only viewing public resources
 	case missingOrg:
-		fmt.Println("Warning: no organization set, only public pipelines will be visible. Run bk auth login, or bk use, to set an organization")
+		fmt.Fprintln(os.Stderr, "Warning: no organization set, only public pipelines will be visible. Run bk auth login, or bk use, to set an organization")
 		return nil
 	}
 

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -61,11 +61,14 @@ func TestValidateConfiguration_MissingValues(t *testing.T) {
 		t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
 		conf := newTestConfig(t)
 
+		var validationErr error
 		stdout, stderr := captureStandardStreams(t, func() {
-			if err := ValidateConfiguration(conf, "pipeline view"); err != nil {
-				t.Fatalf("expected no error when only org is missing, got %v", err)
-			}
+			validationErr = ValidateConfiguration(conf, "pipeline view")
 		})
+
+		if validationErr != nil {
+			t.Fatalf("expected no error when only org is missing, got %v", validationErr)
+		}
 
 		if stdout != "" {
 			t.Fatalf("expected stdout to remain empty, got %q", stdout)

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -1,6 +1,9 @@
 package validation
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/cli/v3/internal/config"
@@ -52,6 +55,26 @@ func TestValidateConfiguration_MissingValues(t *testing.T) {
 			t.Fatalf("expected no error when token and org are set, got %v", err)
 		}
 	})
+
+	t.Run("missing org warning is written to stderr", func(t *testing.T) {
+		t.Setenv("BUILDKITE_API_TOKEN", "token")
+		t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+		conf := newTestConfig(t)
+
+		stdout, stderr := captureStandardStreams(t, func() {
+			if err := ValidateConfiguration(conf, "pipeline view"); err != nil {
+				t.Fatalf("expected no error when only org is missing, got %v", err)
+			}
+		})
+
+		if stdout != "" {
+			t.Fatalf("expected stdout to remain empty, got %q", stdout)
+		}
+
+		if !strings.Contains(stderr, "Warning: no organization set") {
+			t.Fatalf("expected stderr warning, got %q", stderr)
+		}
+	})
 }
 
 func newTestConfig(t *testing.T) *config.Config {
@@ -60,4 +83,55 @@ func newTestConfig(t *testing.T) *config.Config {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	bkKeyring.MockForTesting()
 	return config.New(nil, nil)
+}
+
+func captureStandardStreams(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stdout error = %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stderr error = %v", err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	if err := stdoutW.Close(); err != nil {
+		t.Fatalf("stdout close error = %v", err)
+	}
+	if err := stderrW.Close(); err != nil {
+		t.Fatalf("stderr close error = %v", err)
+	}
+
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("stdout read error = %v", err)
+	}
+	stderrBytes, err := io.ReadAll(stderrR)
+	if err != nil {
+		t.Fatalf("stderr read error = %v", err)
+	}
+
+	if err := stdoutR.Close(); err != nil {
+		t.Fatalf("stdout reader close error = %v", err)
+	}
+	if err := stderrR.Close(); err != nil {
+		t.Fatalf("stderr reader close error = %v", err)
+	}
+
+	return string(stdoutBytes), string(stderrBytes)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -53,6 +53,17 @@ func Write(w io.Writer, v interface{}, format Format) error {
 	}
 }
 
+// WriteTextOrStructured writes a human-readable text line for text output and
+// structured output for JSON or YAML formats.
+func WriteTextOrStructured(w io.Writer, format Format, structuredValue interface{}, text string) error {
+	if format == FormatText {
+		_, err := fmt.Fprintln(w, text)
+		return err
+	}
+
+	return Write(w, structuredValue, format)
+}
+
 func writeJSON(w io.Writer, v interface{}) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,50 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteTextOrStructured(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes text for text output", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		if err := WriteTextOrStructured(&buf, FormatText, []string{}, "No pipelines found."); err != nil {
+			t.Fatalf("WriteTextOrStructured() error = %v", err)
+		}
+
+		if got := strings.TrimSpace(buf.String()); got != "No pipelines found." {
+			t.Fatalf("WriteTextOrStructured() = %q, want %q", got, "No pipelines found.")
+		}
+	})
+
+	t.Run("writes structured empty collections for json output", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		if err := WriteTextOrStructured(&buf, FormatJSON, []string{}, "ignored"); err != nil {
+			t.Fatalf("WriteTextOrStructured() error = %v", err)
+		}
+
+		if got := strings.TrimSpace(buf.String()); got != "[]" {
+			t.Fatalf("WriteTextOrStructured() = %q, want %q", got, "[]")
+		}
+	})
+
+	t.Run("writes structured null values for json output", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		if err := WriteTextOrStructured(&buf, FormatJSON, nil, "ignored"); err != nil {
+			t.Fatalf("WriteTextOrStructured() error = %v", err)
+		}
+
+		if got := strings.TrimSpace(buf.String()); got != "null" {
+			t.Fatalf("WriteTextOrStructured() = %q, want %q", got, "null")
+		}
+	})
+}


### PR DESCRIPTION
Support machine-readable CLI output by keeping diagnostics off stdout.

Structured output commands currently print warnings and empty-state messages to stdout, which breaks callers that expect stdout to contain only JSON or YAML. Browser-open failures also use stdout even though they are diagnostics.

This routes shared warnings to stderr and makes JSON- and YAML-capable commands return structured empty values when no resources are found. It also adds focused regression coverage around the shared output helper and configuration validation warning so structured output stays clean.
