### PR TITLE
Disable in-progress test failures during preflight

### DIFF
--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -247,16 +247,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 			return errExitOnBuildFailing
 		}
 		return nil
-	}, watch.WithRetriedJobs(), watch.WithTestTracking(func(newTestChanges []buildkite.BuildTest) error {
-		return renderer.Render(Event{
-			Type:         EventTestFailure,
-			Time:         time.Now(),
-			PreflightID:  preflightID.String(),
-			Pipeline:     pipelineName,
-			BuildNumber:  build.Number,
-			TestFailures: newTestChanges,
-		})
-	}))
+	}, watch.WithRetriedJobs())
 
 	finalErr := NewResult(finalBuild).Error()
 	cleanupBranch := func() {


### PR DESCRIPTION
### Description

We're currently printing to the preflight log when a test fails, and then again when it subsequently passes. With the new test summary introduced in (https://github.com/buildkite/cli/pull/793), we can show tests which failed all executions at the end of a preflight run with a higher signal to noise ratio (eg. all retries have failed), and reduce the amount of context we omit to an LLM. 

I've only disabled test tracking for now, with some further iteration on excluding flaky tests we could bring back in-progress test failures.