### PR TITLE
feat: allow for preselecting org when authing

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -18,8 +19,18 @@ import (
 
 type LoginCmd struct {
 	Scopes string `help:"OAuth scopes to request" default:""`
-	Org    string `help:"Organization slug (required with --token)" optional:""`
-	Token  string `help:"API token to store (non-OAuth login)" optional:""`
+	Org    string `help:"Organization slug or UUID to request access for" optional:""`
+	Token  string `help:"API token to store (non-OAuth login, requires --org)" optional:""`
+}
+
+var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func organizationIdentifier(org string) (orgSlug, orgUUID string) {
+	if uuidPattern.MatchString(org) {
+		return "", org
+	}
+
+	return org, ""
 }
 
 func (c *LoginCmd) Help() string {
@@ -39,6 +50,9 @@ Examples:
 
   # Login with full permissions (inherits your account's scopes)
   $ bk auth login
+
+  # Login to a specific organization
+  $ bk auth login --org my-org
 
   # Login non-interactively with an API token
   $ bk auth login --org my-org --token my-token
@@ -102,19 +116,19 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return nil
 	}
 
-	if c.Org != "" {
-		return errors.New("--org requires --token. Use `bk auth login` for OAuth or `bk auth login --org <org> --token <token>` for token login")
-	}
-
 	// Resolve scope groups (e.g., "read_only" → individual read_* scopes).
 	// When --scopes is empty, no scope parameter is sent and the token
 	// inherits the user's full Buildkite permissions.
 	resolvedScopes := oauth.ResolveScopes(c.Scopes)
 
+	orgSlug, orgUUID := organizationIdentifier(c.Org)
+
 	// Create OAuth flow
 	cfg := &oauth.Config{
 		// Host default handled via NewFlow, omitted to allow usage of BUILDKITE_HOST
 		ClientID: oauth.DefaultClientID,
+		OrgSlug:  orgSlug,
+		OrgUUID:  orgUUID,
 		Scopes:   resolvedScopes,
 	}
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/buildkite/cli/v3/pkg/oauth"
+	"github.com/google/uuid"
 	"github.com/pkg/browser"
 )
 
@@ -23,13 +24,11 @@ type LoginCmd struct {
 	Token  string `help:"API token to store (non-OAuth login, requires --org)" optional:""`
 }
 
-var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-
 func organizationIdentifier(org string) (orgSlug, orgUUID string) {
-	if uuidPattern.MatchString(org) {
+	parsedUUID, err := uuid.Parse(org)
+	if err == nil && strings.EqualFold(parsedUUID.String(), org) {
 		return "", org
 	}
-
 	return org, ""
 }
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import "testing"
+
+func TestOrganizationIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		org      string
+		wantSlug string
+		wantUUID string
+	}{
+		{
+			name:     "slug",
+			org:      "buildkite",
+			wantSlug: "buildkite",
+			wantUUID: "",
+		},
+		{
+			name:     "uuid",
+			org:      "018f2f7e-7e99-7d77-b4d3-a95cb01805f4",
+			wantSlug: "",
+			wantUUID: "018f2f7e-7e99-7d77-b4d3-a95cb01805f4",
+		},
+		{
+			name:     "uppercase uuid",
+			org:      "018F2F7E-7E99-7D77-B4D3-A95CB01805F4",
+			wantSlug: "",
+			wantUUID: "018F2F7E-7E99-7D77-B4D3-A95CB01805F4",
+		},
+		{
+			name:     "uuid-like slug without hyphens",
+			org:      "018f2f7e7e997d77b4d3a95cb01805f4",
+			wantSlug: "018f2f7e7e997d77b4d3a95cb01805f4",
+			wantUUID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotSlug, gotUUID := organizationIdentifier(tt.org)
+			if gotSlug != tt.wantSlug || gotUUID != tt.wantUUID {
+				t.Fatalf("organizationIdentifier(%q) = (%q, %q), want (%q, %q)", tt.org, gotSlug, gotUUID, tt.wantSlug, tt.wantUUID)
+			}
+		})
+	}
+}

