### PR TITLE
Enable preflight experiment by default

### DIFF
--- a/cmd/preflight/cleanup_cmd_test.go
+++ b/cmd/preflight/cleanup_cmd_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCleanupCmd_Run(t *testing.T) {
 	t.Run("returns validation error when experiment disabled", func(t *testing.T) {
-		t.Setenv("BUILDKITE_EXPERIMENTS", "")
+		t.Setenv("BUILDKITE_EXPERIMENTS", "alpha")
 
 		cmd := &CleanupCmd{}
 		err := cmd.Run(nil, stubGlobals{})

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -19,6 +19,7 @@ import (
 	buildstate "github.com/buildkite/cli/v3/internal/build/state"
 	"github.com/buildkite/cli/v3/internal/build/watch"
 	"github.com/buildkite/cli/v3/internal/cli"
+	internalconfig "github.com/buildkite/cli/v3/internal/config"
 	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	bkhttp "github.com/buildkite/cli/v3/internal/http"
 	"github.com/buildkite/cli/v3/internal/pipeline"
@@ -420,7 +421,7 @@ func setup(pipelineFlag string, globals cli.GlobalFlags) (*preflightContext, err
 		return nil, bkErrors.NewInternalError(err, "failed to initialize CLI", "This is likely a bug", "Report to Buildkite")
 	}
 
-	if !f.Config.HasExperiment("preflight") {
+	if !f.Config.HasExperiment(internalconfig.ExperimentPreflight) {
 		return nil, bkErrors.NewValidationError(
 			fmt.Errorf("experiment not enabled"),
 			"preflight is disabled by the current experiments override. Add `preflight` to `BUILDKITE_EXPERIMENTS` or run `bk config set experiments preflight` to re-enable it")

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -423,7 +423,7 @@ func setup(pipelineFlag string, globals cli.GlobalFlags) (*preflightContext, err
 	if !f.Config.HasExperiment("preflight") {
 		return nil, bkErrors.NewValidationError(
 			fmt.Errorf("experiment not enabled"),
-			"the preflight command is under development and requires the 'preflight' experiment to opt in. Run: bk config set experiments preflight or set BUILDKITE_EXPERIMENTS=preflight")
+			"preflight is disabled by the current experiments override. Add `preflight` to `BUILDKITE_EXPERIMENTS` or run `bk config set experiments preflight` to re-enable it")
 	}
 
 	repoRoot, err := resolveRepositoryRoot(f, globals.EnableDebug())

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -80,7 +80,7 @@ func TestParseExitConditions(t *testing.T) {
 
 func TestPreflightCmd_Run(t *testing.T) {
 	t.Run("returns validation error when experiment disabled", func(t *testing.T) {
-		t.Setenv("BUILDKITE_EXPERIMENTS", "")
+		t.Setenv("BUILDKITE_EXPERIMENTS", "alpha")
 
 		cmd := &RunCmd{}
 		err := cmd.Run(nil, stubGlobals{})

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -36,6 +36,27 @@ func (s stubGlobals) EnableDebug() bool      { return false }
 
 var _ cli.GlobalFlags = stubGlobals{}
 
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	original, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("failed to unset env %s: %v", key, err)
+	}
+
+	t.Cleanup(func() {
+		var err error
+		if had {
+			err = os.Setenv(key, original)
+		} else {
+			err = os.Unsetenv(key)
+		}
+		if err != nil {
+			t.Fatalf("failed to restore env %s: %v", key, err)
+		}
+	})
+}
+
 func TestParseExitConditions(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -82,7 +103,7 @@ func TestPreflightCmd_Run(t *testing.T) {
 	t.Run("returns validation error when experiment disabled", func(t *testing.T) {
 		t.Setenv("BUILDKITE_EXPERIMENTS", "alpha")
 
-		cmd := &RunCmd{}
+		cmd := &RunCmd{Interval: 1}
 		err := cmd.Run(nil, stubGlobals{})
 		if err == nil {
 			t.Fatal("expected error, got nil")
@@ -94,16 +115,20 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 		if !errors.Is(bkErr, bkErrors.ErrValidation) {
 			t.Errorf("expected ErrValidation, got category: %v", bkErr.Category)
+		}
+		if !strings.Contains(bkErr.Details, "preflight is disabled") {
+			t.Errorf("expected disabled experiment validation, got details %q", bkErr.Details)
 		}
 	})
 
-	t.Run("returns validation error when not in git repo", func(t *testing.T) {
-		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
+	t.Run("preflight is enabled by default", func(t *testing.T) {
+		unsetEnv(t, "BUILDKITE_EXPERIMENTS")
 
-		// Run from a temp dir that is not a git repo.
+		// Run from a temp dir that is not a git repo. This should pass the
+		// experiment gate and fail on repository validation instead.
 		t.Chdir(t.TempDir())
 
-		cmd := &RunCmd{}
+		cmd := &RunCmd{Interval: 1}
 		err := cmd.Run(nil, stubGlobals{})
 		if err == nil {
 			t.Fatal("expected error, got nil")
@@ -115,6 +140,9 @@ func TestPreflightCmd_Run(t *testing.T) {
 		}
 		if !errors.Is(bkErr, bkErrors.ErrValidation) {
 			t.Errorf("expected ErrValidation, got category: %v", bkErr.Category)
+		}
+		if !strings.Contains(bkErr.Details, "git repository") {
+			t.Errorf("expected git repository validation after default experiment gate, got details %q", bkErr.Details)
 		}
 	})
 
@@ -1725,6 +1753,7 @@ func initTestRepo(t *testing.T) string {
 	runGit(t, "", "init", worktree)
 	runGit(t, worktree, "config", "user.email", "test@test.com")
 	runGit(t, worktree, "config", "user.name", "Test")
+	runGit(t, worktree, "config", "commit.gpgsign", "false")
 
 	initial := filepath.Join(worktree, "README.md")
 	if err := os.WriteFile(initial, []byte("# test\n"), 0o644); err != nil {

--- a/internal/build/resolver/options/options_test.go
+++ b/internal/build/resolver/options/options_test.go
@@ -27,7 +27,7 @@ func TestResolveBranchFromGitFallback(t *testing.T) {
 	if err := exec.Command("git", "add", filepath.Base(commitFile)).Run(); err != nil {
 		t.Fatalf("git add returned error: %v", err)
 	}
-	if err := exec.Command("git", "-c", "user.name=Person Example", "-c", "user.email=person@example.com", "commit", "-m", "initial").Run(); err != nil {
+	if err := exec.Command("git", "-c", "user.name=Person Example", "-c", "user.email=person@example.com", "-c", "commit.gpgsign=false", "commit", "-m", "initial").Run(); err != nil {
 		t.Fatalf("git commit returned error: %v", err)
 	}
 	if err := exec.Command("git", "checkout", "-b", "feature/test").Run(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,11 @@ var (
 const (
 	DefaultGraphQLEndpoint = "https://graphql.buildkite.com/v1"
 
+	// ExperimentPreflight is the experiment flag name for the preflight command.
+	ExperimentPreflight = "preflight"
+	// DefaultExperiments is the comma-separated experiment list enabled out-of-the-box.
+	DefaultExperiments = ExperimentPreflight
+
 	appData             = "AppData"
 	configFilePath      = "bk.yaml"
 	localConfigFilePath = "." + configFilePath
@@ -350,7 +355,7 @@ func (conf *Config) Experiments() string {
 	if conf.user.Experiments != "" {
 		return conf.user.Experiments
 	}
-	return "preflight"
+	return DefaultExperiments
 }
 
 // HasExperiment reports whether the given experiment name is enabled.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,12 +342,15 @@ func (conf *Config) SetTelemetry(v bool) error {
 }
 
 // Experiments returns the comma-separated list of enabled experiments.
-// Precedence: env (even if empty) > user config
+// Precedence: env (even if empty) > user config > default
 func (conf *Config) Experiments() string {
 	if v, ok := os.LookupEnv("BUILDKITE_EXPERIMENTS"); ok {
 		return v
 	}
-	return conf.user.Experiments
+	if conf.user.Experiments != "" {
+		return conf.user.Experiments
+	}
+	return "preflight"
 }
 
 // HasExperiment reports whether the given experiment name is enabled.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -361,8 +361,8 @@ func TestExperiments(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		conf := New(fs, nil)
 
-		if got := conf.Experiments(); got != "preflight" {
-			t.Errorf("Experiments() = %q, want %q", got, "preflight")
+		if got := conf.Experiments(); got != DefaultExperiments {
+			t.Errorf("Experiments() = %q, want %q", got, DefaultExperiments)
 		}
 	})
 
@@ -419,6 +419,19 @@ func TestExperiments(t *testing.T) {
 	})
 }
 
+func TestHasExperimentEnvOverride(t *testing.T) {
+	t.Run("empty env override disables default experiments", func(t *testing.T) {
+		setEnv(t, "BUILDKITE_EXPERIMENTS", "")
+
+		fs := afero.NewMemMapFs()
+		conf := New(fs, nil)
+
+		if conf.HasExperiment(ExperimentPreflight) {
+			t.Errorf("HasExperiment(%q) = true, want false", ExperimentPreflight)
+		}
+	})
+}
+
 func TestHasExperiment(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -426,7 +439,7 @@ func TestHasExperiment(t *testing.T) {
 		query       string
 		want        bool
 	}{
-		{"preflight defaults on", "", "preflight", true},
+		{"preflight defaults on", "", ExperimentPreflight, true},
 		{"single match", "preflight", "preflight", true},
 		{"multiple with match", "foo,preflight,bar", "preflight", true},
 		{"override without match", "foo,bar", "preflight", false},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -355,14 +355,14 @@ func TestAPITokenForOrgNoKeyring(t *testing.T) {
 }
 
 func TestExperiments(t *testing.T) {
-	t.Run("defaults to empty", func(t *testing.T) {
+	t.Run("defaults to preflight", func(t *testing.T) {
 		unsetEnv(t, "BUILDKITE_EXPERIMENTS")
 
 		fs := afero.NewMemMapFs()
 		conf := New(fs, nil)
 
-		if got := conf.Experiments(); got != "" {
-			t.Errorf("Experiments() = %q, want %q", got, "")
+		if got := conf.Experiments(); got != "preflight" {
+			t.Errorf("Experiments() = %q, want %q", got, "preflight")
 		}
 	})
 
@@ -390,15 +390,15 @@ func TestExperiments(t *testing.T) {
 		}
 	})
 
-	t.Run("config value is used", func(t *testing.T) {
+	t.Run("config overrides the default", func(t *testing.T) {
 		unsetEnv(t, "BUILDKITE_EXPERIMENTS")
 
 		fs := afero.NewMemMapFs()
 		conf := New(fs, nil)
-		conf.SetExperiments("preflight")
+		conf.SetExperiments("beta")
 
-		if got := conf.Experiments(); got != "preflight" {
-			t.Errorf("Experiments() = %q, want %q", got, "preflight")
+		if got := conf.Experiments(); got != "beta" {
+			t.Errorf("Experiments() = %q, want %q", got, "beta")
 		}
 	})
 
@@ -426,11 +426,12 @@ func TestHasExperiment(t *testing.T) {
 		query       string
 		want        bool
 	}{
+		{"preflight defaults on", "", "preflight", true},
 		{"single match", "preflight", "preflight", true},
 		{"multiple with match", "foo,preflight,bar", "preflight", true},
-		{"multiple without match", "foo,bar", "preflight", false},
+		{"override without match", "foo,bar", "preflight", false},
 		{"whitespace handling", " preflight , bar ", "preflight", true},
-		{"empty string", "", "preflight", false},
+		{"other experiments still default off", "", "beta", false},
 		{"partial name no match", "preflightx", "preflight", false},
 	}
 

--- a/internal/preflight/snapshot_test.go
+++ b/internal/preflight/snapshot_test.go
@@ -27,6 +27,7 @@ func initTestRepo(t *testing.T) string {
 	runGit(t, "", "init", worktree)
 	runGit(t, worktree, "config", "user.email", "test@test.com")
 	runGit(t, worktree, "config", "user.name", "Test")
+	runGit(t, worktree, "config", "commit.gpgsign", "false")
 
 	// Create an initial commit so HEAD exists.
 	initial := filepath.Join(worktree, "README.md")

--- a/main.go
+++ b/main.go
@@ -184,8 +184,8 @@ func newKongParser(cli *CLI) (*kong.Kong, error) {
 func applyExperiments(parser *kong.Kong, conf *config.Config) {
 	for _, node := range parser.Model.Children {
 		switch node.Name {
-		case "preflight":
-			node.Hidden = !conf.HasExperiment("preflight")
+		case config.ExperimentPreflight:
+			node.Hidden = !conf.HasExperiment(config.ExperimentPreflight)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -8,9 +9,54 @@ import (
 	"github.com/spf13/afero"
 )
 
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	original, had := os.LookupEnv(key)
+	if had {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("failed to unset env %s: %v", key, err)
+		}
+	}
+	t.Cleanup(func() {
+		var err error
+		if had {
+			err = os.Setenv(key, original)
+		} else {
+			err = os.Unsetenv(key)
+		}
+		if err != nil {
+			t.Fatalf("failed to restore env %s: %v", key, err)
+		}
+	})
+}
+
 func TestApplyExperiments(t *testing.T) {
+	t.Run("preflight visible by default", func(t *testing.T) {
+		unsetEnv(t, "BUILDKITE_EXPERIMENTS")
+		fs := afero.NewMemMapFs()
+		conf := config.New(fs, nil)
+
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		applyExperiments(parser, conf)
+
+		for _, node := range parser.Model.Children {
+			if node.Name == "preflight" {
+				if node.Hidden {
+					t.Error("preflight should be visible by default")
+				}
+				return
+			}
+		}
+		t.Fatal("preflight command not found in parser")
+	})
+
 	t.Run("preflight hidden when experiment disabled", func(t *testing.T) {
-		t.Setenv("BUILDKITE_EXPERIMENTS", "")
+		t.Setenv("BUILDKITE_EXPERIMENTS", "alpha")
 		fs := afero.NewMemMapFs()
 		conf := config.New(fs, nil)
 
@@ -33,7 +79,31 @@ func TestApplyExperiments(t *testing.T) {
 		t.Fatal("preflight command not found in parser")
 	})
 
-	t.Run("preflight visible when experiment enabled", func(t *testing.T) {
+	t.Run("preflight hidden when experiments override is empty", func(t *testing.T) {
+		t.Setenv("BUILDKITE_EXPERIMENTS", "")
+		fs := afero.NewMemMapFs()
+		conf := config.New(fs, nil)
+
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		applyExperiments(parser, conf)
+
+		for _, node := range parser.Model.Children {
+			if node.Name == "preflight" {
+				if !node.Hidden {
+					t.Error("preflight should be hidden when experiments override is empty")
+				}
+				return
+			}
+		}
+		t.Fatal("preflight command not found in parser")
+	})
+
+	t.Run("preflight visible when experiment enabled explicitly", func(t *testing.T) {
 		t.Setenv("BUILDKITE_EXPERIMENTS", "preflight")
 		fs := afero.NewMemMapFs()
 		conf := config.New(fs, nil)


### PR DESCRIPTION
### Description

Enable the Preflight experiment by default. Preflight is still an experimental command, but we're removing the need to enable the experiment flag to access it. Preflight is subject to change, and is a very early preview. Internally, we've been using it to capture the CI loop of commit > push > run-ci > read-results into a single CLI command.
