### PR TITLE
Preflight `--exit-on` & change default to exit on build failing state

### DIFF
--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -34,10 +34,13 @@ type Event struct {
 	// Detail is supplementary information printed to the scrollback log.
 	Detail string `json:"detail,omitempty"`
 
-	Pipeline    string `json:"pipeline,omitempty"`
-	BuildNumber int    `json:"build_number,omitempty"`
-	BuildURL    string `json:"build_url,omitempty"`
-	BuildState  string `json:"build_state,omitempty"`
+	Pipeline      string `json:"pipeline,omitempty"`
+	BuildNumber   int    `json:"build_number,omitempty"`
+	BuildURL      string `json:"build_url,omitempty"`
+	BuildState    string `json:"build_state,omitempty"`
+	Incomplete    bool   `json:"incomplete,omitempty"`
+	StopReason    string `json:"stop_reason,omitempty"`
+	BuildCanceled *bool  `json:"build_canceled,omitempty"`
 
 	Jobs *watch.JobSummary `json:"jobs,omitempty"`
 
@@ -52,6 +55,10 @@ type Event struct {
 
 	// Duration is set for build_summary events. Total elapsed time of the preflight run.
 	Duration time.Duration `json:"duration_ns,omitempty"`
+
+	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
+	// StopReason describes why the summary was emitted early.
+	// BuildCanceled is set when the CLI attempted early-exit cleanup that cancels the remote build.
 
 	// TestFailures is set for test_failure events.
 	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`

--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -68,3 +68,39 @@ type Event struct {
 	// Tests is set for build_summary events when aggregated test summary data is available.
 	Tests internalpreflight.SummaryTests `json:"tests,omitempty"`
 }
+
+func newBuildSummaryEvent(preflightID, pipeline string, buildNumber int, buildURL string, finalBuild buildkite.Build, startedAt time.Time) Event {
+	return Event{
+		Type:        EventBuildSummary,
+		Time:        time.Now(),
+		PreflightID: preflightID,
+		Pipeline:    pipeline,
+		BuildNumber: buildNumber,
+		BuildURL:    buildURL,
+		BuildState:  finalBuild.State,
+		Duration:    time.Since(startedAt),
+	}
+}
+
+func (e *Event) ApplySummaryMeta(meta summaryMeta) {
+	e.Incomplete = meta.Incomplete
+	e.StopReason = meta.StopReason
+
+	if meta.StopReason == "" {
+		return
+	}
+
+	buildCanceled := meta.BuildCanceled
+	e.BuildCanceled = &buildCanceled
+}
+
+func (e *Event) ApplyJobResults(finalBuild buildkite.Build, tracker *watch.JobTracker) {
+	if NewResult(finalBuild).Passed() {
+		if passed := tracker.PassedJobs(); len(passed) <= 10 {
+			e.PassedJobs = passed
+		}
+		return
+	}
+
+	e.FailedJobs = tracker.FailedJobs()
+}

--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -38,8 +38,14 @@ type Event struct {
 	BuildNumber   int    `json:"build_number,omitempty"`
 	BuildURL      string `json:"build_url,omitempty"`
 	BuildState    string `json:"build_state,omitempty"`
+
+	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
 	Incomplete    bool   `json:"incomplete,omitempty"`
+
+	// StopReason describes why the summary was emitted early.
 	StopReason    string `json:"stop_reason,omitempty"`
+
+	// BuildCanceled is set when the CLI attempted early-exit cleanup that cancels the remote build.
 	BuildCanceled *bool  `json:"build_canceled,omitempty"`
 
 	Jobs *watch.JobSummary `json:"jobs,omitempty"`
@@ -55,10 +61,6 @@ type Event struct {
 
 	// Duration is set for build_summary events. Total elapsed time of the preflight run.
 	Duration time.Duration `json:"duration_ns,omitempty"`
-
-	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
-	// StopReason describes why the summary was emitted early.
-	// BuildCanceled is set when the CLI attempted early-exit cleanup that cancels the remote build.
 
 	// TestFailures is set for test_failure events.
 	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`

--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -34,19 +34,19 @@ type Event struct {
 	// Detail is supplementary information printed to the scrollback log.
 	Detail string `json:"detail,omitempty"`
 
-	Pipeline      string `json:"pipeline,omitempty"`
-	BuildNumber   int    `json:"build_number,omitempty"`
-	BuildURL      string `json:"build_url,omitempty"`
-	BuildState    string `json:"build_state,omitempty"`
+	Pipeline    string `json:"pipeline,omitempty"`
+	BuildNumber int    `json:"build_number,omitempty"`
+	BuildURL    string `json:"build_url,omitempty"`
+	BuildState  string `json:"build_state,omitempty"`
 
 	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
-	Incomplete    bool   `json:"incomplete,omitempty"`
+	Incomplete bool `json:"incomplete,omitempty"`
 
 	// StopReason describes why the summary was emitted early.
-	StopReason    string `json:"stop_reason,omitempty"`
+	StopReason string `json:"stop_reason,omitempty"`
 
 	// BuildCanceled is set when the CLI attempted early-exit cleanup that cancels the remote build.
-	BuildCanceled *bool  `json:"build_canceled,omitempty"`
+	BuildCanceled *bool `json:"build_canceled,omitempty"`
 
 	Jobs *watch.JobSummary `json:"jobs,omitempty"`
 

--- a/cmd/preflight/event_test.go
+++ b/cmd/preflight/event_test.go
@@ -78,3 +78,31 @@ func TestEvent_JobFailure(t *testing.T) {
 		t.Fatalf("expected job ID job-1, got %q", e.Job.ID)
 	}
 }
+
+func TestEvent_BuildSummaryStoppedEarly(t *testing.T) {
+	buildCanceled := false
+	e := Event{
+		Type:          EventBuildSummary,
+		Time:          time.Now(),
+		PreflightID:   "preflight-123",
+		Pipeline:      "buildkite/cli",
+		BuildNumber:   42,
+		BuildState:    "failing",
+		Incomplete:    true,
+		StopReason:    "build-failing",
+		BuildCanceled: &buildCanceled,
+	}
+
+	if e.Type != EventBuildSummary {
+		t.Fatalf("expected EventBuildSummary, got %q", e.Type)
+	}
+	if !e.Incomplete {
+		t.Fatal("expected Incomplete to be set")
+	}
+	if e.StopReason != "build-failing" {
+		t.Fatalf("expected stop reason build-failing, got %q", e.StopReason)
+	}
+	if e.BuildCanceled == nil || *e.BuildCanceled {
+		t.Fatalf("expected BuildCanceled=false, got %#v", e.BuildCanceled)
+	}
+}

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -284,6 +284,17 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		summaryEvent := newBuildSummaryEvent(preflightID.String(), pipelineName, build.Number, build.WebURL, finalBuild, startedAt)
 		summaryEvent.ApplySummaryMeta(summaryMeta{Incomplete: true, StopReason: "build-failing", BuildCanceled: buildCanceled})
 		summaryEvent.ApplyJobResults(finalBuild, tracker)
+		showResult, showErr := c.loadFinalResult(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number)
+		if showErr == nil {
+			summaryEvent.Tests = showResult.Tests
+		} else if globals.EnableDebug() {
+			_ = renderer.Render(Event{
+				Type:        EventOperation,
+				Time:        time.Now(),
+				PreflightID: preflightID.String(),
+				Title:       fmt.Sprintf("Debug: failed to load final test summary: %v", showErr),
+			})
+		}
 		_ = renderer.Render(summaryEvent)
 		cleanupBranch()
 		_ = renderer.Close()

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -281,16 +281,10 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 			buildCanceled = cancelBuild(f, renderer, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, preflightID.String(), globals.EnableDebug())
 		}
 
-		_ = renderer.Render(buildSummaryEvent(
-			finalBuild,
-			tracker,
-			preflightID.String(),
-			pipelineName,
-			build.Number,
-			build.WebURL,
-			startedAt,
-			summaryMeta{Incomplete: true, StopReason: "build-failing", BuildCanceled: buildCanceled},
-		))
+		summaryEvent := newBuildSummaryEvent(preflightID.String(), pipelineName, build.Number, build.WebURL, finalBuild, startedAt)
+		summaryEvent.ApplySummaryMeta(summaryMeta{Incomplete: true, StopReason: "build-failing", BuildCanceled: buildCanceled})
+		summaryEvent.ApplyJobResults(finalBuild, tracker)
+		_ = renderer.Render(summaryEvent)
 		cleanupBranch()
 		_ = renderer.Close()
 		return finalErr
@@ -298,7 +292,9 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	// Emit a final summary showing pass/fail, passed jobs (if ≤10), or hard-failed jobs.
 	if buildstate.IsTerminal(buildstate.State(finalBuild.State)) {
-		summaryEvent := buildSummaryEvent(finalBuild, tracker, preflightID.String(), pipelineName, build.Number, build.WebURL, startedAt, summaryMeta{})
+		summaryEvent := newBuildSummaryEvent(preflightID.String(), pipelineName, build.Number, build.WebURL, finalBuild, startedAt)
+		summaryEvent.ApplySummaryMeta(summaryMeta{})
+		summaryEvent.ApplyJobResults(finalBuild, tracker)
 
 		showResult, showErr := c.loadFinalResult(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number)
 		if showErr == nil {
@@ -355,36 +351,6 @@ func cancelBuild(f *factory.Factory, renderer renderer, org, pipeline string, bu
 
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Cancelled build #%d", buildNumber)})
 	return true
-}
-
-func buildSummaryEvent(finalBuild buildkite.Build, tracker *watch.JobTracker, preflightID, pipeline string, buildNumber int, buildURL string, startedAt time.Time, meta summaryMeta) Event {
-	event := Event{
-		Type:        EventBuildSummary,
-		Time:        time.Now(),
-		PreflightID: preflightID,
-		Pipeline:    pipeline,
-		BuildNumber: buildNumber,
-		BuildURL:    buildURL,
-		BuildState:  finalBuild.State,
-		Duration:    time.Since(startedAt),
-		Incomplete:  meta.Incomplete,
-		StopReason:  meta.StopReason,
-	}
-
-	if meta.StopReason != "" {
-		buildCanceled := meta.BuildCanceled
-		event.BuildCanceled = &buildCanceled
-	}
-
-	if NewResult(finalBuild).Passed() {
-		if passed := tracker.PassedJobs(); len(passed) <= 10 {
-			event.PassedJobs = passed
-		}
-		return event
-	}
-
-	event.FailedJobs = tracker.FailedJobs()
-	return event
 }
 
 func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (internalpreflight.SummaryResult, error) {

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -23,20 +23,20 @@ import (
 	bkhttp "github.com/buildkite/cli/v3/internal/http"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
-	"github.com/buildkite/cli/v3/internal/preflight"
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
 type RunCmd struct {
-	Pipeline         string               `help:"The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}." short:"p"`
-	Watch            bool                 `help:"Watch the build until completion." default:"true" negatable:""`
-	ExitOn           []string             `help:"Exit when a condition is met. Options: build-failing (default, exits when a build enters the failing state), build-terminal (exits when the build reaches a terminal state)."`
-	Interval         float64              `help:"Polling interval in seconds when watching." default:"2"`
-	NoCleanup        bool                 `help:"Skip cleanup after completion or early exit. The preflight branch remains and the build keeps running if exiting early."`
-	AwaitTestResults awaitTestResultsFlag `name:"await-test-results" help:"After the build finishes, wait for tests results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait 30s."`
-	Text             bool                 `help:"Use plain text output instead of interactive terminal UI." xor:"output"`
-	JSON             bool                 `help:"Emit one JSON object per event (JSONL)." xor:"output"`
+	Pipeline         string                         `help:"The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}." short:"p"`
+	Watch            bool                           `help:"Watch the build until completion." default:"true" negatable:""`
+	ExitOn           []internalpreflight.ExitPolicy `help:"Exit when a condition is met. Options: build-failing (default, exits when a build enters the failing state), build-terminal (exits when the build reaches a terminal state)."`
+	Interval         float64                        `help:"Polling interval in seconds when watching." default:"2"`
+	NoCleanup        bool                           `help:"Skip cleanup after completion or early exit. The preflight branch remains and the build keeps running if exiting early."`
+	AwaitTestResults awaitTestResultsFlag           `name:"await-test-results" help:"After the build finishes, wait for tests results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait 30s."`
+	Text             bool                           `help:"Use plain text output instead of interactive terminal UI." xor:"output"`
+	JSON             bool                           `help:"Emit one JSON object per event (JSONL)." xor:"output"`
 }
 
 var (
@@ -47,17 +47,6 @@ var (
 )
 
 const defaultAwaitTestResultsDuration = 30 * time.Second
-
-type stopPolicy int
-
-const (
-	stopOnBuildFailing stopPolicy = iota
-	stopOnBuildTerminal
-)
-
-type stopConfig struct {
-	build stopPolicy
-}
 
 type summaryMeta struct {
 	Incomplete    bool
@@ -105,49 +94,19 @@ func (c *RunCmd) Help() string {
 	return `Snapshots your working tree (uncommitted, staged, and untracked changes) and pushes it to a bk/preflight/<id> branch. If there are no local changes, pushes HEAD directly.`
 }
 
-func parseExitConditions(values []string, watch bool) (stopConfig, error) {
-	config := stopConfig{build: stopOnBuildFailing}
-
-	if len(values) == 0 {
-		return config, nil
-	}
-	if !watch {
-		return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("--exit-on requires --watch"), "exit conditions require watch mode")
-	}
-
-	var stopOnFailing bool
-	var stopOnTerminal bool
-	for _, value := range values {
-		name, _, _ := strings.Cut(value, ":")
-		switch name {
-		case "build-failing":
-			stopOnFailing = true
-		case "build-terminal":
-			stopOnTerminal = true
-		default:
-			return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("unsupported --exit-on value %q", value), "invalid exit condition")
-		}
-	}
-
-	if stopOnFailing && stopOnTerminal {
-		return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("build-failing and build-terminal cannot be used together"), "invalid exit conditions")
-	}
-	if stopOnTerminal {
-		config.build = stopOnBuildTerminal
-	}
-
-	return config, nil
-}
-
-func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+func (c *RunCmd) Validate() error {
 	if c.Interval <= 0 {
 		return bkErrors.NewValidationError(fmt.Errorf("interval must be greater than 0"), "invalid polling interval")
 	}
+	return internalpreflight.ValidateExitPolicies(c.ExitOn, c.Watch)
+}
 
-	stopConfig, err := parseExitConditions(c.ExitOn, c.Watch)
-	if err != nil {
+func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
+	if err := c.Validate(); err != nil {
 		return err
 	}
+
+	exitPolicy := internalpreflight.EffectiveExitPolicy(c.ExitOn)
 
 	pCtx, err := setup(c.Pipeline, globals)
 	if err != nil {
@@ -168,7 +127,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 	startedAt := time.Now()
 
-	sourceContext, err := preflight.ResolveSourceContext(repoRoot, globals.EnableDebug())
+	sourceContext, err := internalpreflight.ResolveSourceContext(repoRoot, globals.EnableDebug())
 	if err != nil {
 		return bkErrors.NewValidationError(
 			err,
@@ -192,12 +151,12 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: "Pushing snapshot of working tree..."})
 
-	var opts []preflight.SnapshotOption
+	var opts []internalpreflight.SnapshotOption
 	if globals.EnableDebug() {
-		opts = append(opts, preflight.WithDebug())
+		opts = append(opts, internalpreflight.WithDebug())
 	}
 
-	result, err := preflight.Snapshot(repoRoot, preflightID, opts...)
+	result, err := internalpreflight.Snapshot(repoRoot, preflightID, opts...)
 	if err != nil {
 		return bkErrors.NewSnapshotError(err, "failed to create preflight snapshot",
 			"Ensure you have uncommitted or committed changes to snapshot",
@@ -284,7 +243,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		}); err != nil {
 			return err
 		}
-		if stopConfig.build == stopOnBuildFailing && buildstate.State(b.State) == buildstate.Failing {
+		if exitPolicy == internalpreflight.ExitOnBuildFailing && buildstate.State(b.State) == buildstate.Failing {
 			return errExitOnBuildFailing
 		}
 		return nil
@@ -370,7 +329,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 func cleanupRemoteBranch(renderer renderer, repoRoot, branch, ref, preflightID string, debug bool) {
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Cleaning up remote branch %s...", branch)})
-	if cleanupErr := preflight.Cleanup(repoRoot, ref, debug); cleanupErr != nil {
+	if cleanupErr := internalpreflight.Cleanup(repoRoot, ref, debug); cleanupErr != nil {
 		_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Warning: failed to delete remote branch %s: %v", ref, cleanupErr)})
 		return
 	}
@@ -428,19 +387,19 @@ func buildSummaryEvent(finalBuild buildkite.Build, tracker *watch.JobTracker, pr
 	return event
 }
 
-func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (preflight.SummaryResult, error) {
+func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (internalpreflight.SummaryResult, error) {
 	buildWithTests, _, buildErr := client.Builds.Get(ctx, org, pipeline, strconv.Itoa(buildNumber), &buildkite.BuildGetOptions{IncludeTestEngine: true})
 	expectTestSummary := buildErr == nil && buildWithTests.TestEngine != nil && len(buildWithTests.TestEngine.Runs) > 0
 
 	if buildErr != nil {
-		return preflight.SummaryResult{}, buildErr
+		return internalpreflight.SummaryResult{}, buildErr
 	}
 
 	if !c.AwaitTestResults.Enabled || c.AwaitTestResults.Duration <= 0 {
 		return c.loadSummary(ctx, client, org, buildWithTests.ID)
 	}
 	if !expectTestSummary {
-		return preflight.SummaryResult{Tests: preflight.SummaryTests{Runs: map[string]preflight.SummaryTestRun{}, Failures: []preflight.SummaryTestFailure{}}}, nil
+		return internalpreflight.SummaryResult{Tests: internalpreflight.SummaryTests{Runs: map[string]internalpreflight.SummaryTestRun{}, Failures: []internalpreflight.SummaryTestFailure{}}}, nil
 	}
 
 	timer := time.NewTimer(c.AwaitTestResults.Duration)
@@ -448,25 +407,25 @@ func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, 
 
 	select {
 	case <-ctx.Done():
-		return preflight.SummaryResult{}, ctx.Err()
+		return internalpreflight.SummaryResult{}, ctx.Err()
 	case <-timer.C:
 	}
 
 	return c.loadSummary(ctx, client, org, buildWithTests.ID)
 }
 
-func (c *RunCmd) loadSummary(ctx context.Context, client *buildkite.Client, org, buildID string) (preflight.SummaryResult, error) {
+func (c *RunCmd) loadSummary(ctx context.Context, client *buildkite.Client, org, buildID string) (internalpreflight.SummaryResult, error) {
 	if buildID == "" {
-		return preflight.SummaryResult{Tests: preflight.SummaryTests{Runs: map[string]preflight.SummaryTestRun{}, Failures: []preflight.SummaryTestFailure{}}}, nil
+		return internalpreflight.SummaryResult{Tests: internalpreflight.SummaryTests{Runs: map[string]internalpreflight.SummaryTestRun{}, Failures: []internalpreflight.SummaryTestFailure{}}}, nil
 	}
 
-	summary, err := preflight.NewRunSummaryService(client).Get(ctx, org, buildID, &preflight.RunSummaryGetOptions{
+	summary, err := internalpreflight.NewRunSummaryService(client).Get(ctx, org, buildID, &internalpreflight.RunSummaryGetOptions{
 		Result:          "^failed",
 		State:           "enabled",
 		IncludeFailures: true,
 	})
 	if err != nil {
-		return preflight.SummaryResult{}, err
+		return internalpreflight.SummaryResult{}, err
 	}
 
 	return summary.SummaryResult(), nil
@@ -544,5 +503,5 @@ func resolveRepositoryRoot(f *factory.Factory, debug bool) (string, error) {
 		}
 	}
 
-	return preflight.RepositoryRoot(".", debug)
+	return internalpreflight.RepositoryRoot(".", debug)
 }

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -31,8 +31,9 @@ import (
 type RunCmd struct {
 	Pipeline         string               `help:"The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}." short:"p"`
 	Watch            bool                 `help:"Watch the build until completion." default:"true" negatable:""`
+	ExitOn           []string             `help:"Exit when a condition is met. Options: build-failing (default, exits when a build enters the failing state), build-terminal (exits when the build reaches a terminal state)."`
 	Interval         float64              `help:"Polling interval in seconds when watching." default:"2"`
-	NoCleanup        bool                 `help:"Skip deleting the remote preflight branch after the build finishes."`
+	NoCleanup        bool                 `help:"Skip cleanup after completion or early exit. The preflight branch remains and the build keeps running if exiting early."`
 	AwaitTestResults awaitTestResultsFlag `name:"await-test-results" help:"After the build finishes, wait for tests results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait 30s."`
 	Text             bool                 `help:"Use plain text output instead of interactive terminal UI." xor:"output"`
 	JSON             bool                 `help:"Emit one JSON object per event (JSONL)." xor:"output"`
@@ -41,9 +42,28 @@ type RunCmd struct {
 var (
 	notifyContext = signal.NotifyContext
 	newFactory    = factory.New
+
+	errExitOnBuildFailing = errors.New("exit-on build-failing")
 )
 
 const defaultAwaitTestResultsDuration = 30 * time.Second
+
+type stopPolicy int
+
+const (
+	stopOnBuildFailing stopPolicy = iota
+	stopOnBuildTerminal
+)
+
+type stopConfig struct {
+	build stopPolicy
+}
+
+type summaryMeta struct {
+	Incomplete    bool
+	StopReason    string
+	BuildCanceled bool
+}
 
 func preflightUserAgentSuffix() string {
 	major := strings.TrimPrefix(version.Version, "v")
@@ -85,9 +105,48 @@ func (c *RunCmd) Help() string {
 	return `Snapshots your working tree (uncommitted, staged, and untracked changes) and pushes it to a bk/preflight/<id> branch. If there are no local changes, pushes HEAD directly.`
 }
 
+func parseExitConditions(values []string, watch bool) (stopConfig, error) {
+	config := stopConfig{build: stopOnBuildFailing}
+
+	if len(values) == 0 {
+		return config, nil
+	}
+	if !watch {
+		return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("--exit-on requires --watch"), "exit conditions require watch mode")
+	}
+
+	var stopOnFailing bool
+	var stopOnTerminal bool
+	for _, value := range values {
+		name, _, _ := strings.Cut(value, ":")
+		switch name {
+		case "build-failing":
+			stopOnFailing = true
+		case "build-terminal":
+			stopOnTerminal = true
+		default:
+			return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("unsupported --exit-on value %q", value), "invalid exit condition")
+		}
+	}
+
+	if stopOnFailing && stopOnTerminal {
+		return stopConfig{}, bkErrors.NewValidationError(fmt.Errorf("build-failing and build-terminal cannot be used together"), "invalid exit conditions")
+	}
+	if stopOnTerminal {
+		config.build = stopOnBuildTerminal
+	}
+
+	return config, nil
+}
+
 func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	if c.Interval <= 0 {
 		return bkErrors.NewValidationError(fmt.Errorf("interval must be greater than 0"), "invalid polling interval")
+	}
+
+	stopConfig, err := parseExitConditions(c.ExitOn, c.Watch)
+	if err != nil {
+		return err
 	}
 
 	pCtx, err := setup(c.Pipeline, globals)
@@ -213,7 +272,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 				return err
 			}
 		}
-		return renderer.Render(Event{
+		if err := renderer.Render(Event{
 			Type:        EventBuildStatus,
 			Time:        time.Now(),
 			PreflightID: preflightID.String(),
@@ -222,7 +281,13 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 			BuildURL:    build.WebURL,
 			BuildState:  b.State,
 			Jobs:        &status.Summary,
-		})
+		}); err != nil {
+			return err
+		}
+		if stopConfig.build == stopOnBuildFailing && buildstate.State(b.State) == buildstate.Failing {
+			return errExitOnBuildFailing
+		}
+		return nil
 	}, watch.WithRetriedJobs(), watch.WithTestTracking(func(newTestChanges []buildkite.BuildTest) error {
 		return renderer.Render(Event{
 			Type:         EventTestFailure,
@@ -234,21 +299,47 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		})
 	}))
 
-	buildResult := NewResult(finalBuild)
-	finalErr := buildResult.Error()
+	finalErr := NewResult(finalBuild).Error()
+	cleanupBranch := func() {
+		if c.NoCleanup {
+			return
+		}
+		cleanupRemoteBranch(renderer, repoRoot, result.Branch, result.Ref, preflightID.String(), globals.EnableDebug())
+	}
+
+	if errors.Is(err, context.Canceled) {
+		cleanupBranch()
+		if finalBuild.FinishedAt == nil && !buildstate.IsTerminal(buildstate.State(finalBuild.State)) && !c.NoCleanup {
+			cancelBuild(f, renderer, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, preflightID.String(), globals.EnableDebug())
+		}
+		_ = renderer.Close()
+		return bkErrors.NewUserAbortedError(context.Canceled, "preflight canceled by user")
+	}
+
+	if errors.Is(err, errExitOnBuildFailing) {
+		buildCanceled := false
+		if !c.NoCleanup {
+			buildCanceled = cancelBuild(f, renderer, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, preflightID.String(), globals.EnableDebug())
+		}
+
+		_ = renderer.Render(buildSummaryEvent(
+			finalBuild,
+			tracker,
+			preflightID.String(),
+			pipelineName,
+			build.Number,
+			build.WebURL,
+			startedAt,
+			summaryMeta{Incomplete: true, StopReason: "build-failing", BuildCanceled: buildCanceled},
+		))
+		cleanupBranch()
+		_ = renderer.Close()
+		return finalErr
+	}
 
 	// Emit a final summary showing pass/fail, passed jobs (if ≤10), or hard-failed jobs.
 	if buildstate.IsTerminal(buildstate.State(finalBuild.State)) {
-		summaryEvent := Event{
-			Type:        EventBuildSummary,
-			Time:        time.Now(),
-			PreflightID: preflightID.String(),
-			Pipeline:    pipelineName,
-			BuildNumber: build.Number,
-			BuildURL:    build.WebURL,
-			BuildState:  finalBuild.State,
-			Duration:    time.Since(startedAt),
-		}
+		summaryEvent := buildSummaryEvent(finalBuild, tracker, preflightID.String(), pipelineName, build.Number, build.WebURL, startedAt, summaryMeta{})
 
 		showResult, showErr := c.loadFinalResult(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number)
 		if showErr == nil {
@@ -261,46 +352,10 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 				Title:       fmt.Sprintf("Debug: failed to load final test summary: %v", showErr),
 			})
 		}
-
-		if buildResult.Passed() {
-			if passed := tracker.PassedJobs(); len(passed) <= 10 {
-				summaryEvent.PassedJobs = passed
-			}
-		} else {
-			summaryEvent.FailedJobs = tracker.FailedJobs()
-		}
 		_ = renderer.Render(summaryEvent)
 	}
 
-	if !c.NoCleanup {
-		_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Cleaning up remote branch %s...", result.Branch)})
-		if cleanupErr := preflight.Cleanup(repoRoot, result.Ref, globals.EnableDebug()); cleanupErr != nil {
-			_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Warning: failed to delete remote branch %s: %v", result.Ref, cleanupErr)})
-		} else {
-			_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Deleted remote branch %s", result.Branch)})
-		}
-	}
-
-	if errors.Is(err, context.Canceled) {
-		if finalBuild.FinishedAt == nil && !buildstate.IsTerminal(buildstate.State(finalBuild.State)) {
-			cancelCtx, cancelStop := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancelStop()
-			if _, cancelErr := f.RestAPIClient.Builds.Cancel(cancelCtx, resolvedPipeline.Org, resolvedPipeline.Name, strconv.Itoa(build.Number)); cancelErr != nil {
-				var apiErr *buildkite.ErrorResponse
-				if errors.As(cancelErr, &apiErr) && apiErr.Response.StatusCode == http.StatusUnprocessableEntity && apiErr.Message == "Build can't be canceled because it's already finished." {
-					if globals.EnableDebug() {
-						_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Debug: build #%d already finished, skipping cancel", build.Number)})
-					}
-				} else {
-					_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Warning: failed to cancel build #%d: %v", build.Number, cancelErr)})
-				}
-			} else {
-				_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Cancelled build #%d", build.Number)})
-			}
-		}
-		_ = renderer.Close()
-		return bkErrors.NewUserAbortedError(context.Canceled, "preflight canceled by user")
-	}
+	cleanupBranch()
 	_ = renderer.Close()
 
 	if err != nil {
@@ -311,6 +366,66 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	return finalErr
+}
+
+func cleanupRemoteBranch(renderer renderer, repoRoot, branch, ref, preflightID string, debug bool) {
+	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Cleaning up remote branch %s...", branch)})
+	if cleanupErr := preflight.Cleanup(repoRoot, ref, debug); cleanupErr != nil {
+		_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Warning: failed to delete remote branch %s: %v", ref, cleanupErr)})
+		return
+	}
+	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Deleted remote branch %s", branch)})
+}
+
+func cancelBuild(f *factory.Factory, renderer renderer, org, pipeline string, buildNumber int, preflightID string, debug bool) bool {
+	cancelCtx, cancelStop := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelStop()
+
+	if _, err := f.RestAPIClient.Builds.Cancel(cancelCtx, org, pipeline, strconv.Itoa(buildNumber)); err != nil {
+		var apiErr *buildkite.ErrorResponse
+		if errors.As(err, &apiErr) && apiErr.Response.StatusCode == http.StatusUnprocessableEntity && apiErr.Message == "Build can't be canceled because it's already finished." {
+			if debug {
+				_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Debug: build #%d already finished, skipping cancel", buildNumber)})
+			}
+			return false
+		}
+
+		_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Warning: failed to cancel build #%d: %v", buildNumber, err)})
+		return false
+	}
+
+	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID, Title: fmt.Sprintf("Cancelled build #%d", buildNumber)})
+	return true
+}
+
+func buildSummaryEvent(finalBuild buildkite.Build, tracker *watch.JobTracker, preflightID, pipeline string, buildNumber int, buildURL string, startedAt time.Time, meta summaryMeta) Event {
+	event := Event{
+		Type:        EventBuildSummary,
+		Time:        time.Now(),
+		PreflightID: preflightID,
+		Pipeline:    pipeline,
+		BuildNumber: buildNumber,
+		BuildURL:    buildURL,
+		BuildState:  finalBuild.State,
+		Duration:    time.Since(startedAt),
+		Incomplete:  meta.Incomplete,
+		StopReason:  meta.StopReason,
+	}
+
+	if meta.StopReason != "" {
+		buildCanceled := meta.BuildCanceled
+		event.BuildCanceled = &buildCanceled
+	}
+
+	if NewResult(finalBuild).Passed() {
+		if passed := tracker.PassedJobs(); len(passed) <= 10 {
+			event.PassedJobs = passed
+		}
+		return event
+	}
+
+	event.FailedJobs = tracker.FailedJobs()
+	return event
 }
 
 func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (preflight.SummaryResult, error) {

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -118,6 +118,188 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("build-failing early exit enriches summary with test results", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		var buildCancelRequests atomic.Int32
+		var buildPolls atomic.Int32
+		var summaryRequests atomic.Int32
+		var includeLatestFail atomic.Bool
+		var stateEnabled atomic.Bool
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/builds/1/cancel"):
+				buildCancelRequests.Add(1)
+				json.NewEncoder(w).Encode(buildkite.Build{Number: 1, State: "canceling"})
+				return
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/builds"):
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "scheduled",
+					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
+				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
+				poll := buildPolls.Add(1)
+				exitOne := 1
+				build := buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "running",
+					Jobs: []buildkite.Job{{
+						ID:    "job-running",
+						Type:  "script",
+						Name:  "Lint",
+						State: "running",
+					}},
+				}
+				if poll >= 2 {
+					build.State = "failing"
+					build.TestEngine = &buildkite.TestEngineProperty{
+						Runs: []buildkite.TestEngineRun{{
+							ID: "run-1",
+							Suite: buildkite.TestEngineSuite{
+								Slug: "rspec",
+							},
+						}},
+					}
+					build.Jobs = []buildkite.Job{{
+						ID:         "job-failed",
+						Type:       "script",
+						Name:       "Lint",
+						State:      "failed",
+						ExitStatus: &exitOne,
+					}}
+				}
+				json.NewEncoder(w).Encode(build)
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
+				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
+				return
+
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/analytics/organizations/test-org/builds/build-id-123/preflight/v1":
+				summaryRequests.Add(1)
+				if r.URL.Query().Get("include") == "latest_fail" {
+					includeLatestFail.Store(true)
+				}
+				if r.URL.Query().Get("state") == "enabled" {
+					stateEnabled.Store(true)
+				}
+				_, _ = w.Write([]byte(`{
+					"tests": {
+						"runs": {
+							"run-1": {
+								"suite": {"id": "suite-1", "slug": "rspec", "name": "RSpec"},
+								"passed": 47,
+								"failed": 1,
+								"skipped": 12
+							}
+						},
+						"failures": [
+							{
+								"run_id": "run-1",
+								"suite_name": "RSpec",
+								"suite_slug": "rspec",
+								"name": "AuthService.validateToken handles expired tokens",
+								"location": "src/auth.test.ts:89",
+								"latest_fail": {
+									"failure_reason": "Expected 'expired' but got 'invalid'"
+								}
+							}
+						]
+					}
+				}`))
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		stdout := captureStdout(t, func() {
+			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true}
+			err := cmd.Run(nil, stubGlobals{})
+			var bkErr *bkErrors.Error
+			if !errors.As(err, &bkErr) || !errors.Is(bkErr, bkErrors.ErrPreflightIncompleteFailure) {
+				t.Fatalf("expected incomplete failure error, got %v", err)
+			}
+		})
+
+		events := decodeJSONLEvents(t, stdout)
+		var buildStatusCount int
+		var summaries []Event
+		for _, event := range events {
+			if event.Type == EventBuildStatus {
+				buildStatusCount++
+			}
+			if event.Type == EventBuildSummary {
+				summaries = append(summaries, event)
+			}
+		}
+
+		if buildStatusCount != 2 {
+			t.Fatalf("expected 2 build status events before early stop, got %d", buildStatusCount)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("expected exactly 1 build summary event, got %d", len(summaries))
+		}
+		summary := summaries[0]
+		if !summary.Incomplete {
+			t.Fatal("expected summary to be marked incomplete")
+		}
+		if summary.StopReason != "build-failing" {
+			t.Fatalf("expected stop reason build-failing, got %q", summary.StopReason)
+		}
+		if summary.BuildCanceled == nil || !*summary.BuildCanceled {
+			t.Fatalf("expected build_canceled=true, got %#v", summary.BuildCanceled)
+		}
+		if summary.BuildState != "failing" {
+			t.Fatalf("expected failing build state, got %q", summary.BuildState)
+		}
+		if len(summary.FailedJobs) != 1 || summary.FailedJobs[0].Name != "Lint" {
+			t.Fatalf("expected failed jobs in summary, got %#v", summary.FailedJobs)
+		}
+		if got := summary.Tests.Runs["run-1"]; got.SuiteName != "RSpec" || got.Failed != 1 || got.Passed != 47 || got.Skipped != 12 {
+			t.Fatalf("expected enriched test run summary, got %#v", got)
+		}
+		if len(summary.Tests.Failures) != 1 || summary.Tests.Failures[0].Name != "AuthService.validateToken handles expired tokens" {
+			t.Fatalf("expected enriched test failures, got %#v", summary.Tests.Failures)
+		}
+		if !includeLatestFail.Load() {
+			t.Fatal("expected early-exit summary to request latest_fail details")
+		}
+		if !stateEnabled.Load() {
+			t.Fatal("expected early-exit summary to request state=enabled")
+		}
+		if summaryRequests.Load() != 1 {
+			t.Fatalf("expected one preflight summary request, got %d", summaryRequests.Load())
+		}
+		if buildCancelRequests.Load() != 1 {
+			t.Fatalf("expected one build cancel request, got %d", buildCancelRequests.Load())
+		}
+		if buildPolls.Load() != 3 {
+			t.Fatalf("expected three build polls including final summary fetch, got %d", buildPolls.Load())
+		}
+
+		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")
+		if strings.Contains(refs, "bk/preflight/") {
+			t.Errorf("expected preflight branch to be cleaned up, but found: %s", refs)
+		}
+	})
+
 	t.Run("snapshots and creates build", func(t *testing.T) {
 		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
 
@@ -348,11 +530,12 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("defaults to stopping early on failing builds", func(t *testing.T) {
+	t.Run("early exit summary tolerates summary endpoint failure", func(t *testing.T) {
 		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
 
 		var buildCancelRequests atomic.Int32
 		var buildPolls atomic.Int32
+		var summaryRequests atomic.Int32
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 
@@ -400,6 +583,12 @@ func TestPreflightCmd_Run(t *testing.T) {
 
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
 				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
+				return
+
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/analytics/organizations/test-org/builds/build-id-123/preflight/v1":
+				summaryRequests.Add(1)
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"API::Error::NotFound"}`))
 				return
 			}
 
@@ -457,11 +646,17 @@ func TestPreflightCmd_Run(t *testing.T) {
 		if len(summary.FailedJobs) != 1 || summary.FailedJobs[0].Name != "Lint" {
 			t.Fatalf("expected failed jobs in summary, got %#v", summary.FailedJobs)
 		}
+		if len(summary.Tests.Runs) != 0 || len(summary.Tests.Failures) != 0 {
+			t.Fatalf("expected no enriched tests when summary endpoint fails, got %#v", summary.Tests)
+		}
+		if summaryRequests.Load() != 1 {
+			t.Fatalf("expected one preflight summary request, got %d", summaryRequests.Load())
+		}
 		if buildCancelRequests.Load() != 1 {
 			t.Fatalf("expected one build cancel request, got %d", buildCancelRequests.Load())
 		}
-		if buildPolls.Load() != 2 {
-			t.Fatalf("expected two build polls before exit, got %d", buildPolls.Load())
+		if buildPolls.Load() != 3 {
+			t.Fatalf("expected three build polls including final summary fetch, got %d", buildPolls.Load())
 		}
 
 		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -35,6 +35,48 @@ func (s stubGlobals) EnableDebug() bool      { return false }
 
 var _ cli.GlobalFlags = stubGlobals{}
 
+func TestParseExitConditions(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      []string
+		watch       bool
+		wantPolicy  stopPolicy
+		wantErrText string
+	}{
+		{name: "defaults to build-failing", watch: true, wantPolicy: stopOnBuildFailing},
+		{name: "accepts build-failing", values: []string{"build-failing"}, watch: true, wantPolicy: stopOnBuildFailing},
+		{name: "accepts build-terminal", values: []string{"build-terminal"}, watch: true, wantPolicy: stopOnBuildTerminal},
+		{name: "rejects mixed lifecycle policies", values: []string{"build-failing", "build-terminal"}, watch: true, wantErrText: "build-failing and build-terminal cannot be used together"},
+		{name: "rejects unknown conditions", values: []string{"test-failed:3"}, watch: true, wantErrText: `unsupported --exit-on value "test-failed:3"`},
+		{name: "rejects exit-on when watch disabled", values: []string{"build-failing"}, watch: false, wantErrText: "--exit-on requires --watch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExitConditions(tt.values, tt.watch)
+			if tt.wantErrText != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, bkErrors.ErrValidation) {
+					t.Fatalf("expected validation error, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErrText, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got.build != tt.wantPolicy {
+				t.Fatalf("policy = %v, want %v", got.build, tt.wantPolicy)
+			}
+		})
+	}
+}
+
 func TestPreflightCmd_Run(t *testing.T) {
 	t.Run("returns validation error when experiment disabled", func(t *testing.T) {
 		t.Setenv("BUILDKITE_EXPERIMENTS", "")
@@ -299,6 +341,340 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 
 		// Verify the remote preflight branch was deleted.
+		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")
+		if strings.Contains(refs, "bk/preflight/") {
+			t.Errorf("expected preflight branch to be cleaned up, but found: %s", refs)
+		}
+	})
+
+	t.Run("defaults to stopping early on failing builds", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		var buildCancelRequests atomic.Int32
+		var buildPolls atomic.Int32
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/builds/1/cancel"):
+				buildCancelRequests.Add(1)
+				json.NewEncoder(w).Encode(buildkite.Build{Number: 1, State: "canceling"})
+				return
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/builds"):
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "scheduled",
+					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
+				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
+				poll := buildPolls.Add(1)
+				build := buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "running",
+					Jobs: []buildkite.Job{{
+						ID:    "job-running",
+						Type:  "script",
+						Name:  "Lint",
+						State: "running",
+					}},
+				}
+				if poll >= 2 {
+					exitOne := 1
+					build.State = "failing"
+					build.Jobs = []buildkite.Job{{
+						ID:         "job-failed",
+						Type:       "script",
+						Name:       "Lint",
+						State:      "failed",
+						ExitStatus: &exitOne,
+					}}
+				}
+				json.NewEncoder(w).Encode(build)
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
+				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		stdout := captureStdout(t, func() {
+			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true}
+			err := cmd.Run(nil, stubGlobals{})
+			var bkErr *bkErrors.Error
+			if !errors.As(err, &bkErr) || !errors.Is(bkErr, bkErrors.ErrPreflightIncompleteFailure) {
+				t.Fatalf("expected incomplete failure error, got %v", err)
+			}
+		})
+
+		events := decodeJSONLEvents(t, stdout)
+		var buildStatusCount int
+		var summaries []Event
+		for _, event := range events {
+			if event.Type == EventBuildStatus {
+				buildStatusCount++
+			}
+			if event.Type == EventBuildSummary {
+				summaries = append(summaries, event)
+			}
+		}
+
+		if buildStatusCount != 2 {
+			t.Fatalf("expected 2 build status events before early stop, got %d", buildStatusCount)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("expected exactly 1 build summary event, got %d", len(summaries))
+		}
+		summary := summaries[0]
+		if !summary.Incomplete {
+			t.Fatal("expected summary to be marked incomplete")
+		}
+		if summary.StopReason != "build-failing" {
+			t.Fatalf("expected stop reason build-failing, got %q", summary.StopReason)
+		}
+		if summary.BuildCanceled == nil || !*summary.BuildCanceled {
+			t.Fatalf("expected build_canceled=true, got %#v", summary.BuildCanceled)
+		}
+		if summary.BuildState != "failing" {
+			t.Fatalf("expected failing build state, got %q", summary.BuildState)
+		}
+		if len(summary.FailedJobs) != 1 || summary.FailedJobs[0].Name != "Lint" {
+			t.Fatalf("expected failed jobs in summary, got %#v", summary.FailedJobs)
+		}
+		if buildCancelRequests.Load() != 1 {
+			t.Fatalf("expected one build cancel request, got %d", buildCancelRequests.Load())
+		}
+		if buildPolls.Load() != 2 {
+			t.Fatalf("expected two build polls before exit, got %d", buildPolls.Load())
+		}
+
+		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")
+		if strings.Contains(refs, "bk/preflight/") {
+			t.Errorf("expected preflight branch to be cleaned up, but found: %s", refs)
+		}
+	})
+
+	t.Run("no-cleanup leaves branch and build running after early stop", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		var buildCancelRequests atomic.Int32
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/builds/1/cancel"):
+				buildCancelRequests.Add(1)
+				json.NewEncoder(w).Encode(buildkite.Build{Number: 1, State: "canceling"})
+				return
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/builds"):
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "scheduled",
+					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
+				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
+				exitOne := 1
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "failing",
+					Jobs: []buildkite.Job{{
+						ID:         "job-failed",
+						Type:       "script",
+						Name:       "Lint",
+						State:      "failed",
+						ExitStatus: &exitOne,
+					}},
+				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
+				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		stdout := captureStdout(t, func() {
+			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true, NoCleanup: true}
+			err := cmd.Run(nil, stubGlobals{})
+			var bkErr *bkErrors.Error
+			if !errors.As(err, &bkErr) || !errors.Is(bkErr, bkErrors.ErrPreflightIncompleteFailure) {
+				t.Fatalf("expected incomplete failure error, got %v", err)
+			}
+		})
+
+		events := decodeJSONLEvents(t, stdout)
+		var summaries []Event
+		for _, event := range events {
+			if event.Type == EventBuildSummary {
+				summaries = append(summaries, event)
+			}
+		}
+
+		if len(summaries) != 1 {
+			t.Fatalf("expected exactly 1 build summary event, got %d", len(summaries))
+		}
+		summary := summaries[0]
+		if summary.BuildCanceled == nil || *summary.BuildCanceled {
+			t.Fatalf("expected build_canceled=false, got %#v", summary.BuildCanceled)
+		}
+		if buildCancelRequests.Load() != 0 {
+			t.Fatalf("expected no build cancel requests, got %d", buildCancelRequests.Load())
+		}
+
+		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")
+		if !strings.Contains(refs, "bk/preflight/") {
+			t.Error("expected preflight branch to still exist with --no-cleanup")
+		}
+	})
+
+	t.Run("build-terminal waits for terminal completion", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		var buildCancelRequests atomic.Int32
+		var buildPolls atomic.Int32
+		now := time.Now()
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/builds/1/cancel"):
+				buildCancelRequests.Add(1)
+				json.NewEncoder(w).Encode(buildkite.Build{Number: 1, State: "canceling"})
+				return
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/builds"):
+				json.NewEncoder(w).Encode(buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "scheduled",
+					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
+				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
+				poll := buildPolls.Add(1)
+				exitOne := 1
+				build := buildkite.Build{
+					ID:     "build-id-123",
+					Number: 1,
+					State:  "running",
+					Jobs: []buildkite.Job{{
+						ID:    "job-running",
+						Type:  "script",
+						Name:  "Lint",
+						State: "running",
+					}},
+				}
+				if poll >= 2 {
+					build.State = "failing"
+					build.Jobs = []buildkite.Job{{
+						ID:         "job-failed",
+						Type:       "script",
+						Name:       "Lint",
+						State:      "failed",
+						ExitStatus: &exitOne,
+					}}
+				}
+				if poll >= 3 {
+					build.State = "failed"
+					build.FinishedAt = &buildkite.Timestamp{Time: now}
+				}
+				json.NewEncoder(w).Encode(build)
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
+				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		stdout := captureStdout(t, func() {
+			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true, ExitOn: []string{"build-terminal"}}
+			err := cmd.Run(nil, stubGlobals{})
+			var bkErr *bkErrors.Error
+			if !errors.As(err, &bkErr) || !errors.Is(bkErr, bkErrors.ErrPreflightCompletedFailure) {
+				t.Fatalf("expected completed failure error, got %v", err)
+			}
+		})
+
+		events := decodeJSONLEvents(t, stdout)
+		var buildStatusCount int
+		var summaries []Event
+		for _, event := range events {
+			if event.Type == EventBuildStatus {
+				buildStatusCount++
+			}
+			if event.Type == EventBuildSummary {
+				summaries = append(summaries, event)
+			}
+		}
+
+		if buildStatusCount != 3 {
+			t.Fatalf("expected 3 build status events before terminal exit, got %d", buildStatusCount)
+		}
+		if len(summaries) != 1 {
+			t.Fatalf("expected exactly 1 build summary event, got %d", len(summaries))
+		}
+		summary := summaries[0]
+		if summary.Incomplete {
+			t.Fatal("expected terminal summary, got incomplete=true")
+		}
+		if summary.StopReason != "" {
+			t.Fatalf("expected empty stop reason, got %q", summary.StopReason)
+		}
+		if summary.BuildCanceled != nil {
+			t.Fatalf("expected no build_canceled metadata for terminal summary, got %#v", summary.BuildCanceled)
+		}
+		if summary.BuildState != "failed" {
+			t.Fatalf("expected failed build state, got %q", summary.BuildState)
+		}
+		if buildCancelRequests.Load() != 0 {
+			t.Fatalf("expected no build cancel requests, got %d", buildCancelRequests.Load())
+		}
+		if buildPolls.Load() < 3 {
+			t.Fatalf("expected to keep polling through terminal state, got %d polls", buildPolls.Load())
+		}
+
 		refs := runGit(t, worktree, "ls-remote", "--heads", "origin")
 		if strings.Contains(refs, "bk/preflight/") {
 			t.Errorf("expected preflight branch to be cleaned up, but found: %s", refs)
@@ -1156,4 +1532,21 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 
 	return string(out)
+}
+
+func decodeJSONLEvents(t *testing.T, output string) []Event {
+	t.Helper()
+
+	decoder := json.NewDecoder(strings.NewReader(output))
+	var events []Event
+	for {
+		var event Event
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				return events
+			}
+			t.Fatalf("decode JSONL event: %v\noutput:\n%s", err, output)
+		}
+		events = append(events, event)
+	}
 }

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/internal/config"
+	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	buildkite "github.com/buildkite/go-buildkite/v4"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
@@ -38,22 +39,21 @@ var _ cli.GlobalFlags = stubGlobals{}
 func TestParseExitConditions(t *testing.T) {
 	tests := []struct {
 		name        string
-		values      []string
-		watch       bool
-		wantPolicy  stopPolicy
+		cmd         RunCmd
+		wantPolicy  internalpreflight.ExitPolicy
 		wantErrText string
 	}{
-		{name: "defaults to build-failing", watch: true, wantPolicy: stopOnBuildFailing},
-		{name: "accepts build-failing", values: []string{"build-failing"}, watch: true, wantPolicy: stopOnBuildFailing},
-		{name: "accepts build-terminal", values: []string{"build-terminal"}, watch: true, wantPolicy: stopOnBuildTerminal},
-		{name: "rejects mixed lifecycle policies", values: []string{"build-failing", "build-terminal"}, watch: true, wantErrText: "build-failing and build-terminal cannot be used together"},
-		{name: "rejects unknown conditions", values: []string{"test-failed:3"}, watch: true, wantErrText: `unsupported --exit-on value "test-failed:3"`},
-		{name: "rejects exit-on when watch disabled", values: []string{"build-failing"}, watch: false, wantErrText: "--exit-on requires --watch"},
+		{name: "defaults to build-failing", cmd: RunCmd{Watch: true, Interval: 1}, wantPolicy: internalpreflight.ExitOnBuildFailing},
+		{name: "accepts build-failing", cmd: RunCmd{Watch: true, Interval: 1, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildFailing}}, wantPolicy: internalpreflight.ExitOnBuildFailing},
+		{name: "accepts build-terminal", cmd: RunCmd{Watch: true, Interval: 1, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildTerminal}}, wantPolicy: internalpreflight.ExitOnBuildTerminal},
+		{name: "accepts repeated build-terminal", cmd: RunCmd{Watch: true, Interval: 1, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildTerminal, internalpreflight.ExitOnBuildTerminal}}, wantPolicy: internalpreflight.ExitOnBuildTerminal},
+		{name: "rejects mixed lifecycle policies", cmd: RunCmd{Watch: true, Interval: 1, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildFailing, internalpreflight.ExitOnBuildTerminal}}, wantErrText: "build-failing and build-terminal cannot be used together"},
+		{name: "rejects exit-on when watch disabled", cmd: RunCmd{Watch: false, Interval: 1, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildFailing}}, wantErrText: "--exit-on requires --watch"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseExitConditions(tt.values, tt.watch)
+			err := tt.cmd.Validate()
 			if tt.wantErrText != "" {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -70,8 +70,9 @@ func TestParseExitConditions(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
-			if got.build != tt.wantPolicy {
-				t.Fatalf("policy = %v, want %v", got.build, tt.wantPolicy)
+			got := internalpreflight.EffectiveExitPolicy(tt.cmd.ExitOn)
+			if got != tt.wantPolicy {
+				t.Fatalf("policy = %v, want %v", got, tt.wantPolicy)
 			}
 		})
 	}
@@ -629,7 +630,7 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 
 		stdout := captureStdout(t, func() {
-			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true, ExitOn: []string{"build-terminal"}}
+			cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Watch: true, Interval: 0.01, JSON: true, ExitOn: []internalpreflight.ExitPolicy{internalpreflight.ExitOnBuildTerminal}}
 			err := cmd.Run(nil, stubGlobals{})
 			var bkErr *bkErrors.Error
 			if !errors.As(err, &bkErr) || !errors.Is(bkErr, bkErrors.ErrPreflightCompletedFailure) {

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -136,13 +136,31 @@ func (r *jsonRenderer) Close() error { return nil }
 
 func summaryHeader(e Event) string {
 	verdict := "❌ Preflight Failed"
-	if e.BuildState == "passed" {
+	if e.Incomplete {
+		verdict = "❌ Preflight Incomplete"
+		if reason := summaryStopReasonLabel(e.StopReason); reason != "" {
+			verdict = fmt.Sprintf("%s (%s)", verdict, reason)
+		}
+	} else if e.BuildState == "passed" {
 		verdict = "✅ Preflight Passed"
 	}
 	if e.Duration > 0 {
 		return fmt.Sprintf("%s (%s)", verdict, formatDuration(e.Duration))
 	}
 	return verdict
+}
+
+func summaryStopReasonLabel(reason string) string {
+	if reason == "" {
+		return ""
+	}
+
+	switch reason {
+	case "build-failing":
+		return "build failing"
+	default:
+		return strings.ReplaceAll(reason, "-", " ")
+	}
 }
 
 func summaryBuildLine(e Event) string {

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -698,6 +698,41 @@ func TestPlainRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	}
 }
 
+func TestPlainRenderer_Render_BuildSummaryStoppedEarly(t *testing.T) {
+	var out bytes.Buffer
+	r := newPlainRenderer(&out)
+
+	buildCanceled := false
+	exitOne := 1
+	if err := r.Render(Event{
+		Type:          EventBuildSummary,
+		Time:          time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
+		Pipeline:      "buildkite/cli",
+		BuildNumber:   42,
+		BuildURL:      "https://buildkite.com/buildkite/cli/builds/42",
+		BuildState:    "failing",
+		Incomplete:    true,
+		StopReason:    "build-failing",
+		BuildCanceled: &buildCanceled,
+		FailedJobs: []buildkite.Job{
+			{ID: "job-1", Name: "Lint", Type: "script", State: "failed", ExitStatus: &exitOne},
+		},
+	}); err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "❌ Preflight Incomplete (build failing)") {
+		t.Fatalf("expected early-stop header, got %q", got)
+	}
+	if !strings.Contains(got, "Build Failures:") {
+		t.Fatalf("expected build failures section, got %q", got)
+	}
+	if !strings.Contains(got, "Lint") {
+		t.Fatalf("expected failed job name, got %q", got)
+	}
+}
+
 func TestPlainRenderer_Render_BuildSummaryIncludesTests(t *testing.T) {
 	var out bytes.Buffer
 	r := newPlainRenderer(&out)
@@ -801,6 +836,43 @@ func TestJSONRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	failedJobs, ok := got["failed_jobs"].([]any)
 	if !ok || len(failedJobs) != 1 {
 		t.Fatalf("expected 1 failed job, got %v", got["failed_jobs"])
+	}
+}
+
+func TestJSONRenderer_Render_BuildSummaryStoppedEarly(t *testing.T) {
+	var out bytes.Buffer
+	r := newJSONRenderer(&out)
+
+	buildCanceled := false
+	if err := r.Render(Event{
+		Type:          EventBuildSummary,
+		Time:          time.Date(2025, 1, 15, 10, 32, 0, 0, time.UTC),
+		PreflightID:   "pfid-123",
+		Pipeline:      "buildkite/cli",
+		BuildNumber:   42,
+		BuildState:    "failing",
+		Incomplete:    true,
+		StopReason:    "build-failing",
+		BuildCanceled: &buildCanceled,
+	}); err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if got["type"] != "build_summary" {
+		t.Fatalf("expected type build_summary, got %v", got["type"])
+	}
+	if got["incomplete"] != true {
+		t.Fatalf("expected incomplete=true, got %v", got["incomplete"])
+	}
+	if got["stop_reason"] != "build-failing" {
+		t.Fatalf("expected stop_reason=build-failing, got %v", got["stop_reason"])
+	}
+	if got["build_canceled"] != false {
+		t.Fatalf("expected build_canceled=false, got %v", got["build_canceled"])
 	}
 }
 

--- a/cmd/preflight/tty_test.go
+++ b/cmd/preflight/tty_test.go
@@ -71,6 +71,19 @@ func TestBuildSummaryView_ReturnsOutput(t *testing.T) {
 			contains: []string{"Build #42", "https://buildkite.com/buildkite/cli/builds/42", "✗", "Lint", "failed with exit 1"},
 		},
 		{
+			name:  "build stopped early",
+			width: 0,
+			event: Event{
+				Type:        EventBuildSummary,
+				BuildState:  "failing",
+				BuildNumber: 42,
+				BuildURL:    "https://buildkite.com/buildkite/cli/builds/42",
+				Incomplete:  true,
+				StopReason:  "build-failing",
+			},
+			contains: []string{"Preflight Incomplete (build failing)", "Build #42", "https://buildkite.com/buildkite/cli/builds/42"},
+		},
+		{
 			name:  "wraps build url on narrow terminals",
 			width: 24,
 			event: Event{

--- a/internal/preflight/exit_policy.go
+++ b/internal/preflight/exit_policy.go
@@ -1,0 +1,47 @@
+package preflight
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	bkErrors "github.com/buildkite/cli/v3/internal/errors"
+)
+
+type ExitPolicy int
+
+const (
+	ExitOnBuildFailing ExitPolicy = iota
+	ExitOnBuildTerminal
+)
+
+func (p *ExitPolicy) UnmarshalText(text []byte) error {
+	value := string(text)
+	name, _, _ := strings.Cut(value, ":")
+	switch name {
+	case "build-failing":
+		*p = ExitOnBuildFailing
+	case "build-terminal":
+		*p = ExitOnBuildTerminal
+	default:
+		return bkErrors.NewValidationError(fmt.Errorf("unsupported --exit-on value %q", value), "invalid exit condition")
+	}
+	return nil
+}
+
+func EffectiveExitPolicy(policies []ExitPolicy) ExitPolicy {
+	if slices.Contains(policies, ExitOnBuildTerminal) {
+		return ExitOnBuildTerminal
+	}
+	return ExitOnBuildFailing
+}
+
+func ValidateExitPolicies(policies []ExitPolicy, watch bool) error {
+	if len(policies) > 0 && !watch {
+		return bkErrors.NewValidationError(fmt.Errorf("--exit-on requires --watch"), "exit conditions require watch mode")
+	}
+	if slices.Contains(policies, ExitOnBuildFailing) && slices.Contains(policies, ExitOnBuildTerminal) {
+		return bkErrors.NewValidationError(fmt.Errorf("build-failing and build-terminal cannot be used together"), "invalid exit conditions")
+	}
+	return nil
+}

--- a/main_test.go
+++ b/main_test.go
@@ -104,4 +104,43 @@ func TestApplyExperiments(t *testing.T) {
 			t.Fatalf("expected explicit await-test-results duration, got %s", cli.Preflight.Run.AwaitTestResults.Duration)
 		}
 	})
+
+	t.Run("preflight exit-on parses repeated flags", func(t *testing.T) {
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		if _, err := parser.Parse([]string{"preflight", "--exit-on=build-failing", "--exit-on=build-failing"}); err != nil {
+			t.Fatalf("failed to parse repeated preflight exit-on flags: %v", err)
+		}
+		if len(cli.Preflight.Run.ExitOn) != 2 {
+			t.Fatalf("expected 2 exit-on values, got %d", len(cli.Preflight.Run.ExitOn))
+		}
+	})
+
+	t.Run("preflight exit-on rejects unknown values", func(t *testing.T) {
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		if _, err := parser.Parse([]string{"preflight", "--exit-on=test-failed:3"}); err == nil {
+			t.Fatal("expected parse error for invalid exit-on value")
+		}
+	})
+
+	t.Run("preflight exit-on rejects incompatible combinations", func(t *testing.T) {
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		if _, err := parser.Parse([]string{"preflight", "--exit-on=build-failing", "--exit-on=build-terminal"}); err == nil {
+			t.Fatal("expected parse error for incompatible exit-on values")
+		}
+	})
 }


### PR DESCRIPTION
This introduces `--exit-on` handling for `bk preflight`, and changes watch mode to stop on the first observed `failing` build state by default instead of always waiting for a terminal build state.

The goal of preflight is to reduce time to actionable failure. Previously `bk preflight` would continue polling until the build reached a terminal state, even after Buildkite had already marked the build as `failing`. The failing state indicates that the build is on track to fail, all automatic retries have been exhausted and the step has hard failed.

The defaults for --exit-on is `--exit-on=build-failing` when `--watch` is enabled.

The previous behaviour of waiting for the final terminal state is available through `--exit-on=build-terminal` to preserve the previous watch-until-terminal behavior. `--exit-on` is not supported when `--watch=false`. Reuses the existing build cancel path so early exits cancel the remote build and cleanup the branch by default, but this can be skipped with `--no-cleanup`. Marks early-stop summaries as incomplete so output can distinguish “stopped on `failing`” from a completed terminal failure while still returning the existing incomplete-failure exit code.