### PR TITLE
Fixes a UI issue when preflight errors

### DIFF
--- a/cmd/preflight/cleanup_cmd.go
+++ b/cmd/preflight/cleanup_cmd.go
@@ -70,7 +70,7 @@ func (c *CleanupCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return nil
 	}
 
-	renderer := newRenderer(os.Stdout, c.JSON, c.Text, pCtx.Stop)
+	renderer := rendererFactory(os.Stdout, c.JSON, c.Text, pCtx.Stop)
 	defer renderer.Close()
 
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), Title: fmt.Sprintf("Found %d preflight branch(es), checking build status...", len(branches))})

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -40,8 +40,9 @@ type RunCmd struct {
 }
 
 var (
-	notifyContext = signal.NotifyContext
-	newFactory    = factory.New
+	notifyContext   = signal.NotifyContext
+	newFactory      = factory.New
+	rendererFactory = newRenderer
 
 	errExitOnBuildFailing = errors.New("exit-on build-failing")
 )
@@ -136,7 +137,8 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		)
 	}
 
-	renderer := newRenderer(os.Stdout, c.JSON, c.Text, stop)
+	renderer := rendererFactory(os.Stdout, c.JSON, c.Text, stop)
+	defer renderer.Close()
 
 	rlTransport.OnRateLimit = func(attempt int, delay time.Duration) {
 		if globals.EnableDebug() {
@@ -198,7 +200,6 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	_ = renderer.Render(Event{Type: EventOperation, Time: time.Now(), PreflightID: preflightID.String(), Title: fmt.Sprintf("Created build on %s/%s...", resolvedPipeline.Org, resolvedPipeline.Name), Detail: fmt.Sprintf("Build:  %s", build.WebURL)})
 
 	if !c.Watch {
-		_ = renderer.Close()
 		return nil
 	}
 
@@ -262,7 +263,6 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		if finalBuild.FinishedAt == nil && !buildstate.IsTerminal(buildstate.State(finalBuild.State)) && !c.NoCleanup {
 			cancelBuild(f, renderer, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, preflightID.String(), globals.EnableDebug())
 		}
-		_ = renderer.Close()
 		return bkErrors.NewUserAbortedError(context.Canceled, "preflight canceled by user")
 	}
 
@@ -288,7 +288,6 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		}
 		_ = renderer.Render(summaryEvent)
 		cleanupBranch()
-		_ = renderer.Close()
 		return finalErr
 	}
 
@@ -313,7 +312,6 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	cleanupBranch()
-	_ = renderer.Close()
 
 	if err != nil {
 		return bkErrors.NewInternalError(err, "watching build failed",

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -1663,6 +1663,55 @@ func TestPreflightCmd_Run(t *testing.T) {
 			t.Fatalf("expected build creation error, got: %v", err)
 		}
 	})
+
+	t.Run("closes renderer when build creation fails", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+
+		originalRendererFactory := rendererFactory
+		fakeRenderer := &recordingRenderer{}
+		rendererFactory = func(io.Writer, bool, bool, context.CancelFunc) renderer {
+			return fakeRenderer
+		}
+		t.Cleanup(func() { rendererFactory = originalRendererFactory })
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"message":"Authentication required"}`))
+		}))
+		defer s.Close()
+		t.Setenv("BUILDKITE_REST_API_ENDPOINT", s.URL)
+
+		worktree := initTestRepo(t)
+		t.Chdir(worktree)
+
+		if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("hello\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &RunCmd{Pipeline: "test-org/test-pipeline", Interval: 2}
+		err := cmd.Run(nil, stubGlobals{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "creating preflight build") {
+			t.Fatalf("expected build creation error, got: %v", err)
+		}
+		if fakeRenderer.closeCalls != 1 {
+			t.Fatalf("expected renderer to be closed once, got %d", fakeRenderer.closeCalls)
+		}
+	})
+}
+
+type recordingRenderer struct {
+	closeCalls int
+}
+
+func (r *recordingRenderer) Render(Event) error { return nil }
+
+func (r *recordingRenderer) Close() error {
+	r.closeCalls++
+	return nil
 }
 
 func initTestRepo(t *testing.T) string {


### PR DESCRIPTION
### Description

We previously had a similar CLI issue when we used Bubbletea more prominantly; we need to ensure the renderer is also closed on error.

### Changes

- closes the renderer on errors

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

