### PR TITLE
Adding cluster queue support

### DIFF
--- a/cmd/queue/create.go
+++ b/cmd/queue/create.go
@@ -35,8 +35,6 @@ func (c *CreateCmd) Validate() error {
 
 func (c *CreateCmd) Help() string {
 	return `
-Create a new queue in a cluster.
-
 Examples:
   # Create a queue with just a key
   $ bk queue create my-cluster-uuid --key my-queue

--- a/cmd/queue/create.go
+++ b/cmd/queue/create.go
@@ -25,11 +25,15 @@ type CreateCmd struct {
 }
 
 func (c *CreateCmd) Validate() error {
-	switch c.RetryAgentAffinity {
-	case "", "prefer-warmest", "prefer-different": // doing this to avoid enum which clashes with Kong as a value must be present, when this will default on the API side if not provided.
+	switch buildkite.RetryAgentAffinity(c.RetryAgentAffinity) {
+	case "", buildkite.RetryAgentAffinityPreferWarmest, buildkite.RetryAgentAffinityPreferDifferent:
 		return nil
 	default:
-		return fmt.Errorf("invalid --retry-agent-affinity value %q: must be prefer-warmest or prefer-different", c.RetryAgentAffinity)
+		return fmt.Errorf("invalid --retry-agent-affinity value %q: must be %s or %s",
+			c.RetryAgentAffinity,
+			buildkite.RetryAgentAffinityPreferWarmest,
+			buildkite.RetryAgentAffinityPreferDifferent,
+		)
 	}
 }
 

--- a/cmd/queue/create.go
+++ b/cmd/queue/create.go
@@ -83,12 +83,12 @@ func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	var queue buildkite.ClusterQueue
-	if err = bkIO.SpinWhile(f, "Creating queue", func() error {
+	if err = bkIO.SpinWhile(f, "Creating cluster queue", func() error {
 		var apiErr error
 		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Create(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, input)
 		return apiErr
 	}); err != nil {
-		return fmt.Errorf("error creating queue: %w", err)
+		return fmt.Errorf("error creating cluster queue: %w", err)
 	}
 
 	queueView := output.Viewable[buildkite.ClusterQueue]{
@@ -100,6 +100,9 @@ func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return output.Write(os.Stdout, queueView, format)
 	}
 
-	fmt.Fprintf(os.Stdout, "Queue %s created successfully\n\n", queue.Key)
-	return output.Write(os.Stdout, queueView, format)
+	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
+	defer func() { _ = cleanup() }()
+
+	fmt.Fprintf(writer, "Queue %s created successfully\n\n", queue.Key)
+	return output.Write(writer, queueView, format)
 }

--- a/cmd/queue/create.go
+++ b/cmd/queue/create.go
@@ -1,0 +1,103 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type CreateCmd struct {
+	ClusterUUID        string `arg:"" help:"Cluster UUID to create the queue in" name:"cluster-uuid"`
+	Key                string `help:"A unique key for the queue" required:""`
+	Description        string `help:"A description of the queue" optional:""`
+	RetryAgentAffinity string `help:"Retry agent affinity setting (prefer-warmest or prefer-different)" optional:"" name:"retry-agent-affinity"`
+	output.OutputFlags
+}
+
+func (c *CreateCmd) Validate() error {
+	switch c.RetryAgentAffinity {
+	case "", "prefer-warmest", "prefer-different": // doing this to avoid enum which clashes with Kong as a value must be present, when this will default on the API side if not provided.
+		return nil
+	default:
+		return fmt.Errorf("invalid --retry-agent-affinity value %q: must be prefer-warmest or prefer-different", c.RetryAgentAffinity)
+	}
+}
+
+func (c *CreateCmd) Help() string {
+	return `
+Create a new queue in a cluster.
+
+Examples:
+  # Create a queue with just a key
+  $ bk queue create my-cluster-uuid --key my-queue
+
+  # Create a queue with a description
+  $ bk queue create my-cluster-uuid --key my-queue --description "My new queue"
+
+  # Create a queue with retry agent affinity set
+  $ bk queue create my-cluster-uuid --key my-queue --retry-agent-affinity prefer-different
+
+  # Create a queue and output as JSON
+  $ bk queue create my-cluster-uuid --key my-queue -o json
+`
+}
+
+func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+	f.NoPager = f.NoPager || globals.DisablePager()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	input := buildkite.ClusterQueueCreate{
+		Key:         c.Key,
+		Description: c.Description,
+	}
+	if c.RetryAgentAffinity != "" {
+		input.RetryAgentAffinity = buildkite.RetryAgentAffinity(c.RetryAgentAffinity)
+	}
+
+	var queue buildkite.ClusterQueue
+	if err = bkIO.SpinWhile(f, "Creating queue", func() error {
+		var apiErr error
+		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Create(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, input)
+		return apiErr
+	}); err != nil {
+		return fmt.Errorf("error creating queue: %w", err)
+	}
+
+	queueView := output.Viewable[buildkite.ClusterQueue]{
+		Data:   queue,
+		Render: renderQueueText,
+	}
+
+	if format != output.FormatText {
+		return output.Write(os.Stdout, queueView, format)
+	}
+
+	fmt.Fprintf(os.Stdout, "Queue %s created successfully\n\n", queue.Key)
+	return output.Write(os.Stdout, queueView, format)
+}

--- a/cmd/queue/delete.go
+++ b/cmd/queue/delete.go
@@ -65,6 +65,6 @@ func (c *DeleteCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return fmt.Errorf("error deleting cluster queue: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, "Queue deleted successfully.")
+	fmt.Fprintf(os.Stderr, "Queue %s deleted successfully.\n", c.QueueUUID)
 	return nil
 }

--- a/cmd/queue/delete.go
+++ b/cmd/queue/delete.go
@@ -1,0 +1,70 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+)
+
+type DeleteCmd struct {
+	ClusterUUID string `arg:"" help:"Cluster UUID the queue belongs to" name:"cluster-uuid"`
+	QueueUUID   string `arg:"" help:"Queue UUID to delete" name:"queue-uuid"`
+}
+
+func (c *DeleteCmd) Help() string {
+	return `
+You will be prompted to confirm deletion unless --yes is set.
+
+Examples:
+  # Delete a queue
+  $ bk queue delete my-cluster-uuid my-queue-uuid
+
+  # Delete a queue without confirmation
+  $ bk queue delete my-cluster-uuid my-queue-uuid --yes
+`
+}
+
+func (c *DeleteCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	confirmed, err := bkIO.Confirm(f, fmt.Sprintf("Are you sure you want to delete queue %s?", c.QueueUUID))
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		fmt.Fprintln(os.Stderr, "Deletion cancelled.")
+		return nil
+	}
+
+	if err = bkIO.SpinWhile(f, "Deleting cluster queue", func() error {
+		_, apiErr := f.RestAPIClient.ClusterQueues.Delete(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
+		return apiErr
+	}); err != nil {
+		return fmt.Errorf("error deleting cluster queue: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Queue deleted successfully.")
+	return nil
+}

--- a/cmd/queue/list.go
+++ b/cmd/queue/list.go
@@ -1,0 +1,150 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type ListCmd struct {
+	ClusterUUID string `arg:"" help:"Cluster UUID to list queues for" name:"cluster-uuid"`
+	PerPage     int    `help:"Number of queues per page" default:"30"`
+	Limit       int    `help:"Maximum number of queues to return" default:"100"`
+	output.OutputFlags
+}
+
+func (c *ListCmd) Validate() error {
+	if c.PerPage < 1 {
+		return fmt.Errorf("invalid --per-page %d: must be greater than 0", c.PerPage)
+	}
+
+	if c.Limit < 0 {
+		return fmt.Errorf("invalid --limit %d: must be greater than or equal to 0", c.Limit)
+	}
+
+	return nil
+}
+
+func (c *ListCmd) Help() string {
+	return `
+List cluster queues.
+
+Examples:
+  # List all queues for a cluster
+  $ bk queue list my-cluster-uuid
+
+  # Return more queues
+  $ bk queue list my-cluster-uuid --limit 200
+
+  # List in JSON format
+  $ bk queue list my-cluster-uuid -o json
+`
+}
+
+func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+	f.NoPager = f.NoPager || globals.DisablePager()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var queues []buildkite.ClusterQueue
+	page := 1
+	var previousFirstQueueID string
+
+	for len(queues) < c.Limit {
+		opts := &buildkite.ClusterQueuesListOptions{
+			ListOptions: buildkite.ListOptions{
+				Page:    page,
+				PerPage: c.PerPage,
+			},
+		}
+
+		var pageQueues []buildkite.ClusterQueue
+		if err := bkIO.SpinWhile(f, "Fetching cluster queues", func() error {
+			var apiErr error
+			pageQueues, _, apiErr = f.RestAPIClient.ClusterQueues.List(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, opts)
+			return apiErr
+		}); err != nil {
+			return fmt.Errorf("error fetching cluster queues: %w", err)
+		}
+
+		if len(pageQueues) == 0 {
+			break
+		}
+
+		if page > 1 && pageQueues[0].ID == previousFirstQueueID {
+			return fmt.Errorf("API returned duplicate page content at page %d, stopping pagination to prevent infinite loop", page)
+		}
+		previousFirstQueueID = pageQueues[0].ID
+
+		queues = append(queues, pageQueues...)
+
+		if len(pageQueues) < c.PerPage {
+			break
+		}
+
+		if len(queues) >= c.Limit {
+			break
+		}
+
+		page++
+	}
+
+	if len(queues) > c.Limit {
+		queues = queues[:c.Limit]
+	}
+
+	if format != output.FormatText {
+		return output.Write(os.Stdout, queues, format)
+	}
+
+	if len(queues) == 0 {
+		fmt.Fprintln(os.Stdout, "No queues found")
+		return nil
+	}
+
+	rows := make([][]string, 0, len(queues))
+	for _, q := range queues {
+		paused := "No"
+		if q.DispatchPaused {
+			paused = "Yes"
+		}
+		rows = append(rows, []string{q.Key, output.ValueOrDash(q.Description), paused, q.ID})
+	}
+
+	table := output.Table(
+		[]string{"Key", "Description", "Paused", "ID"},
+		rows,
+		map[string]string{"key": "bold"},
+	)
+
+	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
+	defer func() { _ = cleanup() }()
+
+	_, err = fmt.Fprintf(writer, "Queues (%d)\n\n%s\n", len(queues), table)
+	return err
+}

--- a/cmd/queue/list.go
+++ b/cmd/queue/list.go
@@ -37,8 +37,6 @@ func (c *ListCmd) Validate() error {
 
 func (c *ListCmd) Help() string {
 	return `
-List cluster queues.
-
 Examples:
   # List all queues for a cluster
   $ bk queue list my-cluster-uuid

--- a/cmd/queue/pause.go
+++ b/cmd/queue/pause.go
@@ -1,0 +1,94 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type PauseCmd struct {
+	ClusterUUID string `arg:"" help:"Cluster UUID the queue belongs to" name:"cluster-uuid"`
+	QueueUUID   string `arg:"" help:"Queue UUID to pause" name:"queue-uuid"`
+	Note        string `help:"Optional note explaining why the queue is being paused" optional:"" name:"note"`
+	output.OutputFlags
+}
+
+func (c *PauseCmd) Help() string {
+	return `
+The queue remains paused until it is resumed with "bk queue resume".
+
+Examples:
+  # Pause a queue
+  $ bk queue pause my-cluster-uuid my-queue-uuid
+
+  # Pause a queue with a note
+  $ bk queue pause my-cluster-uuid my-queue-uuid --note "Pausing for maintenance"
+
+  # Output the paused queue as JSON
+  $ bk queue pause my-cluster-uuid my-queue-uuid --note "Maintenance" -o json
+`
+}
+
+func (c *PauseCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+	f.NoPager = f.NoPager || globals.DisablePager()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	input := buildkite.ClusterQueuePause{
+		Note: c.Note,
+	}
+
+	var queue buildkite.ClusterQueue
+	if err = bkIO.SpinWhile(f, "Pausing cluster queue", func() error {
+		var apiErr error
+		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Pause(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID, input)
+		return apiErr
+	}); err != nil {
+		return fmt.Errorf("error pausing cluster queue: %w", err)
+	}
+
+	queueView := output.Viewable[buildkite.ClusterQueue]{
+		Data:   queue,
+		Render: renderQueueText,
+	}
+
+	if format != output.FormatText {
+		return output.Write(os.Stdout, queueView, format)
+	}
+
+	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
+	defer func() { _ = cleanup() }()
+
+	queueIdentifier := queue.Key
+	if queueIdentifier == "" {
+		queueIdentifier = c.QueueUUID
+	}
+
+	fmt.Fprintf(writer, "Queue %s paused successfully\n\n", queueIdentifier)
+	return output.Write(writer, queueView, format)
+}

--- a/cmd/queue/queue_test.go
+++ b/cmd/queue/queue_test.go
@@ -1,0 +1,402 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+func newTestQueue(key, id string, paused bool) buildkite.ClusterQueue {
+	return buildkite.ClusterQueue{
+		ID:             id,
+		Key:            key,
+		Description:    "Test queue",
+		DispatchPaused: paused,
+		CreatedAt:      &buildkite.Timestamp{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+}
+
+func TestCmdQueueList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validates per-page and limit", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			perPage int
+			limit   int
+			wantErr bool
+		}{
+			{"valid defaults", 30, 100, false},
+			{"per-page zero invalid", 0, 100, true},
+			{"per-page negative invalid", -1, 100, true},
+			{"limit zero valid", 30, 0, false},
+			{"limit negative invalid", 30, -1, true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				cmd := &ListCmd{PerPage: tt.perPage, Limit: tt.limit}
+				err := cmd.Validate()
+				if tt.wantErr && err == nil {
+					t.Error("expected error, got nil")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("fetches queues through API", func(t *testing.T) {
+		t.Parallel()
+
+		queues := []buildkite.ClusterQueue{
+			newTestQueue("default", "queue-1", false),
+			newTestQueue("deploy", "queue-2", true),
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "1" {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(queues)
+			} else {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode([]buildkite.ClusterQueue{})
+			}
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		got, _, err := client.ClusterQueues.List(ctx, "test-org", "cluster-1", &buildkite.ClusterQueuesListOptions{
+			ListOptions: buildkite.ListOptions{Page: 1, PerPage: 30},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 queues, got %d", len(got))
+		}
+		if got[0].Key != "default" {
+			t.Errorf("expected first key 'default', got %q", got[0].Key)
+		}
+		if !got[1].DispatchPaused {
+			t.Error("expected second queue to be paused")
+		}
+	})
+
+	t.Run("empty result returns empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]buildkite.ClusterQueue{})
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		got, _, err := client.ClusterQueues.List(ctx, "test-org", "cluster-1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 queues, got %d", len(got))
+		}
+	})
+}
+
+func TestCmdQueueCreate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validates retry agent affinity", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			affinity string
+			wantErr  bool
+		}{
+			{"empty affinity valid", "", false},
+			{"prefer-warmest valid", string(buildkite.RetryAgentAffinityPreferWarmest), false},
+			{"prefer-different valid", string(buildkite.RetryAgentAffinityPreferDifferent), false},
+			{"invalid affinity", "prefer-random", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				cmd := &CreateCmd{ClusterUUID: "cluster-1", Key: "my-queue", RetryAgentAffinity: tt.affinity}
+				err := cmd.Validate()
+				if tt.wantErr && err == nil {
+					t.Error("expected error, got nil")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("creates queue through API", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTestQueue("my-queue", "queue-abc", false)
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(queue)
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		got, _, err := client.ClusterQueues.Create(ctx, "test-org", "cluster-1", buildkite.ClusterQueueCreate{
+			Key:         "my-queue",
+			Description: "Test queue",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Key != "my-queue" {
+			t.Errorf("expected key 'my-queue', got %q", got.Key)
+		}
+	})
+}
+
+func TestCmdQueueUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("requires at least one field", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			description string
+			affinity    string
+			wantErr     bool
+		}{
+			{"no fields provided", "", "", true},
+			{"description only", "new desc", "", false},
+			{"affinity only valid", string(buildkite.RetryAgentAffinityPreferWarmest), "", false},
+			{"both fields", "new desc", string(buildkite.RetryAgentAffinityPreferDifferent), false},
+			{"invalid affinity", "", "bad-value", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				cmd := &UpdateCmd{
+					ClusterUUID:        "cluster-1",
+					QueueUUID:          "queue-1",
+					Description:        tt.description,
+					RetryAgentAffinity: tt.affinity,
+				}
+				err := cmd.Validate()
+				if tt.wantErr && err == nil {
+					t.Error("expected error, got nil")
+				}
+				if !tt.wantErr && err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("updates queue through API", func(t *testing.T) {
+		t.Parallel()
+
+		updated := newTestQueue("my-queue", "queue-abc", false)
+		updated.Description = "Updated description"
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPatch {
+				t.Errorf("expected PATCH, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(updated)
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		got, _, err := client.ClusterQueues.Update(ctx, "test-org", "cluster-1", "queue-abc", buildkite.ClusterQueueUpdate{
+			Description: "Updated description",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Description != "Updated description" {
+			t.Errorf("expected description 'Updated description', got %q", got.Description)
+		}
+	})
+}
+
+func TestCmdQueueDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends DELETE request", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		_, err = client.ClusterQueues.Delete(ctx, "test-org", "cluster-1", "queue-abc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !called {
+			t.Error("expected DELETE to be called")
+		}
+	})
+}
+
+func TestCmdQueuePause(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends POST to pause_dispatch with note", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTestQueue("my-queue", "queue-abc", true)
+		queue.DispatchPausedNote = "maintenance"
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if !strings.HasSuffix(r.URL.Path, "/pause_dispatch") {
+				t.Errorf("expected path to end in /pause_dispatch, got %q", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(queue)
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		got, _, err := client.ClusterQueues.Pause(ctx, "test-org", "cluster-1", "queue-abc", buildkite.ClusterQueuePause{
+			Note: "maintenance",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.DispatchPaused {
+			t.Error("expected queue to be paused")
+		}
+		if got.DispatchPausedNote != "maintenance" {
+			t.Errorf("expected note 'maintenance', got %q", got.DispatchPausedNote)
+		}
+	})
+}
+
+func TestCmdQueueResume(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends POST to resume_dispatch", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if !strings.HasSuffix(r.URL.Path, "/resume_dispatch") {
+				t.Errorf("expected path to end in /resume_dispatch, got %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer s.Close()
+
+		client, err := buildkite.NewOpts(buildkite.WithBaseURL(s.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		_, err = client.ClusterQueues.Resume(ctx, "test-org", "cluster-1", "queue-abc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !called {
+			t.Error("expected resume_dispatch to be called")
+		}
+	})
+}
+
+func TestRenderQueueText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unpaused queue", func(t *testing.T) {
+		t.Parallel()
+		q := newTestQueue("my-queue", "queue-abc", false)
+		out := renderQueueText(q)
+		if !strings.Contains(out, "my-queue") {
+			t.Error("expected output to contain queue key")
+		}
+		if !strings.Contains(out, "No") {
+			t.Error("expected output to show paused as 'No'")
+		}
+	})
+
+	t.Run("paused queue with note", func(t *testing.T) {
+		t.Parallel()
+		q := newTestQueue("my-queue", "queue-abc", true)
+		q.DispatchPausedNote = "maintenance window"
+		out := renderQueueText(q)
+		if !strings.Contains(out, "Yes") {
+			t.Error("expected output to show paused as 'Yes'")
+		}
+		if !strings.Contains(out, "maintenance window") {
+			t.Error("expected output to contain pause note")
+		}
+	})
+}

--- a/cmd/queue/resume.go
+++ b/cmd/queue/resume.go
@@ -63,7 +63,7 @@ func (c *ResumeCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	var queue buildkite.ClusterQueue
-	if err = bkIO.SpinWhile(f, "Loading queue", func() error {
+	if err = bkIO.SpinWhile(f, "Loading cluster queue", func() error {
 		var apiErr error
 		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Get(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
 		return apiErr

--- a/cmd/queue/resume.go
+++ b/cmd/queue/resume.go
@@ -16,30 +16,26 @@ import (
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
-type PauseCmd struct {
+type ResumeCmd struct {
 	ClusterUUID string `arg:"" help:"Cluster UUID the queue belongs to" name:"cluster-uuid"`
-	QueueUUID   string `arg:"" help:"Queue UUID to pause" name:"queue-uuid"`
-	Note        string `help:"Optional note explaining why the queue is being paused" optional:"" name:"note"`
+	QueueUUID   string `arg:"" help:"Queue UUID to resume" name:"queue-uuid"`
 	output.OutputFlags
 }
 
-func (c *PauseCmd) Help() string {
+func (c *ResumeCmd) Help() string {
 	return `
-The queue remains paused until it is resumed with "bk queue resume".
+Resumes dispatch for a paused cluster queue.
 
 Examples:
-  # Pause a queue
-  $ bk queue pause my-cluster-uuid my-queue-uuid
+  # Resume a queue
+  $ bk queue resume my-cluster-uuid my-queue-uuid
 
-  # Pause a queue with a note
-  $ bk queue pause my-cluster-uuid my-queue-uuid --note "Pausing for maintenance"
-
-  # Output the paused queue as JSON
-  $ bk queue pause my-cluster-uuid my-queue-uuid --note "Maintenance" -o json
+  # Output the resumed queue as JSON
+  $ bk queue resume my-cluster-uuid my-queue-uuid -o json
 `
 }
 
-func (c *PauseCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+func (c *ResumeCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
 	if err != nil {
 		return err
@@ -59,17 +55,20 @@ func (c *PauseCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	input := buildkite.ClusterQueuePause{
-		Note: c.Note,
+	if err = bkIO.SpinWhile(f, "Resuming cluster queue", func() error {
+		_, apiErr := f.RestAPIClient.ClusterQueues.Resume(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
+		return apiErr
+	}); err != nil {
+		return fmt.Errorf("error resuming cluster queue: %w", err)
 	}
 
 	var queue buildkite.ClusterQueue
-	if err = bkIO.SpinWhile(f, "Pausing cluster queue", func() error {
+	if err = bkIO.SpinWhile(f, "Loading queue", func() error {
 		var apiErr error
-		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Pause(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID, input)
+		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Get(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
 		return apiErr
 	}); err != nil {
-		return fmt.Errorf("error pausing cluster queue: %w", err)
+		return fmt.Errorf("error fetching cluster queue: %w", err)
 	}
 
 	queueView := output.Viewable[buildkite.ClusterQueue]{
@@ -84,6 +83,6 @@ func (c *PauseCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
 	defer func() { _ = cleanup() }()
 
-	fmt.Fprintf(writer, "Queue %s paused successfully\n\n", queue.Key)
+	fmt.Fprintf(writer, "Queue %s resumed successfully\n\n", queue.Key)
 	return output.Write(writer, queueView, format)
 }

--- a/cmd/queue/update.go
+++ b/cmd/queue/update.go
@@ -1,0 +1,113 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type UpdateCmd struct {
+	ClusterUUID        string `arg:"" help:"Cluster UUID the queue belongs to" name:"cluster-uuid"`
+	QueueUUID          string `arg:"" help:"Queue UUID to update" name:"queue-uuid"`
+	Description        string `help:"New description for the queue" optional:""`
+	RetryAgentAffinity string `help:"Retry agent affinity (prefer-warmest or prefer-different)" optional:"" name:"retry-agent-affinity"`
+	output.OutputFlags
+}
+
+func (c *UpdateCmd) Validate() error {
+	if c.Description == "" && c.RetryAgentAffinity == "" {
+		return fmt.Errorf("at least one of --description or --retry-agent-affinity must be provided")
+	}
+
+	switch buildkite.RetryAgentAffinity(c.RetryAgentAffinity) {
+	case "", buildkite.RetryAgentAffinityPreferWarmest, buildkite.RetryAgentAffinityPreferDifferent:
+		return nil
+	default:
+		return fmt.Errorf("invalid --retry-agent-affinity value %q: must be %s or %s",
+			c.RetryAgentAffinity,
+			buildkite.RetryAgentAffinityPreferWarmest,
+			buildkite.RetryAgentAffinityPreferDifferent,
+		)
+	}
+}
+
+func (c *UpdateCmd) Help() string {
+	return `
+At least one of --description or --retry-agent-affinity must be provided.
+
+Examples:
+  # Update a queue's description
+  $ bk queue update my-cluster-uuid my-queue-uuid --description "New description"
+
+  # Update retry agent affinity
+  $ bk queue update my-cluster-uuid my-queue-uuid --retry-agent-affinity prefer-different
+
+  # Update both settings
+  $ bk queue update my-cluster-uuid my-queue-uuid --description "New description" --retry-agent-affinity prefer-warmest
+
+  # Output the updated queue as JSON
+  $ bk queue update my-cluster-uuid my-queue-uuid --description "New description" -o json
+`
+}
+
+func (c *UpdateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+	f.NoPager = f.NoPager || globals.DisablePager()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	input := buildkite.ClusterQueueUpdate{
+		Description: c.Description,
+	}
+	if c.RetryAgentAffinity != "" {
+		input.RetryAgentAffinity = buildkite.RetryAgentAffinity(c.RetryAgentAffinity)
+	}
+
+	var queue buildkite.ClusterQueue
+	if err = bkIO.SpinWhile(f, "Updating cluster queue", func() error {
+		var apiErr error
+		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Update(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID, input)
+		return apiErr
+	}); err != nil {
+		return fmt.Errorf("error updating cluster queue: %w", err)
+	}
+
+	queueView := output.Viewable[buildkite.ClusterQueue]{
+		Data:   queue,
+		Render: renderQueueText,
+	}
+
+	if format != output.FormatText {
+		return output.Write(os.Stdout, queueView, format)
+	}
+
+	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
+	defer func() { _ = cleanup() }()
+
+	fmt.Fprintf(writer, "Queue %s updated successfully\n\n", queue.Key)
+	return output.Write(writer, queueView, format)
+}

--- a/cmd/queue/view.go
+++ b/cmd/queue/view.go
@@ -56,12 +56,12 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	defer stop()
 
 	var queue buildkite.ClusterQueue
-	if err = bkIO.SpinWhile(f, "Loading queue information", func() error {
+	if err = bkIO.SpinWhile(f, "Loading cluster queue", func() error {
 		var apiErr error
 		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Get(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
 		return apiErr
 	}); err != nil {
-		return err
+		return fmt.Errorf("error loading cluster queue: %w", err)
 	}
 
 	queueView := output.Viewable[buildkite.ClusterQueue]{

--- a/cmd/queue/view.go
+++ b/cmd/queue/view.go
@@ -1,0 +1,136 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
+	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+type ViewCmd struct {
+	ClusterUUID string `arg:"" help:"Cluster UUID the queue belongs to" name:"cluster-uuid"`
+	QueueUUID   string `arg:"" help:"Queue UUID to view" name:"queue-uuid"`
+	output.OutputFlags
+}
+
+func (c *ViewCmd) Help() string {
+	return `
+Examples:
+  # View a queue
+  $ bk queue view my-cluster-uuid my-queue-uuid
+
+  # View a queue in JSON format
+  $ bk queue view my-cluster-uuid my-queue-uuid -o json
+`
+}
+
+func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	if err != nil {
+		return err
+	}
+
+	f.SkipConfirm = globals.SkipConfirmation()
+	f.NoInput = globals.DisableInput()
+	f.Quiet = globals.IsQuiet()
+	f.NoPager = f.NoPager || globals.DisablePager()
+
+	if err := validation.ValidateConfiguration(f.Config, kongCtx.Command()); err != nil {
+		return err
+	}
+
+	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var queue buildkite.ClusterQueue
+	if err = bkIO.SpinWhile(f, "Loading queue information", func() error {
+		var apiErr error
+		queue, _, apiErr = f.RestAPIClient.ClusterQueues.Get(ctx, f.Config.OrganizationSlug(), c.ClusterUUID, c.QueueUUID)
+		return apiErr
+	}); err != nil {
+		return err
+	}
+
+	queueView := output.Viewable[buildkite.ClusterQueue]{
+		Data:   queue,
+		Render: renderQueueText,
+	}
+
+	if format != output.FormatText {
+		return output.Write(os.Stdout, queueView, format)
+	}
+
+	writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
+	defer func() { _ = cleanup() }()
+
+	return output.Write(writer, queueView, format)
+}
+
+func renderQueueText(q buildkite.ClusterQueue) string {
+	paused := "No"
+	if q.DispatchPaused {
+		paused = "Yes"
+	}
+
+	rows := [][]string{
+		{"Key", output.ValueOrDash(q.Key)},
+		{"Description", output.ValueOrDash(q.Description)},
+		{"ID", output.ValueOrDash(q.ID)},
+		{"GraphQL ID", output.ValueOrDash(q.GraphQLID)},
+		{"Retry Agent Affinity", output.ValueOrDash(string(q.RetryAgentAffinity))},
+		{"Dispatch Paused", paused},
+		{"Web URL", output.ValueOrDash(q.WebURL)},
+		{"API URL", output.ValueOrDash(q.URL)},
+		{"Cluster URL", output.ValueOrDash(q.ClusterURL)},
+	}
+
+	if q.DispatchPaused {
+		rows = append(rows, []string{"Dispatch Paused Note", output.ValueOrDash(q.DispatchPausedNote)})
+		if q.DispatchPausedAt != nil {
+			rows = append(rows, []string{"Dispatch Paused At", q.DispatchPausedAt.Format(time.RFC3339)})
+		}
+		if q.DispatchPausedBy != nil {
+			rows = append(rows,
+				[]string{"Dispatch Paused By Name", output.ValueOrDash(q.DispatchPausedBy.Name)},
+				[]string{"Dispatch Paused By Email", output.ValueOrDash(q.DispatchPausedBy.Email)},
+			)
+		}
+	}
+
+	if q.CreatedBy.ID != "" {
+		rows = append(rows,
+			[]string{"Created By Name", output.ValueOrDash(q.CreatedBy.Name)},
+			[]string{"Created By Email", output.ValueOrDash(q.CreatedBy.Email)},
+			[]string{"Created By ID", output.ValueOrDash(q.CreatedBy.ID)},
+		)
+	}
+
+	if q.CreatedAt != nil {
+		rows = append(rows, []string{"Created At", q.CreatedAt.Format(time.RFC3339)})
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Queue: %s\n\n", output.ValueOrDash(q.Key))
+
+	table := output.Table(
+		[]string{"Field", "Value"},
+		rows,
+		map[string]string{"field": "dim", "value": "italic"},
+	)
+
+	sb.WriteString(table)
+	return sb.String()
+}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ type (
 	}
 	QueueCmd struct {
 		View   queue.ViewCmd   `cmd:"" help:"View a cluster queue."`
+		Create queue.CreateCmd `cmd:"" help:"Create a new cluster queue."`
 	}
 	SecretCmd struct {
 		List   secret.ListCmd   `cmd:"" help:"List secrets for a cluster." aliases:"ls"`

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildkite/cli/v3/cmd/pipeline"
 	"github.com/buildkite/cli/v3/cmd/pkg"
 	"github.com/buildkite/cli/v3/cmd/preflight"
+	"github.com/buildkite/cli/v3/cmd/queue"
 	"github.com/buildkite/cli/v3/cmd/secret"
 	"github.com/buildkite/cli/v3/cmd/use"
 	"github.com/buildkite/cli/v3/cmd/user"
@@ -49,6 +50,7 @@ type CLI struct {
 	Build        BuildCmd           `cmd:"" help:"Manage pipeline builds"`
 	Cluster      ClusterCmd         `cmd:"" help:"Manage organization clusters"`
 	Maintainer   MaintainerCmd      `cmd:"" help:"Manage cluster maintainers"`
+	Queue        QueueCmd           `cmd:"" help:"Manage cluster queues"`
 	Secret       SecretCmd          `cmd:"" help:"Manage cluster secrets"`
 	Config       bkConfig.ConfigCmd `cmd:"" help:"Manage CLI configuration"`
 	Configure    ConfigureCmd       `cmd:"" help:"Configure Buildkite API token" hidden:""`
@@ -108,6 +110,9 @@ type (
 		List   maintainer.ListCmd   `cmd:"" help:"List cluster maintainers." aliases:"ls"`
 		Create maintainer.CreateCmd `cmd:"" help:"Create a cluster maintainer."`
 		Delete maintainer.DeleteCmd `cmd:"" help:"Delete a cluster maintainer." aliases:"rm"`
+	}
+	QueueCmd struct {
+		View   queue.ViewCmd   `cmd:"" help:"View a cluster queue."`
 	}
 	SecretCmd struct {
 		List   secret.ListCmd   `cmd:"" help:"List secrets for a cluster." aliases:"ls"`

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ type (
 		Delete maintainer.DeleteCmd `cmd:"" help:"Delete a cluster maintainer." aliases:"rm"`
 	}
 	QueueCmd struct {
+		List   queue.ListCmd   `cmd:"" help:"List cluster queues." aliases:"ls"`
 		View   queue.ViewCmd   `cmd:"" help:"View a cluster queue."`
 		Create queue.CreateCmd `cmd:"" help:"Create a new cluster queue."`
 	}

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ type (
 		List   queue.ListCmd   `cmd:"" help:"List cluster queues." aliases:"ls"`
 		View   queue.ViewCmd   `cmd:"" help:"View a cluster queue."`
 		Create queue.CreateCmd `cmd:"" help:"Create a new cluster queue."`
+		Update queue.UpdateCmd `cmd:"" help:"Update a cluster queue."`
 		Delete queue.DeleteCmd `cmd:"" help:"Delete a cluster queue." aliases:"rm"`
 	}
 	SecretCmd struct {

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ type (
 		List   queue.ListCmd   `cmd:"" help:"List cluster queues." aliases:"ls"`
 		View   queue.ViewCmd   `cmd:"" help:"View a cluster queue."`
 		Create queue.CreateCmd `cmd:"" help:"Create a new cluster queue."`
+		Delete queue.DeleteCmd `cmd:"" help:"Delete a cluster queue." aliases:"rm"`
 	}
 	SecretCmd struct {
 		List   secret.ListCmd   `cmd:"" help:"List secrets for a cluster." aliases:"ls"`

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ type (
 		Update queue.UpdateCmd `cmd:"" help:"Update a cluster queue."`
 		Delete queue.DeleteCmd `cmd:"" help:"Delete a cluster queue." aliases:"rm"`
 		Pause  queue.PauseCmd  `cmd:"" help:"Pause dispatch for a cluster queue."`
+		Resume queue.ResumeCmd `cmd:"" help:"Resume dispatch for a cluster queue."`
 	}
 	SecretCmd struct {
 		List   secret.ListCmd   `cmd:"" help:"List secrets for a cluster." aliases:"ls"`

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ type (
 		Create queue.CreateCmd `cmd:"" help:"Create a new cluster queue."`
 		Update queue.UpdateCmd `cmd:"" help:"Update a cluster queue."`
 		Delete queue.DeleteCmd `cmd:"" help:"Delete a cluster queue." aliases:"rm"`
+		Pause  queue.PauseCmd  `cmd:"" help:"Pause dispatch for a cluster queue."`
 	}
 	SecretCmd struct {
 		List   secret.ListCmd   `cmd:"" help:"List secrets for a cluster." aliases:"ls"`


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Adds full cluster queue command support from `go-buildkite`
### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

Adds the following sub-commands:
- `bk queue list`
- `bk queue view`
- `bk queue create`
- `bk queue update`
- `bk queue delete`
- `bk queue pause`
- `bk queue resume`

All just call upon the `go-buildkite` `ClusterQueuesService` methods for the relevant commands, adding functionality to manage queues as a whole (excluding metrics such as insights).

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->

N/A