### PR TITLE
chore: condense the output of preflight runs

### DIFF
--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -17,7 +17,7 @@ const (
 	EventBuildStatus    EventType = "build_status"
 	EventJobFailure     EventType = "job_failure"
 	EventJobRetryPassed EventType = "job_retry_passed"
-	EventBuildSummary   EventType = "preflight_summary"
+	EventBuildSummary   EventType = "build_summary"
 	EventTestFailure    EventType = "test_failure"
 )
 
@@ -40,7 +40,7 @@ type Event struct {
 	BuildURL    string `json:"build_url,omitempty"`
 	BuildState  string `json:"build_state,omitempty"`
 
-	// Incomplete is set for preflight_summary events when the CLI stops before a terminal build state.
+	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
 	Incomplete bool `json:"incomplete,omitempty"`
 
 	// StopReason describes why the summary was emitted early.
@@ -54,19 +54,19 @@ type Event struct {
 	// Job is set for job_failure and job_retry_passed events.
 	Job *buildkite.Job `json:"job,omitempty"`
 
-	// FailedJobs is set for preflight_summary events when the build failed. Contains hard-failed jobs only (soft failures excluded).
+	// FailedJobs is set for build_summary events when the build failed. Contains hard-failed jobs only (soft failures excluded).
 	FailedJobs []buildkite.Job `json:"failed_jobs,omitempty"`
 
-	// PassedJobs is set for preflight_summary events when the build passed and has 10 or fewer jobs.
+	// PassedJobs is set for build_summary events when the build passed and has 10 or fewer jobs.
 	PassedJobs []buildkite.Job `json:"passed_jobs,omitempty"`
 
-	// Duration is set for preflight_summary events. Total elapsed time of the preflight run.
+	// Duration is set for build_summary events. Total elapsed time of the preflight run.
 	Duration time.Duration `json:"duration_ns,omitempty"`
 
 	// TestFailures is set for test_failure events.
 	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`
 
-	// Tests is set for preflight_summary events when aggregated test summary data is available.
+	// Tests is set for build_summary events when aggregated test summary data is available.
 	Tests internalpreflight.SummaryTests `json:"tests,omitempty"`
 }
 

--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -1,6 +1,7 @@
 package preflight
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
@@ -16,7 +17,7 @@ const (
 	EventBuildStatus    EventType = "build_status"
 	EventJobFailure     EventType = "job_failure"
 	EventJobRetryPassed EventType = "job_retry_passed"
-	EventBuildSummary   EventType = "build_summary"
+	EventBuildSummary   EventType = "preflight_summary"
 	EventTestFailure    EventType = "test_failure"
 )
 
@@ -39,7 +40,7 @@ type Event struct {
 	BuildURL    string `json:"build_url,omitempty"`
 	BuildState  string `json:"build_state,omitempty"`
 
-	// Incomplete is set for build_summary events when the CLI stops before a terminal build state.
+	// Incomplete is set for preflight_summary events when the CLI stops before a terminal build state.
 	Incomplete bool `json:"incomplete,omitempty"`
 
 	// StopReason describes why the summary was emitted early.
@@ -53,20 +54,127 @@ type Event struct {
 	// Job is set for job_failure and job_retry_passed events.
 	Job *buildkite.Job `json:"job,omitempty"`
 
-	// FailedJobs is set for build_summary events when the build failed. Contains hard-failed jobs only (soft failures excluded).
+	// FailedJobs is set for preflight_summary events when the build failed. Contains hard-failed jobs only (soft failures excluded).
 	FailedJobs []buildkite.Job `json:"failed_jobs,omitempty"`
 
-	// PassedJobs is set for build_summary events when the build passed and has 10 or fewer jobs.
+	// PassedJobs is set for preflight_summary events when the build passed and has 10 or fewer jobs.
 	PassedJobs []buildkite.Job `json:"passed_jobs,omitempty"`
 
-	// Duration is set for build_summary events. Total elapsed time of the preflight run.
+	// Duration is set for preflight_summary events. Total elapsed time of the preflight run.
 	Duration time.Duration `json:"duration_ns,omitempty"`
 
 	// TestFailures is set for test_failure events.
 	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`
 
-	// Tests is set for build_summary events when aggregated test summary data is available.
+	// Tests is set for preflight_summary events when aggregated test summary data is available.
 	Tests internalpreflight.SummaryTests `json:"tests,omitempty"`
+}
+
+// jsonJob is the compact job shape emitted in JSON mode. The Buildkite REST
+// job model contains large nested agent, cluster, priority, step, and timing
+// payloads that are useful for API clients but expensive and noisy for LLM
+// preflight consumers.
+type jsonJob struct {
+	ID             string `json:"id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Command        string `json:"command,omitempty"`
+	State          string `json:"state,omitempty"`
+	ExitStatus     *int   `json:"exit_status,omitempty"`
+	SoftFailed     bool   `json:"soft_failed"`
+	Retried        bool   `json:"retried"`
+	RetriesCount   int    `json:"retries_count,omitempty"`
+	RetriedInJobID string `json:"retried_in_job_id,omitempty"`
+}
+
+func newJSONJob(j buildkite.Job) jsonJob {
+	return jsonJob{
+		ID:             j.ID,
+		Name:           j.Name,
+		Command:        j.Command,
+		State:          j.State,
+		ExitStatus:     j.ExitStatus,
+		SoftFailed:     j.SoftFailed,
+		Retried:        j.Retried,
+		RetriesCount:   j.RetriesCount,
+		RetriedInJobID: j.RetriedInJobID,
+	}
+}
+
+func newJSONJobs(jobs []buildkite.Job) []jsonJob {
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	result := make([]jsonJob, 0, len(jobs))
+	for _, job := range jobs {
+		result = append(result, newJSONJob(job))
+	}
+	return result
+}
+
+func (e Event) MarshalJSON() ([]byte, error) {
+	type eventJSON struct {
+		Type EventType `json:"type"`
+		Time time.Time `json:"timestamp"`
+
+		PreflightID string `json:"preflight_id,omitempty"`
+		Title       string `json:"title,omitempty"`
+		Detail      string `json:"detail,omitempty"`
+
+		Pipeline    string `json:"pipeline,omitempty"`
+		BuildNumber int    `json:"build_number,omitempty"`
+		BuildURL    string `json:"build_url,omitempty"`
+		BuildState  string `json:"build_state,omitempty"`
+
+		Incomplete    bool   `json:"incomplete,omitempty"`
+		StopReason    string `json:"stop_reason,omitempty"`
+		BuildCanceled *bool  `json:"build_canceled,omitempty"`
+
+		Jobs *watch.JobSummary `json:"jobs,omitempty"`
+
+		Job *jsonJob `json:"job,omitempty"`
+
+		FailedJobs []jsonJob `json:"failed_jobs,omitempty"`
+		PassedJobs []jsonJob `json:"passed_jobs,omitempty"`
+
+		Duration time.Duration `json:"duration_ns,omitempty"`
+
+		TestFailures []buildkite.BuildTest           `json:"test_failures,omitempty"`
+		Tests        *internalpreflight.SummaryTests `json:"tests,omitempty"`
+	}
+
+	var job *jsonJob
+	if e.Job != nil {
+		j := newJSONJob(*e.Job)
+		job = &j
+	}
+
+	var tests *internalpreflight.SummaryTests
+	if len(e.Tests.Runs) > 0 || len(e.Tests.Failures) > 0 {
+		tests = &e.Tests
+	}
+
+	return json.Marshal(eventJSON{
+		Type:          e.Type,
+		Time:          e.Time,
+		PreflightID:   e.PreflightID,
+		Title:         e.Title,
+		Detail:        e.Detail,
+		Pipeline:      e.Pipeline,
+		BuildNumber:   e.BuildNumber,
+		BuildURL:      e.BuildURL,
+		BuildState:    e.BuildState,
+		Incomplete:    e.Incomplete,
+		StopReason:    e.StopReason,
+		BuildCanceled: e.BuildCanceled,
+		Jobs:          e.Jobs,
+		Job:           job,
+		FailedJobs:    newJSONJobs(e.FailedJobs),
+		PassedJobs:    newJSONJobs(e.PassedJobs),
+		Duration:      e.Duration,
+		TestFailures:  e.TestFailures,
+		Tests:         tests,
+	})
 }
 
 func newBuildSummaryEvent(preflightID, pipeline string, buildNumber int, buildURL string, finalBuild buildkite.Build, startedAt time.Time) Event {

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -359,10 +359,13 @@ func TestJSONRenderer_Render_JobFailure(t *testing.T) {
 		Pipeline:    "buildkite/cli",
 		BuildNumber: 42,
 		Job: &buildkite.Job{
-			ID:         "job-1",
-			Name:       "Lint",
-			State:      "failed",
-			ExitStatus: &exitOne,
+			ID:              "job-1",
+			Name:            "Lint",
+			Command:         "go test ./...",
+			State:           "failed",
+			ExitStatus:      &exitOne,
+			Agent:           buildkite.Agent{Name: "agent-1"},
+			AgentQueryRules: []string{"queue=large"},
 		},
 	})
 
@@ -382,8 +385,31 @@ func TestJSONRenderer_Render_JobFailure(t *testing.T) {
 	if got.Job.Name != "Lint" {
 		t.Fatalf("expected job name Lint, got %q", got.Job.Name)
 	}
+	if got.Job.Command != "go test ./..." {
+		t.Fatalf("expected job command, got %q", got.Job.Command)
+	}
 	if got.Job.ExitStatus == nil || *got.Job.ExitStatus != 1 {
 		t.Fatalf("expected exit status 1, got %v", got.Job.ExitStatus)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON map: %v", err)
+	}
+	job, ok := raw["job"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected compact job object, got %v", raw["job"])
+	}
+	for _, omitted := range []string{"agent", "agent_query_rules", "created_at", "scheduled_at", "priority", "step"} {
+		if _, ok := job[omitted]; ok {
+			t.Fatalf("expected compact JSON job to omit %q, got %v", omitted, job)
+		}
+	}
+	if _, ok := job["soft_failed"]; !ok {
+		t.Fatalf("expected compact JSON job to include soft_failed=false, got %v", job)
+	}
+	if _, ok := job["retried"]; !ok {
+		t.Fatalf("expected compact JSON job to include retried=false, got %v", job)
 	}
 }
 
@@ -797,8 +823,8 @@ func TestJSONRenderer_Render_BuildSummaryPassed(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
 	}
-	if got["type"] != "build_summary" {
-		t.Fatalf("expected type build_summary, got %v", got["type"])
+	if got["type"] != "preflight_summary" {
+		t.Fatalf("expected type preflight_summary, got %v", got["type"])
 	}
 	if got["build_state"] != "passed" {
 		t.Fatalf("expected build_state=passed, got %v", got["build_state"])
@@ -821,7 +847,16 @@ func TestJSONRenderer_Render_BuildSummaryFailed(t *testing.T) {
 		BuildNumber: 42,
 		BuildState:  "failed",
 		FailedJobs: []buildkite.Job{
-			{ID: "job-1", Name: "Lint", Type: "script", State: "failed", ExitStatus: &exitOne},
+			{
+				ID:              "job-1",
+				Name:            "Lint",
+				Type:            "script",
+				Command:         "go test ./...",
+				State:           "failed",
+				ExitStatus:      &exitOne,
+				Agent:           buildkite.Agent{Name: "agent-1"},
+				AgentQueryRules: []string{"queue=large"},
+			},
 		},
 	}); err != nil {
 		t.Fatalf("Render() error: %v", err)
@@ -837,6 +872,16 @@ func TestJSONRenderer_Render_BuildSummaryFailed(t *testing.T) {
 	failedJobs, ok := got["failed_jobs"].([]any)
 	if !ok || len(failedJobs) != 1 {
 		t.Fatalf("expected 1 failed job, got %v", got["failed_jobs"])
+	}
+	failedJob, ok := failedJobs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected failed job object, got %v", failedJobs[0])
+	}
+	if failedJob["command"] != "go test ./..." {
+		t.Fatalf("expected failed job command, got %v", failedJob)
+	}
+	if _, ok := failedJob["agent"]; ok {
+		t.Fatalf("expected failed job JSON to omit agent, got %v", failedJob)
 	}
 }
 
@@ -863,8 +908,8 @@ func TestJSONRenderer_Render_BuildSummaryStoppedEarly(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
 	}
-	if got["type"] != "build_summary" {
-		t.Fatalf("expected type build_summary, got %v", got["type"])
+	if got["type"] != "preflight_summary" {
+		t.Fatalf("expected type preflight_summary, got %v", got["type"])
 	}
 	if got["incomplete"] != true {
 		t.Fatalf("expected incomplete=true, got %v", got["incomplete"])

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -823,8 +823,8 @@ func TestJSONRenderer_Render_BuildSummaryPassed(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
 	}
-	if got["type"] != "preflight_summary" {
-		t.Fatalf("expected type preflight_summary, got %v", got["type"])
+	if got["type"] != "build_summary" {
+		t.Fatalf("expected type build_summary, got %v", got["type"])
 	}
 	if got["build_state"] != "passed" {
 		t.Fatalf("expected build_state=passed, got %v", got["build_state"])
@@ -908,8 +908,8 @@ func TestJSONRenderer_Render_BuildSummaryStoppedEarly(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
 	}
-	if got["type"] != "preflight_summary" {
-		t.Fatalf("expected type preflight_summary, got %v", got["type"])
+	if got["type"] != "build_summary" {
+		t.Fatalf("expected type build_summary, got %v", got["type"])
 	}
 	if got["incomplete"] != true {
 		t.Fatalf("expected incomplete=true, got %v", got["incomplete"])

--- a/mise.lock
+++ b/mise.lock
@@ -32,6 +32,45 @@ url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.
 checksum = "sha256:20872b464435512b74678b1155b75bd75220de5737ad8c075b9151c846543697"
 url = "https://github.com/mvdan/gofumpt/releases/download/v0.10.0/gofumpt_v0.10.0_windows_amd64.exe"
 
+[[tools."github:goreleaser/goreleaser-pro"]]
+version = "2.15.4"
+backend = "github:goreleaser/goreleaser-pro"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.linux-arm64"]
+checksum = "sha256:c2714766cd73d45997e10397cf9ed889ef17761e9ffdcb72f179fec605d6155f"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587720"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.linux-arm64-musl"]
+checksum = "sha256:c2714766cd73d45997e10397cf9ed889ef17761e9ffdcb72f179fec605d6155f"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587720"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.linux-x64"]
+checksum = "sha256:a7902f82d5afdcc2f43d5333d0f9d77db2d2c261b33189182c5358fc2f0bc1dc"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587704"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.linux-x64-musl"]
+checksum = "sha256:a7902f82d5afdcc2f43d5333d0f9d77db2d2c261b33189182c5358fc2f0bc1dc"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587704"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.macos-arm64"]
+checksum = "sha256:f48b6ce7d17d959a2fdb033ece22c09e90e12956cac9c6ab40a7cfe6d6d202d3"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587658"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.macos-x64"]
+checksum = "sha256:0f115ca6678220e06df496c112b7c86f0e059b4e64832f5fce97e31c9027bea0"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587659"
+
+[tools."github:goreleaser/goreleaser-pro"."platforms.windows-x64"]
+checksum = "sha256:3adf85a67efd6c43caaa11256d396c93a8b753bd5d477b1faaea135604a78bc4"
+url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/goreleaser-pro_Windows_x86_64.zip"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587867"
+
 [[tools.go]]
 version = "1.26.3"
 backend = "core:go"


### PR DESCRIPTION
### Description

`preflight` runs will consume a lot of tokens with the current way we report to the LLM, this attempts to fix that by reducing the information density.

### Changes

- in JSON output, only returns a payload which contains relevant information for an LLM to use in order to get information on which jobs have failed

#### Caveats

This is entirely open to change/improvement

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

Example build_summary JSON now looks more like:

 ```json
   {
     "type": "preflight_summary",
     "timestamp": "2026-04-08T12:49:28.246592+10:00",
     "preflight_id": "019d6afe-407e-742a-a532-9eaf247099c7",
     "pipeline": "buildkite/cli",
     "build_number": 185541,
     "build_url": "https://buildkite.com/buildkite/cli/builds/185541",
     "build_state": "failed",
     "failed_jobs": [
       {
         "id": "019d6afe-80b8-4f62-a0e4-8871e94b977e",
         "name": ":pipeline: Upload Pipeline",
         "command": "./.buildkite/pipeline.sh | buildkite-agent pipeline upload",
         "state": "failed",
         "exit_status": 128,
         "soft_failed": false,
         "retried": false
       }
     ],
     "duration_ns": 27448501500
   }
 ```

 For a live job_failure event:

 ```json
   {
     "type": "job_failure",
     "timestamp": "2026-04-08T12:49:27.390000+10:00",
     "preflight_id": "019d6afe-407e-742a-a532-9eaf247099c7",
     "pipeline": "buildkite/cli",
     "build_number": 185541,
     "build_url": "https://buildkite.com/buildkite/cli/builds/185541",
     "job": {
       "id": "019d6afe-80b8-4f62-a0e4-8871e94b977e",
       "name": ":pipeline: Upload Pipeline",
       "command": "./.buildkite/pipeline.sh | buildkite-agent pipeline upload",
       "state": "failed",
       "exit_status": 128,
       "soft_failed": false,
       "retried": false
     }
   }
 ```

### Disclosures / Credits

Written by Codex. YOLO acceped by me.

