### PR TITLE
Add batching to `bk preflight cleanup`

### DIFF
--- a/internal/preflight/branch_build.go
+++ b/internal/preflight/branch_build.go
@@ -3,6 +3,8 @@ package preflight
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 
 	buildstate "github.com/buildkite/cli/v3/internal/build/state"
@@ -77,7 +79,11 @@ func lsRemotePreflightBranches(dir, pattern string, debug bool) ([]BranchBuild, 
 // maxResolveBuildPages is the maximum number of API pages to fetch when
 // resolving builds. This prevents runaway pagination when orphaned branches
 // have no matching builds.
-const maxResolveBuildPages = 10
+const (
+	maxResolveBuildPages       = 10
+	resolveBuildsPerPage       = 100
+	maxResolveBuildQueryLength = 6000
+)
 
 // ResolveBuilds looks up the most recent build for each preflight branch and
 // populates the Build field. Branches with no matching build retain a nil Build.
@@ -86,33 +92,34 @@ func ResolveBuilds(ctx context.Context, client *buildkite.Client, org, pipeline 
 		return nil
 	}
 
-	branchNames := make([]string, len(branches))
-	for i := range branches {
-		branchNames[i] = branches[i].Branch
-	}
-
 	resolved := make(map[string]*buildkite.Build, len(branches))
-	opts := &buildkite.BuildsListOptions{
-		Branch:      branchNames,
-		ListOptions: buildkite.ListOptions{PerPage: 100},
-	}
-
-	for page := 0; page < maxResolveBuildPages; page++ {
-		builds, resp, err := client.Builds.ListByPipeline(ctx, org, pipeline, opts)
-		if err != nil {
-			return fmt.Errorf("listing builds for preflight branches: %w", err)
+	for _, branchBatch := range resolveBuildBranchBatches(branches) {
+		opts := &buildkite.BuildsListOptions{
+			Branch:      branchBatch,
+			ListOptions: buildkite.ListOptions{PerPage: resolveBuildsPerPage},
 		}
 
-		for i := range builds {
-			if _, exists := resolved[builds[i].Branch]; !exists {
-				resolved[builds[i].Branch] = &builds[i]
+		for page := 0; page < maxResolveBuildPages; page++ {
+			builds, resp, err := client.Builds.ListByPipeline(ctx, org, pipeline, opts)
+			if err != nil {
+				return fmt.Errorf("listing builds for preflight branches: %w", err)
 			}
+
+			for i := range builds {
+				if _, exists := resolved[builds[i].Branch]; !exists {
+					resolved[builds[i].Branch] = &builds[i]
+				}
+			}
+
+			if len(builds) == 0 || len(resolved) >= len(branches) || resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
 		}
 
-		if len(builds) == 0 || len(resolved) >= len(branches) || resp.NextPage == 0 {
+		if len(resolved) >= len(branches) {
 			break
 		}
-		opts.Page = resp.NextPage
 	}
 
 	for i := range branches {
@@ -120,4 +127,37 @@ func ResolveBuilds(ctx context.Context, client *buildkite.Client, org, pipeline 
 	}
 
 	return nil
+}
+
+func resolveBuildBranchBatches(branches []BranchBuild) [][]string {
+	if len(branches) == 0 {
+		return nil
+	}
+
+	batches := make([][]string, 0, 1)
+	current := make([]string, 0, len(branches))
+	for i := range branches {
+		branch := branches[i].Branch
+		if len(current) > 0 && resolveBuildQueryLength(append(current, branch)) > maxResolveBuildQueryLength {
+			batches = append(batches, current)
+			current = []string{branch}
+			continue
+		}
+		current = append(current, branch)
+	}
+
+	if len(current) > 0 {
+		batches = append(batches, current)
+	}
+
+	return batches
+}
+
+func resolveBuildQueryLength(branches []string) int {
+	query := url.Values{
+		"branch[]": append([]string(nil), branches...),
+	}
+	query.Set("per_page", strconv.Itoa(resolveBuildsPerPage))
+	query.Set("page", strconv.Itoa(maxResolveBuildPages))
+	return len(query.Encode())
 }

--- a/internal/preflight/branch_build_test.go
+++ b/internal/preflight/branch_build_test.go
@@ -1,0 +1,76 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	buildkite "github.com/buildkite/go-buildkite/v4"
+)
+
+func TestResolveBuilds_BatchesRequestsToAvoidLongQuery(t *testing.T) {
+	const maxRawQueryLen = 6500
+
+	var requestQueryLens []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/builds") {
+			http.NotFound(w, r)
+			return
+		}
+
+		requestQueryLens = append(requestQueryLens, len(r.URL.RawQuery))
+		if len(r.URL.RawQuery) > maxRawQueryLen {
+			http.Error(w, `{"message":"request uri too long"}`, http.StatusRequestURITooLong)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		builds := make([]buildkite.Build, 0, len(r.URL.Query()["branch[]"]))
+		for _, branch := range r.URL.Query()["branch[]"] {
+			builds = append(builds, buildkite.Build{Branch: branch, State: "passed"})
+		}
+		if err := json.NewEncoder(w).Encode(builds); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := buildkite.NewOpts(buildkite.WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("creating buildkite client: %v", err)
+	}
+
+	branches := make([]BranchBuild, 80)
+	for i := range branches {
+		branches[i] = BranchBuild{
+			Branch: fmt.Sprintf("bk/preflight/%s-%02d", strings.Repeat("x", 96), i),
+		}
+	}
+
+	if err := ResolveBuilds(context.Background(), client, "test-org", "test-pipeline", branches); err != nil {
+		t.Fatalf("ResolveBuilds() error: %v", err)
+	}
+
+	if len(requestQueryLens) < 2 {
+		t.Fatalf("expected ResolveBuilds to batch requests, got %d request(s)", len(requestQueryLens))
+	}
+
+	for _, queryLen := range requestQueryLens {
+		if queryLen > maxRawQueryLen {
+			t.Fatalf("expected each request query to stay under %d bytes, got %d", maxRawQueryLen, queryLen)
+		}
+	}
+
+	for i := range branches {
+		if branches[i].Build == nil {
+			t.Fatalf("expected branch %q to have a resolved build", branches[i].Branch)
+		}
+		if branches[i].Build.Branch != branches[i].Branch {
+			t.Fatalf("expected build for %q, got %q", branches[i].Branch, branches[i].Build.Branch)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Querying all branches for a pipeline in a single request was exceeding the accepted query length limits of the Builds API, and being rejected with a 414 URI Too Long error. This batches the requests, so that a large number of branches (> 100) can be deleted.
