### PR TITLE
feat: Add device auth login

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -22,6 +22,7 @@ type LoginCmd struct {
 	Scopes string `help:"OAuth scopes to request" default:""`
 	Org    string `help:"Organization slug or UUID to request access for" optional:""`
 	Token  string `help:"API token to store (non-OAuth login, requires --org)" optional:""`
+	Device bool   `help:"Authenticate using OAuth device authorization instead of opening a browser callback" optional:""`
 }
 
 func organizationIdentifier(org string) (orgSlug, orgUUID string) {
@@ -55,6 +56,9 @@ Examples:
 
   # Login non-interactively with an API token
   $ bk auth login --org my-org --token my-token
+
+  # Login on a headless machine or remote shell
+  $ bk auth login --device
 
   # Login with read-only access
   $ bk auth login --scopes read_only
@@ -139,6 +143,10 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return err
 	}
 
+	if err := c.validate(); err != nil {
+		return err
+	}
+
 	if c.Token != "" {
 		if err := LoginWithToken(f, c.Org, c.Token); err != nil {
 			return err
@@ -152,6 +160,10 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	// When --scopes is empty, no scope parameter is sent and the token
 	// inherits the user's full Buildkite permissions.
 	resolvedScopes := oauth.ResolveScopes(c.Scopes)
+
+	if c.Device {
+		return c.runDeviceLogin(context.Background(), f, resolvedScopes)
+	}
 
 	orgSlug, orgUUID := organizationIdentifier(c.Org)
 
@@ -200,38 +212,105 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return fmt.Errorf("token exchange failed: %w", err)
 	}
 
+	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp)
+	if err != nil {
+		return err
+	}
+
+	printOAuthLoginSuccess(org, tokenResp, autoRefreshConfigured)
+
+	return nil
+}
+
+func (c *LoginCmd) validate() error {
+	if c.Device && c.Token != "" {
+		return errors.New("--device cannot be used with --token")
+	}
+	if c.Device && c.Org != "" {
+		return errors.New("--org is not supported with --device; choose an organization on the authorization page")
+	}
+	return nil
+}
+
+func (c *LoginCmd) runDeviceLogin(ctx context.Context, f *factory.Factory, resolvedScopes string) error {
+	cfg := &oauth.Config{
+		ClientID: oauth.DefaultClientID,
+		Scopes:   resolvedScopes,
+	}
+
+	deviceAuth, err := oauth.RequestDeviceAuthorization(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to start device authorization: %w", err)
+	}
+
+	verificationURL := deviceAuth.VerificationURIComplete
+	if verificationURL == "" {
+		verificationURL = deviceAuth.VerificationURI
+	}
+
+	fmt.Println("Visit this URL to authorize this device:")
+	fmt.Printf("  %s\n\n", verificationURL)
+	fmt.Println("Code:")
+	fmt.Printf("  %s\n\n", deviceAuth.UserCode)
+	fmt.Println("Waiting for authorization...")
+
+	timeout := time.Duration(deviceAuth.ExpiresIn) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	tokenResp, err := oauth.PollDeviceAccessToken(pollCtx, cfg, deviceAuth)
+	if err != nil {
+		return fmt.Errorf("device authorization failed: %w", err)
+	}
+
+	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp)
+	if err != nil {
+		return err
+	}
+
+	printOAuthLoginSuccess(org, tokenResp, autoRefreshConfigured)
+
+	return nil
+}
+
+func completeOAuthLogin(ctx context.Context, f *factory.Factory, tokenResp *oauth.TokenResponse) (string, bool, error) {
 	// Resolve org from the API using the new token
 	client, err := buildkite.NewOpts(
 		buildkite.WithTokenAuth(tokenResp.AccessToken),
 		buildkite.WithBaseURL(f.Config.RESTAPIEndpoint()),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
+		return "", false, fmt.Errorf("failed to create API client: %w", err)
 	}
 
 	orgs, _, err := client.Organizations.List(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to list organizations: %w", err)
+		return "", false, fmt.Errorf("failed to list organizations: %w", err)
 	}
 	if len(orgs) == 0 {
-		return fmt.Errorf("no organizations found for this token")
+		return "", false, fmt.Errorf("no organizations found for this token")
 	}
 
 	org := orgs[0]
 
 	autoRefreshConfigured, err := persistOAuthLogin(f, keyring.New(), org.Slug, tokenResp.AccessToken, tokenResp.RefreshToken)
 	if err != nil {
-		return err
+		return "", false, err
 	}
 	fmt.Println("Token stored securely in system keychain.")
 
-	fmt.Printf("\n✅ Successfully authenticated with organization %q\n", org.Slug)
+	return org.Slug, autoRefreshConfigured, nil
+}
+
+func printOAuthLoginSuccess(org string, tokenResp *oauth.TokenResponse, autoRefreshConfigured bool) {
+	fmt.Printf("\n✅ Successfully authenticated with organization %q\n", org)
 	fmt.Printf("  Scopes: %s\n", tokenResp.Scope)
 	if autoRefreshConfigured {
 		fmt.Printf("  Token expires in: %s (will refresh automatically)\n", formatDuration(tokenResp.ExpiresIn))
 	}
-
-	return nil
 }
 
 func formatDuration(seconds int) string {

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -1,11 +1,19 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/keyring"
+	"github.com/buildkite/cli/v3/pkg/oauth"
+	buildkite "github.com/buildkite/go-buildkite/v4"
 )
 
 type stubOAuthTokenStore struct {
@@ -41,6 +49,14 @@ func (s *stubOAuthTokenStore) SetRefreshToken(org, token string) error {
 	s.refresh[org] = token
 	return nil
 }
+
+type authStubGlobals struct{}
+
+func (authStubGlobals) SkipConfirmation() bool { return false }
+func (authStubGlobals) DisableInput() bool     { return false }
+func (authStubGlobals) IsQuiet() bool          { return false }
+func (authStubGlobals) DisablePager() bool     { return false }
+func (authStubGlobals) EnableDebug() bool      { return false }
 
 func TestOrganizationIdentifier(t *testing.T) {
 	t.Parallel()
@@ -144,4 +160,177 @@ func TestPersistOAuthLogin(t *testing.T) {
 			t.Fatalf("expected refresh token to be stored, got %q", got)
 		}
 	})
