### PR TITLE
Add preflight test summary output

### DIFF
--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
@@ -53,4 +54,7 @@ type Event struct {
 
 	// TestFailures is set for test_failure events.
 	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`
+
+	// Tests is set for build_summary events when aggregated test summary data is available.
+	Tests map[string]internalpreflight.ShowTestSuite `json:"tests,omitempty"`
 }

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -34,6 +34,7 @@ type PreflightCmd struct {
 	JSON      bool                `help:"Emit one JSON object per event (JSONL)." xor:"output"`
 	Default   PreflightDefaultCmd `cmd:"" optional:"" hidden:"" default:"1"`
 	Show      ShowCmd             `cmd:"" help:"Show the current status and results for a preflight build."`
+	WatchRun  WatchRunCmd         `cmd:"" help:"Watch preflight-edge events for a preflight run." hidden:""`
 }
 
 type PreflightDefaultCmd struct{}
@@ -215,6 +216,20 @@ func (c *PreflightCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error
 			BuildState:  finalBuild.State,
 			Duration:    time.Since(startedAt),
 		}
+
+		showResult, showErr := preflight.LoadShowResult(ctx, f.RestAPIClient, resolvedPipeline.Org, preflightID.String(), preflight.ShowOptions{})
+		if showErr == nil {
+			summaryEvent.Tests = showResult.Tests
+		} else if globals.EnableDebug() {
+			_ = renderer.Render(Event{
+				Type:        EventOperation,
+				Time:        time.Now(),
+				PreflightID: preflightID.String(),
+				Title:       fmt.Sprintf("Debug: failed to load final test summary: %v", showErr),
+			})
+		}
+
+		// API Call to Preflight Endpoint
 		if buildResult.Passed() {
 			if passed := tracker.PassedJobs(); len(passed) <= 10 {
 				summaryEvent.PassedJobs = passed

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	"github.com/mattn/go-isatty"
 )
 
@@ -88,6 +90,11 @@ func (r *plainRenderer) Render(e Event) error {
 				return err
 			}
 		}
+		for _, line := range summaryTestLines(e.Tests) {
+			if _, err := fmt.Fprintf(r.stdout, "  %s\n", line); err != nil {
+				return err
+			}
+		}
 
 	case EventTestFailure:
 		if e.TestFailures != nil {
@@ -155,6 +162,31 @@ func plural(n int, word string) string {
 		return word
 	}
 	return word + "s"
+}
+
+func summaryTestLines(tests map[string]internalpreflight.ShowTestSuite) []string {
+	if len(tests) == 0 {
+		return nil
+	}
+
+	suites := make([]string, 0, len(tests))
+	for suite := range tests {
+		suites = append(suites, suite)
+	}
+	slices.Sort(suites)
+
+	lines := make([]string, 0, len(suites))
+	for _, suite := range suites {
+		summary := tests[suite]
+		parts := []string{
+			fmt.Sprintf("%d passed", summary.Passed),
+			fmt.Sprintf("%d failed", summary.Failed),
+			fmt.Sprintf("%d skipped", summary.Skipped),
+		}
+		lines = append(lines, fmt.Sprintf("%s tests: %s", suite, strings.Join(parts, ", ")))
+	}
+
+	return lines
 }
 
 func jobLogCommand(pipeline string, buildNumber int, jobID string) string {

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
@@ -554,6 +555,31 @@ func TestPlainRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	}
 }
 
+func TestPlainRenderer_Render_BuildSummaryIncludesTests(t *testing.T) {
+	var out bytes.Buffer
+	r := newPlainRenderer(&out)
+
+	if err := r.Render(Event{
+		Type:       EventBuildSummary,
+		Time:       time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
+		BuildState: "failed",
+		Tests: map[string]internalpreflight.ShowTestSuite{
+			"go":    {Passed: 12, Failed: 1, Skipped: 0},
+			"rspec": {Passed: 47, Failed: 2, Skipped: 3},
+		},
+	}); err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "go tests: 12 passed, 1 failed, 0 skipped") {
+		t.Fatalf("expected go test summary, got %q", got)
+	}
+	if !strings.Contains(got, "rspec tests: 47 passed, 2 failed, 3 skipped") {
+		t.Fatalf("expected rspec test summary, got %q", got)
+	}
+}
+
 func TestJSONRenderer_Render_BuildSummaryPassed(t *testing.T) {
 	var out bytes.Buffer
 	r := newJSONRenderer(&out)
@@ -613,6 +639,39 @@ func TestJSONRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	failedJobs, ok := got["failed_jobs"].([]any)
 	if !ok || len(failedJobs) != 1 {
 		t.Fatalf("expected 1 failed job, got %v", got["failed_jobs"])
+	}
+}
+
+func TestJSONRenderer_Render_BuildSummaryIncludesTests(t *testing.T) {
+	var out bytes.Buffer
+	r := newJSONRenderer(&out)
+
+	if err := r.Render(Event{
+		Type:        EventBuildSummary,
+		Time:        time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
+		PreflightID: "pfid-123",
+		BuildState:  "failed",
+		Tests: map[string]internalpreflight.ShowTestSuite{
+			"rspec": {Passed: 47, Failed: 2, Skipped: 3},
+		},
+	}); err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	tests, ok := got["tests"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tests object, got %v", got["tests"])
+	}
+	rspec, ok := tests["rspec"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected rspec summary, got %v", tests["rspec"])
+	}
+	if rspec["passed"] != float64(47) || rspec["failed"] != float64(2) || rspec["skipped"] != float64(3) {
+		t.Fatalf("unexpected rspec summary: %v", rspec)
 	}
 }
 

--- a/cmd/preflight/show.go
+++ b/cmd/preflight/show.go
@@ -18,6 +18,7 @@ import (
 
 type ShowCmd struct {
 	PreflightID string `arg:"" name:"uuid" help:"The preflight UUID to inspect."`
+	Failures    bool   `help:"Include detailed test failures in the output."`
 }
 
 func (c *ShowCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
@@ -54,7 +55,9 @@ func (c *ShowCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return bkErrors.NewValidationError(err, "invalid preflight UUID")
 	}
 
-	result, err := internalpreflight.LoadShowResult(context.Background(), f.RestAPIClient, org, preflightID.String())
+	result, err := internalpreflight.LoadShowResult(context.Background(), f.RestAPIClient, org, preflightID.String(), internalpreflight.ShowOptions{
+		IncludeFailures: c.Failures,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/preflight/show_test.go
+++ b/cmd/preflight/show_test.go
@@ -19,29 +19,36 @@ func TestShowCmd_Run(t *testing.T) {
 
 	preflightID := "00000000-0000-0000-0000-000000000123"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	type requestExpectations struct {
+		includeLatestFail bool
+	}
 
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
-			if got, want := r.URL.Query()["branch[]"], []string{"bk/preflight/" + preflightID}; len(got) != 1 || got[0] != want[0] {
-				t.Errorf("branch filter = %v, want %v", got, want)
-			}
-			_, _ = w.Write([]byte(`[
+	run := func(t *testing.T, cmd ShowCmd, expect requestExpectations) internalpreflight.ShowResult {
+		t.Helper()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
+				if got, want := r.URL.Query()["branch[]"], []string{"bk/preflight/" + preflightID}; len(got) != 1 || got[0] != want[0] {
+					t.Errorf("branch filter = %v, want %v", got, want)
+				}
+				_, _ = w.Write([]byte(`[
 				{
 					"id": "build-123",
 					"number": 123,
 					"pipeline": {"slug": "test-pipeline"}
 				}
 			]`))
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/pipelines/test-pipeline/builds/123":
-			if r.URL.Query().Get("include_test_engine") != "true" {
-				t.Errorf("include_test_engine query = %q, want true", r.URL.Query().Get("include_test_engine"))
-			}
-			if r.URL.Query().Get("include_retried_jobs") != "true" {
-				t.Errorf("include_retried_jobs query = %q, want true", r.URL.Query().Get("include_retried_jobs"))
-			}
-			_, _ = w.Write([]byte(`{
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/pipelines/test-pipeline/builds/123":
+				if r.URL.Query().Get("include_test_engine") != "true" {
+					t.Errorf("include_test_engine query = %q, want true", r.URL.Query().Get("include_test_engine"))
+				}
+				if r.URL.Query().Get("include_retried_jobs") != "true" {
+					t.Errorf("include_retried_jobs query = %q, want true", r.URL.Query().Get("include_retried_jobs"))
+				}
+				_, _ = w.Write([]byte(`{
 				"id": "build-123",
 				"number": 123,
 				"state": "failed",
@@ -97,115 +104,131 @@ func TestShowCmd_Run(t *testing.T) {
 					}
 				]
 			}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/v2/analytics/organizations/test-org/builds/build-123/tests":
-			switch {
-			case r.URL.Query().Get("result") == "failed":
-				if r.URL.Query().Get("include") != "latest_fail" {
-					t.Errorf("include query = %q, want latest_fail", r.URL.Query().Get("include"))
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/preflight/runs/build-123":
+				if r.URL.Query().Get("build_id") != "build-123" {
+					t.Errorf("build_id query = %q, want build-123", r.URL.Query().Get("build_id"))
 				}
-				_, _ = w.Write([]byte(`[
-					{
-						"id": "test-failed",
-						"scope": "AuthService",
-						"name": "validateToken handles expired tokens",
-						"location": "src/auth.test.ts:89",
-						"state": "enabled",
-						"latest_fail": {
-							"id": "exec-1",
-							"failure_reason": "Expected 'expired' but got 'invalid'",
-							"failure_expanded": [
-								{
-									"backtrace": ["", "        src/auth.test.ts:89", "      "],
-									"expanded": ["Do not use Array index in keys", "react/no-array-index-key"]
-								}
-							]
+				if r.URL.Query().Get("failed_result") != "failed" {
+					t.Errorf("failed_result query = %q, want failed", r.URL.Query().Get("failed_result"))
+				}
+				if gotInclude := r.URL.Query().Get("include"); expect.includeLatestFail {
+					if gotInclude != "latest_fail" {
+						t.Errorf("include query = %q, want latest_fail", gotInclude)
+					}
+				} else if gotInclude != "" {
+					t.Errorf("include query = %q, want empty", gotInclude)
+				}
+				_, _ = w.Write([]byte(`{
+				"tests": {
+					"runs": {
+						"run-1": {
+							"suite": {"id": "suite-1", "slug": "rspec"},
+							"passed": 47,
+							"failed": 1,
+							"skipped": 12
 						}
-					}
-				]`))
-			default:
-				_, _ = w.Write([]byte(`[
-					{
-						"id": "test-passed",
-						"scope": "AuthService",
-						"name": "validateToken handles valid tokens",
-						"location": "src/auth.test.ts:50",
-						"state": "enabled",
-						"executions_count_by_result": {"passed": 47, "failed": 0, "skipped": 0}
 					},
-					{
-						"id": "test-failed",
-						"scope": "AuthService",
-						"name": "validateToken handles expired tokens",
-						"location": "src/auth.test.ts:89",
-						"state": "enabled",
-						"executions_count_by_result": {"passed": 0, "failed": 1, "skipped": 12}
-					}
-				]`))
+					"failures": [
+						{
+							"run_id": "run-1",
+							"suite_slug": "rspec",
+							"name": "AuthService.validateToken handles expired tokens",
+							"location": "src/auth.test.ts:89",
+							"latest_fail": {
+								"failure_reason": "Expected 'expired' but got 'invalid'",
+								"failure_expanded": [
+									{
+										"backtrace": ["", "        src/auth.test.ts:89", "      "],
+										"expanded": ["Do not use Array index in keys", "react/no-array-index-key"]
+									}
+								]
+							}
+						}
+					]
+				}
+			}`))
+			default:
+				http.NotFound(w, r)
 			}
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-	t.Setenv("BUILDKITE_REST_API_ENDPOINT", server.URL)
+		}))
+		t.Cleanup(server.Close)
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", server.URL)
 
-	worktree := initTestRepo(t)
-	t.Chdir(worktree)
-	if err := os.WriteFile(filepath.Join(worktree, ".bk.yaml"), []byte("selected_org: test-org\n"), 0o644); err != nil {
-		t.Fatalf("writing local config: %v", err)
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		if err := os.WriteFile(filepath.Join(worktree, ".bk.yaml"), []byte("selected_org: test-org\n"), 0o644); err != nil {
+			t.Fatalf("writing local config: %v", err)
+		}
+
+		stdout := captureStdout(t, func() {
+			if err := cmd.Run(nil, stubGlobals{}); err != nil {
+				t.Fatalf("ShowCmd.Run returned error: %v", err)
+			}
+		})
+
+		var got internalpreflight.ShowResult
+		if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+			t.Fatalf("decoding output JSON: %v\noutput=%s", err, stdout)
+		}
+
+		return got
 	}
 
-	stdout := captureStdout(t, func() {
-		cmd := &ShowCmd{PreflightID: preflightID}
-		if err := cmd.Run(nil, stubGlobals{}); err != nil {
-			t.Fatalf("ShowCmd.Run returned error: %v", err)
+	t.Run("without failures flag", func(t *testing.T) {
+		got := run(t, ShowCmd{PreflightID: preflightID}, requestExpectations{})
+
+		if got.Status != "failed" {
+			t.Fatalf("status = %q, want failed", got.Status)
+		}
+		if got.DurationMS != 23400 {
+			t.Fatalf("duration_ms = %d, want 23400", got.DurationMS)
+		}
+		if got.BuildURL != "https://buildkite.com/test-org/test-pipeline/builds/123" {
+			t.Fatalf("build_url = %q", got.BuildURL)
+		}
+
+		suite, ok := got.Tests["rspec"]
+		if !ok {
+			t.Fatalf("tests missing rspec suite: %#v", got.Tests)
+		}
+		if suite.Passed != 47 || suite.Failed != 1 || suite.Skipped != 12 {
+			t.Fatalf("suite counts = %+v, want passed=47 failed=1 skipped=12", suite)
+		}
+		if len(suite.Failures) != 0 {
+			t.Fatalf("failures len = %d, want 0", len(suite.Failures))
+		}
+
+		if got.Jobs.Passed != 1 || got.Jobs.Failed != 1 {
+			t.Fatalf("job summary = %+v, want passed=1 failed=1", got.Jobs)
+		}
+		if len(got.Jobs.FailedJobs) != 1 {
+			t.Fatalf("failed_jobs len = %d, want 1", len(got.Jobs.FailedJobs))
+		}
+		if got.Jobs.FailedJobs[0].ID != "job-failed" || !got.Jobs.FailedJobs[0].Retried {
+			t.Fatalf("failed job = %+v", got.Jobs.FailedJobs[0])
 		}
 	})
 
-	var got internalpreflight.ShowResult
-	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
-		t.Fatalf("decoding output JSON: %v\noutput=%s", err, stdout)
-	}
+	t.Run("with failures flag", func(t *testing.T) {
+		got := run(t, ShowCmd{PreflightID: preflightID, Failures: true}, requestExpectations{includeLatestFail: true})
 
-	if got.Status != "failed" {
-		t.Fatalf("status = %q, want failed", got.Status)
-	}
-	if got.DurationMS != 23400 {
-		t.Fatalf("duration_ms = %d, want 23400", got.DurationMS)
-	}
-	if got.BuildURL != "https://buildkite.com/test-org/test-pipeline/builds/123" {
-		t.Fatalf("build_url = %q", got.BuildURL)
-	}
-
-	suite, ok := got.Tests["rspec"]
-	if !ok {
-		t.Fatalf("tests missing rspec suite: %#v", got.Tests)
-	}
-	if suite.Passed != 47 || suite.Failed != 1 || suite.Skipped != 12 {
-		t.Fatalf("suite counts = %+v, want passed=47 failed=1 skipped=12", suite)
-	}
-	if len(suite.Failures) != 1 {
-		t.Fatalf("failures len = %d, want 1", len(suite.Failures))
-	}
-	if suite.Failures[0].Name != "AuthService.validateToken handles expired tokens" {
-		t.Fatalf("failure name = %q", suite.Failures[0].Name)
-	}
-	if suite.Failures[0].Message != "Expected 'expired' but got 'invalid'" {
-		t.Fatalf("failure message = %q", suite.Failures[0].Message)
-	}
-	if len(suite.Failures[0].FailureDetail) != 1 || len(suite.Failures[0].FailureDetail[0].Expanded) != 2 {
-		t.Fatalf("failure detail = %+v", suite.Failures[0].FailureDetail)
-	}
-
-	if got.Jobs.Passed != 1 || got.Jobs.Failed != 1 {
-		t.Fatalf("job summary = %+v, want passed=1 failed=1", got.Jobs)
-	}
-	if len(got.Jobs.FailedJobs) != 1 {
-		t.Fatalf("failed_jobs len = %d, want 1", len(got.Jobs.FailedJobs))
-	}
-	if got.Jobs.FailedJobs[0].ID != "job-failed" || !got.Jobs.FailedJobs[0].Retried {
-		t.Fatalf("failed job = %+v", got.Jobs.FailedJobs[0])
-	}
+		suite, ok := got.Tests["rspec"]
+		if !ok {
+			t.Fatalf("tests missing rspec suite: %#v", got.Tests)
+		}
+		if len(suite.Failures) != 1 {
+			t.Fatalf("failures len = %d, want 1", len(suite.Failures))
+		}
+		if suite.Failures[0].Name != "AuthService.validateToken handles expired tokens" {
+			t.Fatalf("failure name = %q", suite.Failures[0].Name)
+		}
+		if suite.Failures[0].Message != "Expected 'expired' but got 'invalid'" {
+			t.Fatalf("failure message = %q", suite.Failures[0].Message)
+		}
+		if len(suite.Failures[0].FailureDetail) != 1 || len(suite.Failures[0].FailureDetail[0].Expanded) != 2 {
+			t.Fatalf("failure detail = %+v", suite.Failures[0].FailureDetail)
+		}
+	})
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -187,6 +187,9 @@ func buildSummaryView(e Event) string {
 	for _, j := range e.FailedJobs {
 		out += "\n  " + presenter.ColoredLine(j)
 	}
+	for _, line := range summaryTestLines(e.Tests) {
+		out += "\n  " + ttyDimStyle.Render(line)
+	}
 
 	return out
 }

--- a/cmd/preflight/tty_test.go
+++ b/cmd/preflight/tty_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
@@ -56,6 +57,17 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 				}(),
 			},
 			contains: []string{"✗", "Lint", "failed with exit 1"},
+		},
+		{
+			name: "build with tests",
+			event: Event{
+				Type:       EventBuildSummary,
+				BuildState: "failed",
+				Tests: map[string]internalpreflight.ShowTestSuite{
+					"rspec": {Passed: 47, Failed: 2, Skipped: 3},
+				},
+			},
+			contains: []string{"rspec tests: 47 passed, 2 failed, 3 skipped"},
 		},
 	}
 

