### PR TITLE
Show bk preflight run --help options in bk preflight --help

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -172,16 +173,71 @@ func handleError(err error) {
 	bkErrors.NewHandler().Handle(err)
 }
 
-func newKongParser(cli *CLI) (*kong.Kong, error) {
-	return kong.New(
-		cli,
+func newKongParser(cli *CLI, options ...kong.Option) (*kong.Kong, error) {
+	baseOptions := []kong.Option{
 		kong.Name("bk"),
 		kong.Description("Work with Buildkite from the command line."),
 		kong.Vars{
 			// Empty default allows commands to fall back to config value
 			"output_default_format": "",
 		},
+	}
+	baseOptions = append(baseOptions, options...)
+
+	return kong.New(cli, baseOptions...)
+}
+
+func renderHelp(args []string) (string, error) {
+	cli := &CLI{}
+	var stdout, stderr bytes.Buffer
+	parser, err := newKongParser(
+		cli,
+		kong.Writers(&stdout, &stderr),
+		kong.Exit(func(int) {}),
 	)
+	if err != nil {
+		return "", err
+	}
+	applyExperiments(parser, config.New(nil, nil))
+	if _, err := parser.Parse(args); err != nil {
+		if stdout.Len() > 0 {
+			return stdout.String(), nil
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}
+
+func renderPreflightHelp() (string, error) {
+	parentHelp, err := renderHelp([]string{"preflight", "--help"})
+	if err != nil {
+		return "", err
+	}
+
+	runHelp, err := renderHelp([]string{"preflight", "run", "--help"})
+	if err != nil {
+		return "", err
+	}
+
+	parentFlagsStart := strings.Index(parentHelp, "\nFlags:\n")
+	parentCommandsStart := strings.Index(parentHelp, "\nCommands:\n")
+	runFlagsStart := strings.Index(runHelp, "\nFlags:\n")
+	if parentFlagsStart == -1 || parentCommandsStart == -1 || runFlagsStart == -1 {
+		return parentHelp, nil
+	}
+
+	return parentHelp[:parentFlagsStart] + runHelp[runFlagsStart:] + parentHelp[parentCommandsStart:], nil
+}
+
+func isPreflightHelpRequest(args []string) bool {
+	switch {
+	case len(args) == 2 && args[0] == "preflight" && (args[1] == "--help" || args[1] == "-h"):
+		return true
+	case len(args) == 2 && args[0] == "help" && args[1] == "preflight":
+		return true
+	default:
+		return false
+	}
 }
 
 // applyExperiments toggles visibility of experimental commands based on config.
@@ -219,6 +275,18 @@ func run() int {
 		return 0
 	}
 
+	args := os.Args[1:]
+
+	if isPreflightHelpRequest(args) {
+		help, err := renderPreflightHelp()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Print(help)
+		return 0
+	}
+
 	cliInstance := &CLI{}
 
 	conf := config.New(nil, nil)
@@ -233,9 +301,9 @@ func run() int {
 		return 1
 	}
 	applyExperiments(parser, conf)
-	ctx, err := parser.Parse(os.Args[1:])
+	ctx, err := parser.Parse(args)
 	if err != nil {
-		tracker.TrackCommand("unknown command", os.Args[1:], nil)
+		tracker.TrackCommand("unknown command", args, nil)
 
 		var parseErr *kong.ParseError
 		if errors.As(err, &parseErr) && !strings.Contains(err.Error(), "did you mean") {
@@ -247,7 +315,7 @@ func run() int {
 		return 1
 	}
 
-	tracker.TrackCommand(analytics.ParseSubcommand(ctx.Command()), os.Args[1:], nil)
+	tracker.TrackCommand(analytics.ParseSubcommand(ctx.Command()), args, nil)
 
 	globals := cli.Globals{
 		Yes:     cliInstance.Yes,

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -211,6 +212,60 @@ func TestApplyExperiments(t *testing.T) {
 
 		if _, err := parser.Parse([]string{"preflight", "--exit-on=build-failing", "--exit-on=build-terminal"}); err == nil {
 			t.Fatal("expected parse error for incompatible exit-on values")
+		}
+	})
+
+	t.Run("preflight run subcommand still parses", func(t *testing.T) {
+		cli := &CLI{}
+		parser, err := newKongParser(cli)
+		if err != nil {
+			t.Fatalf("failed to create parser: %v", err)
+		}
+
+		if _, err := parser.Parse([]string{"preflight", "run", "--await-test-results=45s"}); err != nil {
+			t.Fatalf("failed to parse preflight run subcommand: %v", err)
+		}
+		if !cli.Preflight.Run.AwaitTestResults.Enabled {
+			t.Fatal("expected run subcommand await-test-results to be enabled")
+		}
+		if cli.Preflight.Run.AwaitTestResults.Duration != 45*time.Second {
+			t.Fatalf("expected explicit run subcommand await-test-results duration, got %s", cli.Preflight.Run.AwaitTestResults.Duration)
+		}
+	})
+
+	t.Run("preflight help includes mirrored run flags", func(t *testing.T) {
+		help, err := renderPreflightHelp()
+		if err != nil {
+			t.Fatalf("failed to render preflight help: %v", err)
+		}
+		for _, want := range []string{
+			"--[no-]watch",
+			"--exit-on=EXIT-ON,...",
+			"--await-test-results",
+			"--no-cleanup",
+			"preflight cleanup [flags]",
+		} {
+			if !strings.Contains(help, want) {
+				t.Fatalf("expected preflight help to contain %q, got:\n%s", want, help)
+			}
+		}
+	})
+
+	t.Run("preflight help requests are detected", func(t *testing.T) {
+		tests := []struct {
+			args []string
+			want bool
+		}{
+			{args: []string{"preflight", "--help"}, want: true},
+			{args: []string{"preflight", "-h"}, want: true},
+			{args: []string{"help", "preflight"}, want: true},
+			{args: []string{"preflight", "run", "--help"}, want: false},
+		}
+
+		for _, tt := range tests {
+			if got := isPreflightHelpRequest(tt.args); got != tt.want {
+				t.Fatalf("isPreflightHelpRequest(%q) = %v, want %v", tt.args, got, tt.want)
+			}
 		}
 	})
 }


### PR DESCRIPTION
### Description

`bk preflight` is the canonical way to invoke `bk preflight run`, and we want the flags of `bk preflight run` to show up on the help text of `bk preflight`.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`)
- [ ] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
