### PR TITLE
Add experimental label and improve descriptions

### DIFF
--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -49,6 +49,12 @@ var (
 
 const defaultAwaitTestResultsDuration = 30 * time.Second
 
+func HelpText() string {
+	return `Preflight is an experimental preview and subject to change without notice.
+
+Snapshots your working tree (staged, unstaged, and untracked files) to a temporary commit on a bk/preflight/<id> branch, triggers a build on the selected pipeline, monitors failures, exits as soon as the build starts failing, and cleans up the temporary branch when finished.`
+}
+
 type summaryMeta struct {
 	Incomplete    bool
 	StopReason    string
@@ -92,9 +98,7 @@ func (f *awaitTestResultsFlag) Decode(ctx *kong.DecodeContext) error {
 func (f awaitTestResultsFlag) IsBool() bool { return true }
 
 func (c *RunCmd) Help() string {
-	return `Preflight is an experimental preview and subject to change without notice.
-
-Snapshots your working tree (staged, unstaged, and untracked files) to a temporary commit on a bk/preflight/<id> branch, triggers a build on the selected pipeline, monitors failures, exits as soon as the build starts failing, and cleans up the temporary branch when finished.`
+	return HelpText()
 }
 
 func (c *RunCmd) Validate() error {

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -34,7 +34,7 @@ type RunCmd struct {
 	ExitOn           []internalpreflight.ExitPolicy `help:"Exit when a condition is met. Options: build-failing (default, exits when a build enters the failing state), build-terminal (exits when the build reaches a terminal state)."`
 	Interval         float64                        `help:"Polling interval in seconds when watching." default:"2"`
 	NoCleanup        bool                           `help:"Skip cleanup after completion or early exit. The preflight branch remains and the build keeps running if exiting early."`
-	AwaitTestResults awaitTestResultsFlag           `name:"await-test-results" help:"After the build finishes, wait for tests results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait 30s."`
+	AwaitTestResults awaitTestResultsFlag           `name:"await-test-results" help:"After the build finishes, wait for test results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait 30s."`
 	Text             bool                           `help:"Use plain text output instead of interactive terminal UI." xor:"output"`
 	JSON             bool                           `help:"Emit one JSON object per event (JSONL)." xor:"output"`
 }
@@ -92,7 +92,9 @@ func (f *awaitTestResultsFlag) Decode(ctx *kong.DecodeContext) error {
 func (f awaitTestResultsFlag) IsBool() bool { return true }
 
 func (c *RunCmd) Help() string {
-	return `Snapshots your working tree (uncommitted, staged, and untracked changes) and pushes it to a bk/preflight/<id> branch. If there are no local changes, pushes HEAD directly.`
+	return `Preflight is an experimental preview and subject to change without notice.
+
+Snapshots your working tree (staged, unstaged, and untracked files) to a temporary commit on a bk/preflight/<id> branch, triggers a build on the selected pipeline, monitors failures, exits as soon as the build starts failing, and cleans up the temporary branch when finished.`
 }
 
 func (c *RunCmd) Validate() error {

--- a/main.go
+++ b/main.go
@@ -164,6 +164,10 @@ type (
 	}
 )
 
+func (c PreflightCmd) Help() string {
+	return preflight.HelpText()
+}
+
 func handleError(err error) {
 	bkErrors.NewHandler().Handle(err)
 }

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type CLI struct {
 	Organization OrganizationCmd    `cmd:"" help:"Manage organizations" aliases:"org"`
 	Pipeline     PipelineCmd        `cmd:"" help:"Manage pipelines"`
 	Package      PackageCmd         `cmd:"" help:"Manage packages"`
-	Preflight    PreflightCmd       `cmd:"" help:"Validate pre-commit changes"`
+	Preflight    PreflightCmd       `cmd:"" help:"Run a build against a snapshot of the local working tree (experimental)"`
 	Use          use.UseCmd         `cmd:"" help:"Select an organization" hidden:""`
 	User         UserCmd            `cmd:"" help:"Invite users to the organization"`
 	Version      VersionCmd         `cmd:"" help:"Print the version of the CLI being used"`
@@ -150,8 +150,8 @@ type (
 		View     pipeline.ViewCmd     `cmd:"" help:"View a pipeline."`
 	}
 	PreflightCmd struct {
-		Run     preflight.RunCmd     `cmd:"" default:"withargs" help:"Run a preflight check"`
-		Cleanup preflight.CleanupCmd `cmd:"" help:"Clean up completed preflight branches"`
+		Run     preflight.RunCmd     `cmd:"" default:"withargs" help:"Run a build against a snapshot of the local working tree (experimental)"`
+		Cleanup preflight.CleanupCmd `cmd:"" help:"Clean up completed preflight branches (experimental)"`
 	}
 	UserCmd struct {
 		Invite user.InviteCmd `cmd:"" help:"Invite users to your organization."`


### PR DESCRIPTION
### Description

```
./bk --help
....
  preflight run [flags]
    Run a build against a snapshot of the local working tree (experimental)

  preflight cleanup [flags]
    Clean up completed preflight branches (experimental)
```



```
Usage: bk preflight <command> [flags]

Run a build against a snapshot of the local working tree (experimental)

Preflight is an experimental preview and subject to change without notice.

Snapshots your working tree (staged, unstaged, and untracked files) to a temporary commit on a bk/preflight/<id> branch, triggers a build on the selected pipeline,
monitors failures, exits as soon as the build starts failing, and cleans up the temporary branch when finished.

Flags:
  -h, --help        Show context-sensitive help.
  -y, --yes         Skip all confirmation prompts
      --no-input    Disable all interactive prompts
  -q, --quiet       Suppress progress output
      --no-pager    Disable pager for text output
      --debug       Enable debug output for REST API calls

Commands:
  preflight run [flags]
    Run a build against a snapshot of the local working tree (experimental)

  preflight cleanup [flags]
    Clean up completed preflight branches (experimental)
```

```
matthewborden@Matthews-MacBook-Pro-2:~/cli  % ./bk preflight run --help
Usage: bk preflight run [flags]

Run a build against a snapshot of the local working tree (experimental)

Preflight is an experimental preview and subject to change without notice.

Snapshots your working tree (staged, unstaged, and untracked files) to a temporary commit on a bk/preflight/<id> branch, triggers a build on the selected pipeline,
monitors failures, exits as soon as the build starts failing, and cleans up the temporary branch when finished.

Flags:
  -h, --help                   Show context-sensitive help.
  -y, --yes                    Skip all confirmation prompts
      --no-input               Disable all interactive prompts
  -q, --quiet                  Suppress progress output
      --no-pager               Disable pager for text output
      --debug                  Enable debug output for REST API calls

  -p, --pipeline=STRING        The pipeline to build. This can be a {pipeline slug} or in the format {org slug}/{pipeline slug}.
      --[no-]watch             Watch the build until completion.
      --exit-on=EXIT-ON,...    Exit when a condition is met. Options: build-failing (default, exits when a build enters the failing state), build-terminal (exits when
                               the build reaches a terminal state).
      --interval=2             Polling interval in seconds when watching.
      --no-cleanup             Skip cleanup after completion or early exit. The preflight branch remains and the build keeps running if exiting early.
      --await-test-results     After the build finishes, wait for test results to be processed by Test Engine. Provide a duration like 10s, or omit the value to wait
                               30s.
      --text                   Use plain text output instead of interactive terminal UI.
      --json                   Emit one JSON object per event (JSONL).
```