### PR TITLE
feat: when in TTY, jobs fail with a web link, not a CLI command

### DIFF
--- a/cmd/preflight/job_presenter.go
+++ b/cmd/preflight/job_presenter.go
@@ -12,9 +12,10 @@ import (
 type jobPresenter struct {
 	pipeline    string
 	buildNumber int
+	buildURL    string
 }
 
-func (p jobPresenter) failParts(j buildkite.Job) (symbol, name, detail string) {
+func (p jobPresenter) failParts(j buildkite.Job, action string) (symbol, name, detail string) {
 	job := watch.NewFormattedJob(j)
 	name = job.DisplayName()
 
@@ -35,12 +36,12 @@ func (p jobPresenter) failParts(j buildkite.Job) (symbol, name, detail string) {
 		symbol = "⚠"
 	}
 
-	detail = fmt.Sprintf("%s — %s", status, jobLogCommand(p.pipeline, p.buildNumber, j.ID))
+	detail = fmt.Sprintf("%s - %s", status, action)
 	return symbol, name, detail
 }
 
 func (p jobPresenter) Line(j buildkite.Job) string {
-	symbol, name, detail := p.failParts(j)
+	symbol, name, detail := p.failParts(j, jobLogCommand(p.pipeline, p.buildNumber, j.ID))
 	return fmt.Sprintf("%s %s %s", symbol, name, detail)
 }
 
@@ -76,7 +77,7 @@ func (p jobPresenter) ColoredPassedLine(j buildkite.Job, style lipgloss.Style) s
 // Kitty/iTerm2 graphics escape sequences breaking lipgloss styling.
 func (p jobPresenter) ColoredLine(j buildkite.Job) string {
 	job := watch.NewFormattedJob(j)
-	symbol, name, detail := p.failParts(j)
+	symbol, name, detail := p.failParts(j, p.jobLink(j))
 
 	emojiPrefix, textName := emoji.Split(name)
 
@@ -89,4 +90,15 @@ func (p jobPresenter) ColoredLine(j buildkite.Job) string {
 		return style.Render(symbol+" ") + emoji.Render(emojiPrefix) + " " + style.Render(fmt.Sprintf("%s %s", textName, detail))
 	}
 	return style.Render(fmt.Sprintf("%s %s %s", symbol, textName, detail))
+}
+
+func (p jobPresenter) jobLink(j buildkite.Job) string {
+	url := j.WebURL
+	if url == "" && p.buildURL != "" && j.ID != "" {
+		url = p.buildURL + "#" + j.ID
+	}
+	if url == "" {
+		return jobLogCommand(p.pipeline, p.buildNumber, j.ID)
+	}
+	return terminalHyperlink("\033[4:4mView job\033[24m", url)
 }

--- a/cmd/preflight/job_presenter_test.go
+++ b/cmd/preflight/job_presenter_test.go
@@ -21,7 +21,7 @@ func TestJobPresenter_FailedLine(t *testing.T) {
 	assertStringContainsAll(t, line, []string{
 		"✗ Windows smoke tests",
 		"failed with exit 1",
-		"— bk job log -b 183663 -p buildkite/cli failed-windows-smoke-tests",
+		"- bk job log -b 183663 -p buildkite/cli failed-windows-smoke-tests",
 	})
 }
 
@@ -37,7 +37,7 @@ func TestJobPresenter_SoftFailedLine(t *testing.T) {
 	assertStringContainsAll(t, line, []string{
 		"⚠ Bundle Audit",
 		"soft failed",
-		"— bk job log -b 183663 -p buildkite failed-2",
+		"- bk job log -b 183663 -p buildkite failed-2",
 	})
 }
 
@@ -53,7 +53,7 @@ func TestJobPresenter_FailedNoExit(t *testing.T) {
 	assertStringContainsAll(t, line, []string{
 		"✗ Lint",
 		"failed",
-		"— bk job log -b 42 -p buildkite/cli job-1",
+		"- bk job log -b 42 -p buildkite/cli job-1",
 	})
 	if strings.Contains(line, "with exit") {
 		t.Fatalf("did not expect exit status when nil: %q", line)
@@ -130,6 +130,42 @@ func TestJobPresenter_ColoredLine(t *testing.T) {
 	}.ColoredLine(scriptJob("job-1", "Test", "failed", false, &startedAt, &finishedAt, &exitStatus))
 
 	assertStringContainsAll(t, line, []string{"✗", "Test", "failed with exit 1"})
+}
+
+func TestJobPresenter_ColoredLine_UsesClickableJobLink(t *testing.T) {
+	startedAt := buildkite.Timestamp{Time: time.Now().Add(-90 * time.Second)}
+	finishedAt := buildkite.Timestamp{Time: time.Now().Add(-15 * time.Second)}
+	exitStatus := 1
+
+	job := scriptJob("job-1", "Test", "failed", false, &startedAt, &finishedAt, &exitStatus)
+	job.WebURL = "https://buildkite.com/buildkite/cli/builds/42#job-1"
+
+	line := jobPresenter{
+		pipeline:    "buildkite/cli",
+		buildNumber: 42,
+	}.ColoredLine(job)
+
+	assertStringContainsAll(t, line, []string{"✗", "Test", "failed with exit 1 - ", "\033[4:4mView job\033[24m", job.WebURL})
+	if strings.Contains(line, "bk job log") {
+		t.Fatalf("expected clickable job link instead of job log command: %q", line)
+	}
+}
+
+func TestJobPresenter_ColoredLine_DerivesClickableJobLinkFromBuildURL(t *testing.T) {
+	startedAt := buildkite.Timestamp{Time: time.Now().Add(-90 * time.Second)}
+	finishedAt := buildkite.Timestamp{Time: time.Now().Add(-15 * time.Second)}
+	exitStatus := 1
+
+	line := jobPresenter{
+		pipeline:    "buildkite/cli",
+		buildNumber: 42,
+		buildURL:    "https://buildkite.com/buildkite/cli/builds/42",
+	}.ColoredLine(scriptJob("job-1", "Test", "failed", false, &startedAt, &finishedAt, &exitStatus))
+
+	assertStringContainsAll(t, line, []string{"View job", "https://buildkite.com/buildkite/cli/builds/42#job-1"})
+	if strings.Contains(line, "bk job log") {
+		t.Fatalf("expected derived clickable job link instead of job log command: %q", line)
+	}
 }
 
 func TestJobPresenter_ColoredLine_SoftFailed(t *testing.T) {

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -222,6 +222,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 				PreflightID: preflightID.String(),
 				Pipeline:    pipelineName,
 				BuildNumber: build.Number,
+				BuildURL:    build.WebURL,
 				Job:         &failed,
 			}); err != nil {
 				return err
@@ -234,6 +235,7 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 				PreflightID: preflightID.String(),
 				Pipeline:    pipelineName,
 				BuildNumber: build.Number,
+				BuildURL:    build.WebURL,
 				Job:         &retryPassed,
 			}); err != nil {
 				return err

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -71,14 +71,14 @@ func (r *plainRenderer) Render(e Event) error {
 
 	case EventJobFailure:
 		if e.Job != nil {
-			presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
+			presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
 			_, err := fmt.Fprintf(r.stdout, "%s%s\n", prefix, presenter.Line(*e.Job))
 			return err
 		}
 
 	case EventJobRetryPassed:
 		if e.Job != nil {
-			presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
+			presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
 			_, err := fmt.Fprintf(r.stdout, "%s%s\n", prefix, presenter.RetryPassedLine(*e.Job))
 			return err
 		}
@@ -93,7 +93,7 @@ func (r *plainRenderer) Render(e Event) error {
 				return err
 			}
 		}
-		presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
+		presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
 		for _, j := range e.PassedJobs {
 			if _, err := fmt.Fprintf(r.stdout, "  %s\n", presenter.PassedLine(j)); err != nil {
 				return err
@@ -210,7 +210,7 @@ func buildSummaryDetails(e Event, colored bool, width int) string {
 	var sections []string
 
 	if len(e.FailedJobs) > 0 {
-		presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
+		presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
 		lines := []string{"    Build Failures:"}
 		for _, j := range e.FailedJobs {
 			line := presenter.Line(j)
@@ -320,6 +320,13 @@ func summarySuiteLabel(name, slug, fallback string) string {
 
 func jobLogCommand(pipeline string, buildNumber int, jobID string) string {
 	return fmt.Sprintf("bk job log -b %d -p %s %s", buildNumber, pipeline, jobID)
+}
+
+func terminalHyperlink(label, url string) string {
+	if url == "" {
+		return label
+	}
+	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, label)
 }
 
 func timestampPrefix(t time.Time) string {

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -68,14 +68,14 @@ func (m ttyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case EventJobFailure:
 			if msg.Job != nil {
-				presenter := jobPresenter{pipeline: msg.Pipeline, buildNumber: msg.BuildNumber}
+				presenter := jobPresenter{pipeline: msg.Pipeline, buildNumber: msg.BuildNumber, buildURL: msg.BuildURL}
 				line := timestampPrefix(msg.Time) + presenter.ColoredLine(*msg.Job)
 				return m, tea.Printf("%s", m.hardwrapLine(line))
 			}
 
 		case EventJobRetryPassed:
 			if msg.Job != nil {
-				presenter := jobPresenter{pipeline: msg.Pipeline, buildNumber: msg.BuildNumber}
+				presenter := jobPresenter{pipeline: msg.Pipeline, buildNumber: msg.BuildNumber, buildURL: msg.BuildURL}
 				line := timestampPrefix(msg.Time) + presenter.ColoredRetryPassedLine(*msg.Job)
 				return m, tea.Printf("%s", m.hardwrapLine(line))
 			}
@@ -121,7 +121,7 @@ func (m ttyModel) statusText() string {
 	case m.latest.Title != "":
 		return m.latest.Title
 	case m.latest.BuildState != "":
-		link := fmt.Sprintf("\033]8;;%s\033\\build #%d\033]8;;\033\\", m.latest.BuildURL, m.latest.BuildNumber)
+		link := terminalHyperlink(fmt.Sprintf("build #%d", m.latest.BuildNumber), m.latest.BuildURL)
 		return fmt.Sprintf("Watching %s (%s)", link, m.latest.BuildState)
 	default:
 		return "Starting..."
@@ -195,7 +195,7 @@ func buildSummaryView(e Event, width int) string {
 		out += "\n" + buildURL
 	}
 
-	presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber}
+	presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
 	for _, j := range e.PassedJobs {
 		out += "\n  " + presenter.ColoredPassedLine(j, ttyDimStyle)
 	}


### PR DESCRIPTION
### Description

When in TTY, a copy/paste CLI command isn't as useful as a clickable URL.

### Changes

- adjusts the output from a `bk logs...` command that the user can run to a clickable link to the web view

#### Caveats

This change is supported in modern terminals, but if someone is using something from the 1900s then it's likely the link will just display text and do nothing.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

