### PR TITLE
Print build link in preflight summary

### DIFF
--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -137,13 +137,18 @@ func summaryHeader(e Event) string {
 }
 
 func summaryBuildLine(e Event) string {
-	if e.BuildURL == "" {
+	label := summaryBuildLabel(e)
+	if e.BuildURL == "" || label == "" {
 		return ""
 	}
+	return fmt.Sprintf("%s: %s", label, e.BuildURL)
+}
+
+func summaryBuildLabel(e Event) string {
 	if e.BuildNumber > 0 {
-		return fmt.Sprintf("Build #%d: %s", e.BuildNumber, e.BuildURL)
+		return fmt.Sprintf("Build #%d", e.BuildNumber)
 	}
-	return fmt.Sprintf("Build: %s", e.BuildURL)
+	return ""
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -77,6 +77,11 @@ func (r *plainRenderer) Render(e Event) error {
 		if _, err := fmt.Fprintf(r.stdout, "\n%s\n", header); err != nil {
 			return err
 		}
+		if line := summaryBuildLine(e); line != "" {
+			if _, err := fmt.Fprintf(r.stdout, "  %s\n", line); err != nil {
+				return err
+			}
+		}
 		presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
 		for _, j := range e.PassedJobs {
 			if _, err := fmt.Fprintf(r.stdout, "  %s\n", presenter.PassedLine(j)); err != nil {
@@ -129,6 +134,16 @@ func summaryHeader(e Event) string {
 		return fmt.Sprintf("%s (%s)", verdict, formatDuration(e.Duration))
 	}
 	return verdict
+}
+
+func summaryBuildLine(e Event) string {
+	if e.BuildURL == "" {
+		return ""
+	}
+	if e.BuildNumber > 0 {
+		return fmt.Sprintf("Build #%d: %s", e.BuildNumber, e.BuildURL)
+	}
+	return fmt.Sprintf("Build: %s", e.BuildURL)
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -569,6 +569,7 @@ func TestPlainRenderer_Render_BuildSummaryPassed(t *testing.T) {
 		Time:        time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
 		Pipeline:    "buildkite/cli",
 		BuildNumber: 42,
+		BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 		BuildState:  "passed",
 		PassedJobs: []buildkite.Job{
 			{ID: "job-1", Name: "Lint", Type: "script", State: "passed"},
@@ -581,6 +582,9 @@ func TestPlainRenderer_Render_BuildSummaryPassed(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, "✅ Preflight Passed") {
 		t.Fatalf("expected passed header, got %q", got)
+	}
+	if !strings.Contains(got, "Build #42: https://buildkite.com/buildkite/cli/builds/42") {
+		t.Fatalf("expected build URL in summary, got %q", got)
 	}
 	if !strings.Contains(got, "Lint") {
 		t.Fatalf("expected passed job name, got %q", got)
@@ -600,6 +604,7 @@ func TestPlainRenderer_Render_BuildSummaryFailed(t *testing.T) {
 		Time:        time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
 		Pipeline:    "buildkite/cli",
 		BuildNumber: 42,
+		BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 		BuildState:  "failed",
 		FailedJobs: []buildkite.Job{
 			{ID: "job-1", Name: "Lint", Type: "script", State: "failed", ExitStatus: &exitOne},
@@ -611,6 +616,9 @@ func TestPlainRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, "❌ Preflight Failed") {
 		t.Fatalf("expected failed header, got %q", got)
+	}
+	if !strings.Contains(got, "Build #42: https://buildkite.com/buildkite/cli/builds/42") {
+		t.Fatalf("expected build URL in summary, got %q", got)
 	}
 	if !strings.Contains(got, "Lint") {
 		t.Fatalf("expected hard-failed job name, got %q", got)

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -179,6 +179,9 @@ func buildSummaryView(e Event) string {
 
 	separator := ttyBorderStyle.Render("─────────────────────────────────────────────")
 	out := separator + "\n" + style.Render(summaryHeader(e))
+	if line := summaryBuildLine(e); line != "" {
+		out += "\n  " + ttyDimStyle.Render(line)
+	}
 
 	presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
 	for _, j := range e.PassedJobs {

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -80,7 +80,7 @@ func (m ttyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// cursor tracking, causing lines to vanish on re-render.
 			m.summary = &msg
 			return m, tea.Sequence(
-				tea.Printf("%s", buildSummaryView(msg)),
+				tea.Printf("%s", m.buildSummaryView(msg)),
 				tea.Quit,
 			)
 
@@ -170,8 +170,8 @@ func (m ttyModel) View() string {
 	return m.hardwrapLine(m.render())
 }
 
-// buildSummaryView renders the final build summary as a string for use in View().
-func buildSummaryView(e Event) string {
+// buildSummaryView renders the final build summary for TTY output.
+func (m ttyModel) buildSummaryView(e Event) string {
 	style := ttyFailureStyle
 	if e.BuildState == "passed" {
 		style = ttyStatusStyle
@@ -179,8 +179,9 @@ func buildSummaryView(e Event) string {
 
 	separator := ttyBorderStyle.Render("─────────────────────────────────────────────")
 	out := separator + "\n" + style.Render(summaryHeader(e))
-	if line := summaryBuildLine(e); line != "" {
-		out += "\n  " + ttyDimStyle.Render(line)
+	if label := summaryBuildLabel(e); label != "" && e.BuildURL != "" {
+		out += "\n  " + ttyDimStyle.Render(label)
+		out += "\n" + m.hardwrapLine("  "+ttyDimStyle.Render(e.BuildURL))
 	}
 
 	presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}

--- a/cmd/preflight/tty_test.go
+++ b/cmd/preflight/tty_test.go
@@ -10,21 +10,24 @@ import (
 func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 	tests := []struct {
 		name     string
+		width    int
 		event    Event
 		contains []string
 	}{
 		{
-			name: "passed build no jobs",
+			name:  "passed build no jobs",
+			width: 0,
 			event: Event{
 				Type:        EventBuildSummary,
 				BuildState:  "passed",
 				BuildNumber: 42,
 				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 			},
-			contains: []string{"─────", "Build #42: https://buildkite.com/buildkite/cli/builds/42"},
+			contains: []string{"─────", "Build #42", "https://buildkite.com/buildkite/cli/builds/42"},
 		},
 		{
-			name: "passed build with jobs",
+			name:  "passed build with jobs",
+			width: 0,
 			event: Event{
 				Type:        EventBuildSummary,
 				BuildState:  "passed",
@@ -35,20 +38,22 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 					{ID: "j2", Name: "Test", Type: "script", State: "passed"},
 				},
 			},
-			contains: []string{"Build #42: https://buildkite.com/buildkite/cli/builds/42", "✔ Lint", "✔ Test"},
+			contains: []string{"Build #42", "https://buildkite.com/buildkite/cli/builds/42", "✔ Lint", "✔ Test"},
 		},
 		{
-			name: "failed build no jobs",
+			name:  "failed build no jobs",
+			width: 0,
 			event: Event{
 				Type:        EventBuildSummary,
 				BuildState:  "failed",
 				BuildNumber: 42,
 				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 			},
-			contains: []string{"─────", "Build #42: https://buildkite.com/buildkite/cli/builds/42"},
+			contains: []string{"─────", "Build #42", "https://buildkite.com/buildkite/cli/builds/42"},
 		},
 		{
-			name: "failed build with jobs",
+			name:  "failed build with jobs",
+			width: 0,
 			event: Event{
 				Type:        EventBuildSummary,
 				BuildState:  "failed",
@@ -62,13 +67,24 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 					}
 				}(),
 			},
-			contains: []string{"Build #42: https://buildkite.com/buildkite/cli/builds/42", "✗", "Lint", "failed with exit 1"},
+			contains: []string{"Build #42", "https://buildkite.com/buildkite/cli/builds/42", "✗", "Lint", "failed with exit 1"},
+		},
+		{
+			name:  "wraps build url on narrow terminals",
+			width: 24,
+			event: Event{
+				Type:        EventBuildSummary,
+				BuildState:  "passed",
+				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
+			},
+			contains: []string{"Build #42", "https://buildkite.com/", "buildkite/cli/builds/42"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildSummaryView(tt.event)
+			got := (ttyModel{width: tt.width}).buildSummaryView(tt.event)
 			if got == "" {
 				t.Fatal("expected non-empty summary view")
 			}

--- a/cmd/preflight/tty_test.go
+++ b/cmd/preflight/tty_test.go
@@ -16,30 +16,36 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 		{
 			name: "passed build no jobs",
 			event: Event{
-				Type:       EventBuildSummary,
-				BuildState: "passed",
+				Type:        EventBuildSummary,
+				BuildState:  "passed",
+				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 			},
-			contains: []string{"─────"},
+			contains: []string{"─────", "Build #42: https://buildkite.com/buildkite/cli/builds/42"},
 		},
 		{
 			name: "passed build with jobs",
 			event: Event{
-				Type:       EventBuildSummary,
-				BuildState: "passed",
+				Type:        EventBuildSummary,
+				BuildState:  "passed",
+				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 				PassedJobs: []buildkite.Job{
 					{ID: "j1", Name: "Lint", Type: "script", State: "passed"},
 					{ID: "j2", Name: "Test", Type: "script", State: "passed"},
 				},
 			},
-			contains: []string{"✔ Lint", "✔ Test"},
+			contains: []string{"Build #42: https://buildkite.com/buildkite/cli/builds/42", "✔ Lint", "✔ Test"},
 		},
 		{
 			name: "failed build no jobs",
 			event: Event{
-				Type:       EventBuildSummary,
-				BuildState: "failed",
+				Type:        EventBuildSummary,
+				BuildState:  "failed",
+				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 			},
-			contains: []string{"─────"},
+			contains: []string{"─────", "Build #42: https://buildkite.com/buildkite/cli/builds/42"},
 		},
 		{
 			name: "failed build with jobs",
@@ -48,6 +54,7 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 				BuildState:  "failed",
 				Pipeline:    "buildkite/cli",
 				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
 				FailedJobs: func() []buildkite.Job {
 					exit := 1
 					return []buildkite.Job{
@@ -55,7 +62,7 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 					}
 				}(),
 			},
-			contains: []string{"✗", "Lint", "failed with exit 1"},
+			contains: []string{"Build #42: https://buildkite.com/buildkite/cli/builds/42", "✗", "Lint", "failed with exit 1"},
 		},
 	}
 


### PR DESCRIPTION
### Description

Print a link to the build in the summary when preflight finishes.

### Testing
- [X] Tests have run locally (with `go test ./...`)
- [X] Code is formatted (with `go fmt ./...`)