+}
+
+func TestLoginCmdValidateDeviceIncompatibleFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cmd     LoginCmd
+		wantErr string
+	}{
+		{
+			name:    "device with token",
+			cmd:     LoginCmd{Device: true, Token: "token", Org: "buildkite"},
+			wantErr: "--device cannot be used with --token",
+		},
+		{
+			name:    "device with org",
+			cmd:     LoginCmd{Device: true, Org: "buildkite"},
+			wantErr: "--org is not supported with --device; choose an organization on the authorization page",
+		},
+		{
+			name: "device only",
+			cmd:  LoginCmd{Device: true},
+		},
+		{
+			name: "token with org",
+			cmd:  LoginCmd{Token: "token", Org: "buildkite"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cmd.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("validate() error = nil, want error")
+			}
+			if got := err.Error(); got != tt.wantErr {
+				t.Fatalf("validate() error = %q, want %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoginCmdRunDeviceFlow(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+
+	keyring.MockForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	var sawDeviceAuthorization bool
+	var sawTokenExchange bool
+	var sawOrganizationsList bool
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth/device_authorization":
+			sawDeviceAuthorization = true
+			if r.Method != "POST" {
+				t.Errorf("device authorization method = %s, want POST", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.FormValue("client_id"); got != oauth.DefaultClientID {
+				t.Errorf("client_id = %q, want %q", got, oauth.DefaultClientID)
+			}
+			if got := r.FormValue("scope"); got != "read_user read_organizations" {
+				t.Errorf("scope = %q, want requested scopes", got)
+			}
+			_ = json.NewEncoder(w).Encode(oauth.DeviceAuthorizationResponse{
+				DeviceCode:              "device-code",
+				UserCode:                "ABCD-EFGH",
+				VerificationURI:         "https://buildkite.example/device",
+				VerificationURIComplete: "https://buildkite.example/device/ABCD-EFGH",
+				ExpiresIn:               600,
+				Interval:                1,
+			})
+		case "/oauth/token":
+			sawTokenExchange = true
+			if r.Method != "POST" {
+				t.Errorf("token method = %s, want POST", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.FormValue("grant_type"); got != "urn:ietf:params:oauth:grant-type:device_code" {
+				t.Errorf("grant_type = %q, want device code grant", got)
+			}
+			if got := r.FormValue("device_code"); got != "device-code" {
+				t.Errorf("device_code = %q, want device-code", got)
+			}
+			_ = json.NewEncoder(w).Encode(oauth.TokenResponse{
+				AccessToken:  "access-token",
+				TokenType:    "Bearer",
+				Scope:        "read_user read_organizations",
+				RefreshToken: "refresh-token",
+				ExpiresIn:    3600,
+			})
+		case "/v2/organizations":
+			sawOrganizationsList = true
+			if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+				t.Errorf("Authorization = %q, want Bearer access-token", got)
+			}
+			_ = json.NewEncoder(w).Encode([]buildkite.Organization{{Slug: "test-org"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	t.Setenv("BUILDKITE_HOST", strings.TrimPrefix(server.URL, "https://"))
+	t.Setenv("BUILDKITE_REST_API_ENDPOINT", server.URL)
+
+	cmd := &LoginCmd{Device: true, Scopes: "read_user read_organizations"}
+	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if !sawDeviceAuthorization {
+		t.Fatal("device authorization endpoint was not called")
+	}
+	if !sawTokenExchange {
+		t.Fatal("token endpoint was not called")
+	}
+	if !sawOrganizationsList {
+		t.Fatal("organizations endpoint was not called")
+	}
+
+	kr := keyring.New()
+	token, err := kr.Get("test-org")
+	if err != nil {
+		t.Fatalf("Get token: %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("stored token = %q, want access-token", token)
+	}
+
+	refreshToken, err := kr.GetRefreshToken("test-org")
+	if err != nil {
+		t.Fatalf("GetRefreshToken: %v", err)
+	}
+	if refreshToken != "refresh-token" {
+		t.Fatalf("stored refresh token = %q, want refresh-token", refreshToken)
+	}
+
+	configBytes, err := os.ReadFile(filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "bk.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	config := string(configBytes)
+	if !strings.Contains(config, "selected_org: test-org") {
+		t.Fatalf("config did not select test-org:\n%s", config)
+	}
+	if !strings.Contains(config, "test-org:") {
+		t.Fatalf("config did not register test-org:\n%s", config)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/buildkite/go-buildkite/v4 v4.23.0
-	github.com/buildkite/go-buildkite/v5 v5.0.0
 	github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -35,7 +35,6 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buildkite/go-buildkite/v4 v4.23.0 h1:GlLgPzGz/+B/4Fc5CphIxynoQn00SdSu6QQp4PlAI3M=
 github.com/buildkite/go-buildkite/v4 v4.23.0/go.mod h1:t/M4DUcs7qyebtzm3nkyZ1zUB/svWnKtR+uRU2Ca8tQ=
-github.com/buildkite/go-buildkite/v5 v5.0.0/go.mod h1:wsKNPQmX0vAAR+RcGLyDJkSTsHXrHpnwSURaMckM7Wg=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1 h1:aaEl0QZURcwC+KOfFTzSp66xknw5eTmFZ1NgB87s2xk=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1/go.mod h1:ZTEvQlMN3+qzjROvjRb1p0X+xDQxxKpkMFhMSnaTrpw=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/mise.lock
+++ b/mise.lock
@@ -72,36 +72,36 @@ url = "https://github.com/goreleaser/goreleaser-pro/releases/download/v2.15.4/go
 url_api = "https://api.github.com/repos/goreleaser/goreleaser-pro/releases/assets/401587867"
 
 [[tools.go]]
-version = "1.26.3"
+version = "1.26.4"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565"
-url = "https://dl.google.com/go/go1.26.3.linux-arm64.tar.gz"
+checksum = "sha256:ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
+url = "https://dl.google.com/go/go1.26.4.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-arm64-musl"]
-checksum = "sha256:9d89a3ea57d141c2b22d70083f2c8459ba3890f2d9e818e7e933b75614936565"
-url = "https://dl.google.com/go/go1.26.3.linux-arm64.tar.gz"
+checksum = "sha256:ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
+url = "https://dl.google.com/go/go1.26.4.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
-url = "https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz"
+checksum = "sha256:1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
+url = "https://dl.google.com/go/go1.26.4.linux-amd64.tar.gz"
 
 [tools.go."platforms.linux-x64-musl"]
-checksum = "sha256:2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
-url = "https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz"
+checksum = "sha256:1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
+url = "https://dl.google.com/go/go1.26.4.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c"
-url = "https://dl.google.com/go/go1.26.3.darwin-arm64.tar.gz"
+checksum = "sha256:b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
+url = "https://dl.google.com/go/go1.26.4.darwin-arm64.tar.gz"
 
 [tools.go."platforms.macos-x64"]
-checksum = "sha256:278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63"
-url = "https://dl.google.com/go/go1.26.3.darwin-amd64.tar.gz"
+checksum = "sha256:05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
+url = "https://dl.google.com/go/go1.26.4.darwin-amd64.tar.gz"
 
 [tools.go."platforms.windows-x64"]
-checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
-url = "https://dl.google.com/go/go1.26.3.windows-amd64.zip"
+checksum = "sha256:3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
+url = "https://dl.google.com/go/go1.26.4.windows-amd64.zip"
 
 [[tools."go:github.com/nikolaydubina/go-cover-treemap"]]
 version = "1.5.1"

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ aqua.github_attestations = false
 aqua.slsa = false
 
 [tools]
-go = "1.26.3"
+go = "1.26.4"
 golangci-lint = "2.12.2"
 lefthook = "2.1.9"
 "aqua:mvdan/gofumpt" = "0.10.0"

--- a/pkg/oauth/device_test.go
+++ b/pkg/oauth/device_test.go
@@ -3,11 +3,26 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+type failingRoundTripper struct {
+	base       http.RoundTripper
+	failures   int
+	failureErr error
+}
+
+func (rt *failingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.failures > 0 {
+		rt.failures--
+		return nil, rt.failureErr
+	}
+	return rt.base.RoundTrip(req)
+}
 
 func TestRequestDeviceAuthorization(t *testing.T) {
 	var sawRequest bool
@@ -156,5 +171,83 @@ func TestPollDeviceAccessTokenRetriesPendingAndSlowDown(t *testing.T) {
 	}
 	if len(sleeps) != 2 || sleeps[0] != time.Second || sleeps[1] != 6*time.Second {
 		t.Fatalf("sleeps = %v, want [1s 6s]", sleeps)
+	}
+}
+
+func TestPollDeviceAccessTokenRetriesTransientErrors(t *testing.T) {
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("path = %s, want /oauth/token", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.FormValue("device_code"); got != "device-code" {
+			t.Errorf("device_code = %q, want device-code", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"access_token":"access-token",
+			"token_type":"Bearer",
+			"scope":"read_user"
+		}`))
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = &failingRoundTripper{
+		base:       server.Client().Transport,
+		failures:   1,
+		failureErr: errors.New("temporary network error"),
+	}
+	defer func() { http.DefaultTransport = origTransport }()
+
+	var sleeps []time.Duration
+	tokenResp, err := pollDeviceAccessToken(
+		context.Background(),
+		&Config{Host: server.URL[len("https://"):], ClientID: "test-client"},
+		&DeviceAuthorizationResponse{DeviceCode: "device-code", Interval: 2},
+		func(_ context.Context, duration time.Duration) error {
+			sleeps = append(sleeps, duration)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("pollDeviceAccessToken: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if tokenResp.AccessToken != "access-token" {
+		t.Errorf("AccessToken = %q, want access-token", tokenResp.AccessToken)
+	}
+	if len(sleeps) != 1 || sleeps[0] != 2*time.Second {
+		t.Fatalf("sleeps = %v, want [2s]", sleeps)
+	}
+}
+
+func TestPollDeviceAccessTokenReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var slept bool
+	_, err := pollDeviceAccessToken(
+		ctx,
+		&Config{Host: "127.0.0.1:1", ClientID: "test-client"},
+		&DeviceAuthorizationResponse{DeviceCode: "device-code", Interval: 1},
+		func(context.Context, time.Duration) error {
+			slept = true
+			return nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("pollDeviceAccessToken error = %v, want context.Canceled", err)
+	}
+	if slept {
+		t.Fatal("pollDeviceAccessToken slept after context cancellation")
 	}
 }

--- a/pkg/oauth/device_test.go
+++ b/pkg/oauth/device_test.go
@@ -1,0 +1,160 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestDeviceAuthorization(t *testing.T) {
+	var sawRequest bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/oauth/device_authorization" {
+			t.Errorf("path = %s, want /oauth/device_authorization", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.FormValue("client_id"); got != "test-client" {
+			t.Errorf("client_id = %q, want test-client", got)
+		}
+		if got := r.FormValue("scope"); got != "read_user read_organizations" {
+			t.Errorf("scope = %q, want requested scopes", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DeviceAuthorizationResponse{
+			DeviceCode:              "device-code",
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://buildkite.example/oauth/device",
+			VerificationURIComplete: "https://buildkite.example/oauth/device/ABCD-EFGH",
+			ExpiresIn:               600,
+			Interval:                5,
+		})
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	deviceAuth, err := RequestDeviceAuthorization(context.Background(), &Config{
+		Host:     server.URL[len("https://"):],
+		ClientID: "test-client",
+		Scopes:   "read_user read_organizations",
+	})
+	if err != nil {
+		t.Fatalf("RequestDeviceAuthorization: %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("server did not receive request")
+	}
+	if deviceAuth.DeviceCode != "device-code" {
+		t.Errorf("DeviceCode = %q, want device-code", deviceAuth.DeviceCode)
+	}
+	if deviceAuth.UserCode != "ABCD-EFGH" {
+		t.Errorf("UserCode = %q, want ABCD-EFGH", deviceAuth.UserCode)
+	}
+	if deviceAuth.VerificationURIComplete != "https://buildkite.example/oauth/device/ABCD-EFGH" {
+		t.Errorf("VerificationURIComplete = %q", deviceAuth.VerificationURIComplete)
+	}
+}
+
+func TestRequestDeviceAuthorizationError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"invalid_scope","error_description":"Invalid scope"}`))
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	_, err := RequestDeviceAuthorization(context.Background(), &Config{
+		Host:     server.URL[len("https://"):],
+		ClientID: "test-client",
+		Scopes:   "read_user hack_the_planet",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got, want := err.Error(), "device authorization error: invalid_scope - Invalid scope"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestPollDeviceAccessTokenRetriesPendingAndSlowDown(t *testing.T) {
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("path = %s, want /oauth/token", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.FormValue("grant_type"); got != deviceCodeGrantType {
+			t.Errorf("grant_type = %q, want %q", got, deviceCodeGrantType)
+		}
+		if got := r.FormValue("device_code"); got != "device-code" {
+			t.Errorf("device_code = %q, want device-code", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch requests {
+		case 1:
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"authorization_pending","error_description":"Device authorization is pending"}`))
+		case 2:
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"slow_down","error_description":"Polling too quickly"}`))
+		default:
+			w.Write([]byte(`{
+				"access_token":"access-token",
+				"token_type":"Bearer",
+				"scope":"read_user",
+				"refresh_token":"refresh-token",
+				"expires_in":3600
+			}`))
+		}
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	var sleeps []time.Duration
+	tokenResp, err := pollDeviceAccessToken(
+		context.Background(),
+		&Config{Host: server.URL[len("https://"):], ClientID: "test-client"},
+		&DeviceAuthorizationResponse{DeviceCode: "device-code", Interval: 1},
+		func(_ context.Context, duration time.Duration) error {
+			sleeps = append(sleeps, duration)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("pollDeviceAccessToken: %v", err)
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want 3", requests)
+	}
+	if tokenResp.AccessToken != "access-token" {
+		t.Errorf("AccessToken = %q, want access-token", tokenResp.AccessToken)
+	}
+	if len(sleeps) != 2 || sleeps[0] != time.Second || sleeps[1] != 6*time.Second {
+		t.Fatalf("sleeps = %v, want [1s 6s]", sleeps)
+	}
+}

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -19,6 +20,10 @@ import (
 
 const (
 	DefaultHost = "buildkite.com"
+
+	deviceCodeGrantType     = "urn:ietf:params:oauth:grant-type:device_code"
+	defaultDeviceInterval   = 5 * time.Second
+	deviceSlowDownIncrement = 5 * time.Second
 )
 
 // AllScopes is the complete set of Buildkite API token scopes. When no --scopes
@@ -164,6 +169,18 @@ type TokenResponse struct {
 	ErrorDesc    string `json:"error_description,omitempty"`
 }
 
+// DeviceAuthorizationResponse holds the response from the device authorization endpoint.
+type DeviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+	Error                   string `json:"error,omitempty"`
+	ErrorDesc               string `json:"error_description,omitempty"`
+}
+
 // Flow manages an OAuth authentication flow
 type Flow struct {
 	config       *Config
@@ -174,20 +191,7 @@ type Flow struct {
 
 // NewFlow creates a new OAuth flow
 func NewFlow(cfg *Config) (*Flow, error) {
-	if cfg.Host == "" {
-		// Allow override via environment variable for local development
-		if envHost := os.Getenv("BUILDKITE_HOST"); envHost != "" {
-			cfg.Host = envHost
-		} else {
-			cfg.Host = DefaultHost
-		}
-	}
-	if cfg.ClientID == "" {
-		cfg.ClientID = DefaultClientID
-	}
-	if cfg.Scopes == "" {
-		cfg.Scopes = strings.Join(AllScopes, " ")
-	}
+	normalizeConfigDefaults(cfg)
 
 	// Generate PKCE verifier and state
 	codeVerifier, err := generateCodeVerifier()
@@ -370,6 +374,160 @@ func (f *Flow) ExchangeCode(ctx context.Context, code string) (*TokenResponse, e
 	return &tokenResp, nil
 }
 
+// RequestDeviceAuthorization starts an OAuth device authorization flow.
+func RequestDeviceAuthorization(ctx context.Context, cfg *Config) (*DeviceAuthorizationResponse, error) {
+	normalizeConfigDefaults(cfg)
+
+	deviceURL := fmt.Sprintf("https://%s/oauth/device_authorization", cfg.Host)
+	data := url.Values{
+		"client_id": {cfg.ClientID},
+		"scope":     {cfg.Scopes},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", deviceURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var deviceResp DeviceAuthorizationResponse
+	if err := json.Unmarshal(body, &deviceResp); err != nil {
+		return nil, fmt.Errorf("failed to parse device authorization response: %w", err)
+	}
+
+	if deviceResp.Error != "" {
+		return nil, fmt.Errorf("device authorization error: %s - %s", deviceResp.Error, deviceResp.ErrorDesc)
+	}
+
+	if deviceResp.DeviceCode == "" || deviceResp.UserCode == "" || deviceResp.VerificationURI == "" {
+		return nil, fmt.Errorf("incomplete device authorization response")
+	}
+
+	return &deviceResp, nil
+}
+
+// PollDeviceAccessToken polls the OAuth token endpoint until the user authorizes the device code.
+func PollDeviceAccessToken(ctx context.Context, cfg *Config, deviceAuth *DeviceAuthorizationResponse) (*TokenResponse, error) {
+	return pollDeviceAccessToken(ctx, cfg, deviceAuth, sleepContext)
+}
+
+func pollDeviceAccessToken(ctx context.Context, cfg *Config, deviceAuth *DeviceAuthorizationResponse, sleep func(context.Context, time.Duration) error) (*TokenResponse, error) {
+	normalizeConfigDefaults(cfg)
+
+	interval := time.Duration(deviceAuth.Interval) * time.Second
+	if interval <= 0 {
+		interval = defaultDeviceInterval
+	}
+
+	for {
+		tokenResp, err := exchangeDeviceCode(ctx, cfg, deviceAuth.DeviceCode)
+		if err == nil {
+			return tokenResp, nil
+		}
+
+		var tokenErr *tokenError
+		if !errors.As(err, &tokenErr) {
+			return nil, err
+		}
+
+		switch tokenErr.ErrorCode {
+		case "authorization_pending":
+			if err := sleep(ctx, interval); err != nil {
+				return nil, err
+			}
+		case "slow_down":
+			interval += deviceSlowDownIncrement
+			if err := sleep(ctx, interval); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, err
+		}
+	}
+}
+
+type tokenError struct {
+	ErrorCode   string
+	Description string
+}
+
+func (e *tokenError) Error() string {
+	if e.Description == "" {
+		return fmt.Sprintf("token error: %s", e.ErrorCode)
+	}
+	return fmt.Sprintf("token error: %s - %s", e.ErrorCode, e.Description)
+}
+
+func exchangeDeviceCode(ctx context.Context, cfg *Config, deviceCode string) (*TokenResponse, error) {
+	tokenURL := fmt.Sprintf("https://%s/oauth/token", cfg.Host)
+	data := url.Values{
+		"grant_type":  {deviceCodeGrantType},
+		"client_id":   {cfg.ClientID},
+		"device_code": {deviceCode},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var tokenResp TokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to parse device token response: %w", err)
+	}
+
+	if tokenResp.Error != "" {
+		return nil, &tokenError{ErrorCode: tokenResp.Error, Description: tokenResp.ErrorDesc}
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("no access token in device token response")
+	}
+
+	return &tokenResp, nil
+}
+
+func sleepContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // RefreshAccessToken exchanges a refresh token for a new access token and refresh token.
 func RefreshAccessToken(ctx context.Context, host, clientID, refreshToken string) (*TokenResponse, error) {
 	if host == "" {
@@ -457,4 +615,20 @@ func generateState() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func normalizeConfigDefaults(cfg *Config) {
+	if cfg.Host == "" {
+		if envHost := os.Getenv("BUILDKITE_HOST"); envHost != "" {
+			cfg.Host = envHost
+		} else {
+			cfg.Host = DefaultHost
+		}
+	}
+	if cfg.ClientID == "" {
+		cfg.ClientID = DefaultClientID
+	}
+	if cfg.Scopes == "" {
+		cfg.Scopes = strings.Join(AllScopes, " ")
+	}
 }

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -441,7 +441,13 @@ func pollDeviceAccessToken(ctx context.Context, cfg *Config, deviceAuth *DeviceA
 
 		var tokenErr *tokenError
 		if !errors.As(err, &tokenErr) {
-			return nil, err
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+			if err := sleep(ctx, interval); err != nil {
+				return nil, err
+			}
+			continue
 		}
 
 		switch tokenErr.ErrorCode {


### PR DESCRIPTION
## Problem

`bk auth login` currently assumes a browser can be opened on the same machine that is running the CLI and that a localhost callback can be reached. That is awkward or impossible in common headless cases, especially SSH sessions, remote development boxes, and other environments where the user can authorize in a separate browser but cannot rely on loopback browser OAuth.

Buildkite now has OAuth device authorization endpoints, so the CLI should be able to start a device flow and poll for the resulting access token without opening a browser callback listener.

## Impact

Users can run `bk auth login --device` on a headless or remote machine, authorize from another browser, and have the CLI persist the resulting access and refresh tokens through the same OAuth storage path as browser login. Existing browser login and `--token` login behavior is preserved.

## What Changed

- Added `bk auth login --device`.
- Added OAuth device authorization request and device-code token polling helpers.
- Reused the existing OAuth persistence path so browser login and device login both resolve the authorized organization, store the access token, store refresh tokens when present, and select the organization in config.
- Only advertises automatic refresh when refresh-token storage actually succeeds.
- Rejects incompatible `--device --token` and `--device --org` combinations; device flow chooses the organization on the authorization page.
- Added request-level tests for device authorization, `invalid_scope`, `authorization_pending`, and `slow_down` polling behavior.
- Added a command-level device-login test that exercises device authorization, token exchange, organization lookup, keyring storage, refresh-token storage, and config selection.
- Updated the pinned Go toolchain to 1.26.4 and removed unused `go-buildkite/v5` module metadata inherited from the rebase so the current tidy and `govulncheck` CI gates pass.