--- a/internal/preflight/show.go
+++ b/internal/preflight/show.go
@@ -17,6 +17,41 @@ import (
 
 const showLimit = 100
 
+type preflightRunsSummaryResponse struct {
+	Tests preflightRunsSummaryTests `json:"tests"`
+}
+
+type preflightRunsSummaryTests struct {
+	Runs     map[string]preflightRunSummary `json:"runs"`
+	Failures []preflightRunFailure          `json:"failures"`
+}
+
+type preflightRunSummary struct {
+	Suite   preflightRunSuite `json:"suite"`
+	Passed  int               `json:"passed"`
+	Failed  int               `json:"failed"`
+	Skipped int               `json:"skipped"`
+}
+
+type preflightRunSuite struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+}
+
+type preflightRunFailure struct {
+	RunID         string                  `json:"run_id"`
+	SuiteSlug     string                  `json:"suite_slug"`
+	Name          string                  `json:"name"`
+	Location      string                  `json:"location"`
+	FailureReason string                  `json:"failure_reason"`
+	LatestFail    *preflightRunLatestFail `json:"latest_fail,omitempty"`
+}
+
+type preflightRunLatestFail struct {
+	FailureReason   string                      `json:"failure_reason"`
+	FailureExpanded []buildkite.FailureExpanded `json:"failure_expanded,omitempty"`
+}
+
 type ShowResult struct {
 	Status     string                   `json:"status"`
 	DurationMS int64                    `json:"duration_ms"`
@@ -61,7 +96,11 @@ type ShowFailedJob struct {
 	State      string `json:"state"`
 }
 
-func LoadShowResult(ctx context.Context, client *buildkite.Client, org, preflightID string) (ShowResult, error) {
+type ShowOptions struct {
+	IncludeFailures bool
+}
+
+func LoadShowResult(ctx context.Context, client *buildkite.Client, org, preflightID string, opts ShowOptions) (ShowResult, error) {
 	result := ShowResult{
 		Tests: map[string]ShowTestSuite{},
 		Jobs: ShowJobs{
@@ -87,7 +126,7 @@ func LoadShowResult(ctx context.Context, client *buildkite.Client, org, prefligh
 	result.BuildURL = build.WebURL
 	result.Jobs = summarizeJobs(build)
 
-	tests, err := summarizeTests(ctx, client, org, build)
+	tests, err := summarizeTests(ctx, client, org, build, opts)
 	if err != nil {
 		return ShowResult{}, err
 	}
@@ -155,13 +194,13 @@ func summarizeJobs(build buildkite.Build) ShowJobs {
 	return summary
 }
 
-func summarizeTests(ctx context.Context, client *buildkite.Client, org string, build buildkite.Build) (map[string]ShowTestSuite, error) {
+func summarizeTests(ctx context.Context, client *buildkite.Client, org string, build buildkite.Build, opts ShowOptions) (map[string]ShowTestSuite, error) {
 	suiteKey := primarySuiteSlug(build)
 	if suiteKey == "" || build.ID == "" {
 		return map[string]ShowTestSuite{}, nil
 	}
 
-	allTests, err := listBuildTests(ctx, client, org, build.ID, buildkite.BuildTestsListOptions{State: "enabled"}, 0)
+	summary, err := loadPreflightRunsSummary(ctx, client, org, build.ID, opts)
 	if err != nil {
 		if isOptionalShowTestError(err) {
 			return map[string]ShowTestSuite{}, nil
@@ -169,57 +208,62 @@ func summarizeTests(ctx context.Context, client *buildkite.Client, org string, b
 		return nil, bkErrors.WrapAPIError(err, "loading preflight test summary")
 	}
 
-	failedTests, err := listBuildTests(ctx, client, org, build.ID, buildkite.BuildTestsListOptions{
-		Result:  "failed",
-		State:   "enabled",
-		Include: "latest_fail",
-	}, showLimit)
-	if err != nil {
-		if isOptionalShowTestError(err) {
-			return map[string]ShowTestSuite{}, nil
+	tests := map[string]ShowTestSuite{}
+	for _, run := range summary.Tests.Runs {
+		slug := strings.TrimSpace(run.Suite.Slug)
+		if slug == "" {
+			slug = suiteKey
 		}
-		return nil, bkErrors.WrapAPIError(err, "loading preflight test failures")
+		tests[slug] = ShowTestSuite{
+			Passed:   run.Passed,
+			Failed:   run.Failed,
+			Skipped:  run.Skipped,
+			Failures: []ShowTestFailure{},
+		}
 	}
 
-	// The build tests API is scoped to a build rather than a suite, so we can
-	// only produce one aggregated summary for the build today.
-	suite := ShowTestSuite{Failures: []ShowTestFailure{}}
-	for _, test := range allTests {
-		suite.Passed += test.ExecutionsCountByResult.Passed
-		suite.Failed += test.ExecutionsCountByResult.Failed
-		suite.Skipped += test.ExecutionsCountByResult.Skipped
-	}
-	for _, test := range failedTests {
-		suite.Failures = append(suite.Failures, showTestFailure(test))
+	if !opts.IncludeFailures {
+		return tests, nil
 	}
 
-	return map[string]ShowTestSuite{suiteKey: suite}, nil
+	for _, failure := range summary.Tests.Failures {
+		slug := strings.TrimSpace(failure.SuiteSlug)
+		if slug == "" {
+			slug = suiteKey
+		}
+		suite := tests[slug]
+		if len(suite.Failures) >= showLimit {
+			tests[slug] = suite
+			continue
+		}
+		suite.Failures = append(suite.Failures, showRunFailure(failure))
+		tests[slug] = suite
+	}
+
+	return tests, nil
 }
 
-func listBuildTests(ctx context.Context, client *buildkite.Client, org, buildID string, opt buildkite.BuildTestsListOptions, limit int) ([]buildkite.BuildTest, error) {
-	opt.ListOptions = buildkite.ListOptions{Page: 1, PerPage: 100}
-	var tests []buildkite.BuildTest
-
-	for {
-		pageTests, resp, err := client.BuildTests.List(ctx, org, buildID, &opt)
-		if err != nil {
-			return nil, err
-		}
-
-		if limit > 0 && len(tests)+len(pageTests) > limit {
-			pageTests = pageTests[:limit-len(tests)]
-		}
-		tests = append(tests, pageTests...)
-
-		if limit > 0 && len(tests) >= limit {
-			return tests, nil
-		}
-		if resp == nil || resp.NextPage == 0 {
-			return tests, nil
-		}
-
-		opt.Page = resp.NextPage
+func loadPreflightRunsSummary(ctx context.Context, client *buildkite.Client, org, buildID string, opts ShowOptions) (*preflightRunsSummaryResponse, error) {
+	query := url.Values{}
+	query.Set("build_id", buildID)
+	query.Set("failed_result", "failed")
+	if opts.IncludeFailures {
+		query.Set("include", "latest_fail")
 	}
+
+	path := fmt.Sprintf("v2/organizations/%s/preflight/runs/%s?%s", org, buildID, query.Encode())
+	req, err := client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var summary preflightRunsSummaryResponse
+	_, err = client.Do(req, &summary)
+	if err != nil {
+		return nil, err
+	}
+
+	return &summary, nil
 }
 
 func showBuildStatus(build buildkite.Build) string {
@@ -262,20 +306,20 @@ func primarySuiteSlug(build buildkite.Build) string {
 	return ""
 }
 
-func showTestFailure(test buildkite.BuildTest) ShowTestFailure {
+func showRunFailure(runFailure preflightRunFailure) ShowTestFailure {
 	failure := ShowTestFailure{
-		Name:          displayTestName(test),
-		Location:      test.Location,
+		Name:          strings.TrimSpace(runFailure.Name),
+		Location:      runFailure.Location,
 		FailureDetail: []ShowFailureDetail{},
 	}
 
-	if test.LatestFail == nil {
+	if runFailure.LatestFail == nil {
 		return failure
 	}
 
-	failure.Message = test.LatestFail.FailureReason
-	failure.FailureReason = test.LatestFail.FailureReason
-	for _, detail := range test.LatestFail.FailureExpanded {
+	failure.Message = runFailure.LatestFail.FailureReason
+	failure.FailureReason = runFailure.LatestFail.FailureReason
+	for _, detail := range runFailure.LatestFail.FailureExpanded {
 		failure.FailureDetail = append(failure.FailureDetail, ShowFailureDetail{
 			Backtrace: detail.Backtrace,
 			Expanded:  detail.Expanded,
@@ -292,19 +336,6 @@ func displayJobName(job buildkite.Job) string {
 		}
 	}
 	return ""
-}
-
-func displayTestName(test buildkite.BuildTest) string {
-	scope := strings.TrimSpace(test.Scope)
-	name := strings.TrimSpace(test.Name)
-	switch {
-	case scope == "":
-		return name
-	case name == "":
-		return scope
-	default:
-		return scope + "." + name
-	}
 }
 
 func pipelineSlugFromBuild(build buildkite.Build) string {


### PR DESCRIPTION
### Description

This stacks on top of `preflight-show-command` and finishes wiring the new preflight summary API into the CLI output.

The main problem here was that `bk preflight show` always emitted the full failure list, which gets noisy quickly on larger runs, and `bk preflight --watch` still finished with a job-only summary even after the new suite-level test summary endpoint existed.

This change keeps the summary output lightweight by default and uses the preflight summary API for the final watched summary as well.

### Changes

- add `--failures` to `bk preflight show` so detailed test failures are opt-in
- keep the default `bk preflight show` output limited to suite counts
- fetch the aggregated preflight test summary for the final `build_summary` event in `bk preflight --watch`
- render suite counts in the plain-text, TTY, and JSON final summary output
- update the `show` and renderer tests for the new summary behavior

### Testing
- [ ] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

Ran targeted tests locally:
- `go test ./cmd/preflight -run '^(TestShowCmd_Run|TestPlainRenderer_Render_BuildSummary|TestJSONRenderer_Render_BuildSummary|TestBuildSummaryView_ReturnsOutput)$'`
- `go test ./internal/preflight -run '^Test'`

### Disclosures / Credits

I used Codex to implement the CLI changes, run targeted tests, and draft this PR.