--- a/cmd/build/view_test.go
+++ b/cmd/build/view_test.go
@@ -12,6 +12,7 @@ func TestViewCmd_BuildGetOptions_WithJobStates(t *testing.T) {
 	opts := cmd.buildGetOptions()
 	if opts == nil {
 		t.Fatal("Expected non-nil BuildGetOptions")
+		return
 	}
 
 	if len(opts.JobStates) != 2 {
@@ -44,6 +45,7 @@ func TestViewCmd_BuildGetOptions_SingleState(t *testing.T) {
 	opts := cmd.buildGetOptions()
 	if opts == nil {
 		t.Fatal("Expected non-nil BuildGetOptions")
+		return
 	}
 
 	if len(opts.JobStates) != 1 {

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -544,6 +544,7 @@ func TestLatestTestExecution_PicksNewestTimestamp(t *testing.T) {
 
 	if execution == nil {
 		t.Fatal("expected execution to be present")
+		return
 	}
 	if got, want := execution.Status, "passed"; got != want {
 		t.Fatalf("status = %q, want %q", got, want)

--- a/mise.lock
+++ b/mise.lock
@@ -92,28 +92,43 @@ version = "1.5.1"
 backend = "go:github.com/nikolaydubina/go-cover-treemap"
 
 [[tools.golangci-lint]]
-version = "2.11.4"
+version = "2.12.1"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:3bcfa2e6f3d32b2bf5cd75eaa876447507025e0303698633f722a05331988db4"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-linux-arm64.tar.gz"
+checksum = "sha256:23c8e14f42b288d11d46ef52c622e2481d92901edfb263c2cf10875f38d386c4"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-linux-arm64.tar.gz"
+provenance = "github-attestations"
+
+[tools.golangci-lint."platforms.linux-arm64-musl"]
+checksum = "sha256:23c8e14f42b288d11d46ef52c622e2481d92901edfb263c2cf10875f38d386c4"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-linux-arm64.tar.gz"
+provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:200c5b7503f67b59a6743ccf32133026c174e272b930ee79aa2aa6f37aca7ef1"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-linux-amd64.tar.gz"
+checksum = "sha256:82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-linux-amd64.tar.gz"
+provenance = "github-attestations"
+
+[tools.golangci-lint."platforms.linux-x64-musl"]
+checksum = "sha256:82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-linux-amd64.tar.gz"
+provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:02db2a2dae8b26812e53b0688a6f617e3ef1f489790e829ea22862cf76945675"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-darwin-arm64.tar.gz"
+checksum = "sha256:393a64ef9b75a5b6c8c8bf8895b8d8208790e6690a43de19a12f3f8bc0e9ad52"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-darwin-arm64.tar.gz"
+provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64"]
-checksum = "sha256:c900d4048db75d1edfd550fd11cf6a9b3008e7caa8e119fcddbc700412d63e60"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-darwin-amd64.tar.gz"
+checksum = "sha256:26a9508ee6d35e89201145b94261d7b55d779474c57677a7bba8b1f12f59309f"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-darwin-amd64.tar.gz"
+provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64"]
-checksum = "sha256:4932cfca5e75bf60fe1c576edf459e5e809e6644664a068185d64b84af3fad9e"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-windows-amd64.zip"
+checksum = "sha256:2b2f837b2a7b91787ecb9b7493bdeae801e9f84e6588984b2c33c34dc2956478"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.1/golangci-lint-2.12.1-windows-amd64.zip"
+provenance = "github-attestations"
 
 [[tools.ko]]
 version = "0.18.1"

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -140,8 +140,8 @@ var DefaultClientID = "5214b230f06b48938ab5"
 type Config struct {
 	Host        string // e.g., "buildkite.com"
 	ClientID    string // OAuth client ID
-	OrgSlug     string // Organization slug (used for organization_uuid lookup)
-	OrgUUID     string // Organization UUID
+	OrgSlug     string // Organization slug to request access for
+	OrgUUID     string // Organization UUID to request access for
 	CallbackURL string // e.g., "http://127.0.0.1:8080/callback"
 	Scopes      string // Space-separated OAuth scopes
 }
@@ -234,6 +234,8 @@ func (f *Flow) AuthorizationURL() string {
 
 	if f.config.OrgUUID != "" {
 		params.Set("organization_uuid", f.config.OrgUUID)
+	} else if f.config.OrgSlug != "" {
+		params.Set("organization", f.config.OrgSlug)
 	}
 
 	return fmt.Sprintf("https://%s/oauth/authorize?%s", f.config.Host, params.Encode())

--- a/pkg/oauth/oauth_test.go
+++ b/pkg/oauth/oauth_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -81,6 +82,64 @@ func TestNewFlow_DefaultsToAllScopes(t *testing.T) {
 		if !strings.Contains(authURL, s) {
 			t.Errorf("expected scope %q in URL, got: %s", s, authURL)
 		}
+	}
+}
+
+func TestAuthorizationURL_IncludesOrganizationSlug(t *testing.T) {
+	t.Parallel()
+
+	flow, err := NewFlow(&Config{
+		Host:        "buildkite.com",
+		ClientID:    "test-client",
+		CallbackURL: "http://localhost:9999/callback",
+		OrgSlug:     "buildkite",
+		Scopes:      "read_user",
+	})
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	authURL, err := url.Parse(flow.AuthorizationURL())
+	if err != nil {
+		t.Fatalf("Parse AuthorizationURL: %v", err)
+	}
+
+	query := authURL.Query()
+	if got := query.Get("organization"); got != "buildkite" {
+		t.Fatalf("organization = %q, want %q", got, "buildkite")
+	}
+	if got := query.Get("organization_uuid"); got != "" {
+		t.Fatalf("organization_uuid = %q, want empty", got)
+	}
+}
+
+func TestAuthorizationURL_IncludesOrganizationUUID(t *testing.T) {
+	t.Parallel()
+
+	const orgUUID = "018f2f7e-7e99-7d77-b4d3-a95cb01805f4"
+
+	flow, err := NewFlow(&Config{
+		Host:        "buildkite.com",
+		ClientID:    "test-client",
+		CallbackURL: "http://localhost:9999/callback",
+		OrgUUID:     orgUUID,
+		Scopes:      "read_user",
+	})
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	authURL, err := url.Parse(flow.AuthorizationURL())
+	if err != nil {
+		t.Fatalf("Parse AuthorizationURL: %v", err)
+	}
+
+	query := authURL.Query()
+	if got := query.Get("organization_uuid"); got != orgUUID {
+		t.Fatalf("organization_uuid = %q, want %q", got, orgUUID)
+	}
+	if got := query.Get("organization"); got != "" {
+		t.Fatalf("organization = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
### Description

We recently added support for passing in the `organization` or
`organization_uuid` as a URL parameter, which means that we can
preselect the organization in the OAuth modal on behalf of the user.
This "fixes" an issue where the most recently _interacted with_
organization would be selected.

### Changes

- allows users to set `--org` _without_ providing `--token`, too
- passed the set `--org` value as a URL parameter to the Buildkite OAuth modal
- overrides current behaviour of _select most recently interacted with_

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

