### PR TITLE
fix: ensure refresh transport correctly fixes broken auth

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -84,8 +83,25 @@ func buildFullEndpoint(endpoint, orgSlug string, isAnalytics bool) string {
 	return endpointPrefix + endpoint
 }
 
+func newRESTClient(f *factory.Factory) *httpClient.Client {
+	return httpClient.NewClient(
+		f.Config.APIToken(),
+		httpClient.WithBaseURL(f.RestAPIClient.BaseURL.String()),
+		httpClient.WithUserAgent(f.RestAPIClient.UserAgent),
+		httpClient.WithHTTPClient(f.HTTPClient),
+	)
+}
+
 func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
-	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
+	rl := httpClient.NewRateLimitTransport(nil)
+	rl.MaxRetryDelay = 60 * time.Second
+	rl.OnRateLimit = func(attempt int, delay time.Duration) {
+		if c.Verbose {
+			fmt.Fprintf(os.Stderr, "WARNING: Rate limit exceeded, retrying in %v @ %q (attempt %d)\n", delay, time.Now().Add(delay).Format(time.RFC3339), attempt)
+		}
+	}
+
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()), factory.WithTransport(rl))
 	if err != nil {
 		return err
 	}
@@ -115,20 +131,7 @@ func (c *ApiCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	fullEndpoint := buildFullEndpoint(c.Endpoint, f.Config.OrganizationSlug(), c.Analytics)
 
-	// Create an HTTP client with rate-limit retry via the shared transport.
-	rl := httpClient.NewRateLimitTransport(nil)
-	rl.MaxRetryDelay = 60 * time.Second
-	rl.OnRateLimit = func(attempt int, delay time.Duration) {
-		if c.Verbose {
-			fmt.Fprintf(os.Stderr, "WARNING: Rate limit exceeded, retrying in %v @ %q (attempt %d)\n", delay, time.Now().Add(delay).Format(time.RFC3339), attempt)
-		}
-	}
-
-	client := httpClient.NewClient(
-		f.Config.APIToken(),
-		httpClient.WithBaseURL(f.RestAPIClient.BaseURL.String()),
-		httpClient.WithHTTPClient(&http.Client{Transport: rl}),
-	)
+	client := newRESTClient(f)
 
 	// Process custom headers
 	customHeaders := make(map[string]string)

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -1,7 +1,16 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	httpClient "github.com/buildkite/cli/v3/internal/http"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/keyring"
 )
 
 func TestBuildFullEndpoint(t *testing.T) {
@@ -69,5 +78,69 @@ func TestBuildFullEndpoint(t *testing.T) {
 					tc.endpoint, tc.orgSlug, tc.isAnalytics, got, tc.wantEndpoint)
 			}
 		})
+	}
+}
+
+func TestNewRESTClient_UsesFactoryRefreshAwareHTTPClient(t *testing.T) {
+	keyring.MockForTesting()
+	defer keyring.ResetForTesting()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"new-token","refresh_token":"new-refresh-token","token_type":"Bearer","expires_in":3600}`))
+		case "/v2/organizations/test-org/test":
+			if r.Header.Get("Authorization") == "Bearer old-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "test-org")
+	t.Setenv("BUILDKITE_REST_API_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_HOST", strings.TrimPrefix(server.URL, "https://"))
+
+	kr := keyring.New()
+	if err := kr.Set("test-org", "old-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := kr.SetRefreshToken("test-org", "old-refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() error = %v", err)
+	}
+
+	rl := httpClient.NewRateLimitTransport(nil)
+	f, err := factory.New(factory.WithTransport(rl))
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+
+	client := newRESTClient(f)
+
+	var response map[string]bool
+	if err := client.Get(context.Background(), "/v2/organizations/test-org/test", &response); err != nil {
+		t.Fatalf("client.Get() error = %v", err)
+	}
+	if !response["ok"] {
+		t.Fatalf("expected ok response, got %#v", response)
+	}
+
+	if got := f.Config.APITokenForOrg("test-org"); got != "new-token" {
+		t.Fatalf("expected refreshed access token in keyring, got %q", got)
+	}
+	if got := f.Config.RefreshTokenForOrg("test-org"); got != "new-refresh-token" {
+		t.Fatalf("expected rotated refresh token in keyring, got %q", got)
 	}
 }

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -101,6 +100,39 @@ func LoginWithToken(f *factory.Factory, org, token string) error {
 	return nil
 }
 
+type oauthTokenStore interface {
+	IsAvailable() bool
+	Set(org, token string) error
+	SetRefreshToken(org, token string) error
+}
+
+func persistOAuthLogin(f *factory.Factory, store oauthTokenStore, org, accessToken, refreshToken string) (bool, error) {
+	if org == "" {
+		return false, errors.New("organization cannot be empty")
+	}
+	if accessToken == "" {
+		return false, errors.New("access token cannot be empty")
+	}
+	if !store.IsAvailable() {
+		return false, errors.New("OAuth login requires an available system keychain to persist your access token and refresh token")
+	}
+	if refreshToken != "" {
+		if err := store.SetRefreshToken(org, refreshToken); err != nil {
+			return false, fmt.Errorf("failed to store refresh token in keychain: %w", err)
+		}
+	}
+	if err := store.Set(org, accessToken); err != nil {
+		return false, fmt.Errorf("failed to store token in keychain: %w", err)
+	}
+	if err := f.Config.EnsureOrganization(org); err != nil {
+		return false, fmt.Errorf("failed to register organization in config: %w", err)
+	}
+	if err := f.Config.SelectOrganization(org, f.GitRepository != nil); err != nil {
+		return false, fmt.Errorf("failed to select organization: %w", err)
+	}
+	return refreshToken != "", nil
+}
+
 func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
 	if err != nil {
@@ -187,23 +219,15 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	org := orgs[0]
 
-	if err := LoginWithToken(f, org.Slug, tokenResp.AccessToken); err != nil {
+	autoRefreshConfigured, err := persistOAuthLogin(f, keyring.New(), org.Slug, tokenResp.AccessToken, tokenResp.RefreshToken)
+	if err != nil {
 		return err
 	}
-
-	// Store refresh token if the server issued one
-	if tokenResp.RefreshToken != "" {
-		kr := keyring.New()
-		if kr.IsAvailable() {
-			if err := kr.SetRefreshToken(org.Slug, tokenResp.RefreshToken); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to store refresh token: %v\n", err)
-			}
-		}
-	}
+	fmt.Println("Token stored securely in system keychain.")
 
 	fmt.Printf("\n✅ Successfully authenticated with organization %q\n", org.Slug)
 	fmt.Printf("  Scopes: %s\n", tokenResp.Scope)
-	if tokenResp.RefreshToken != "" {
+	if autoRefreshConfigured {
 		fmt.Printf("  Token expires in: %s (will refresh automatically)\n", formatDuration(tokenResp.ExpiresIn))
 	}
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -1,6 +1,46 @@
 package auth
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+)
+
+type stubOAuthTokenStore struct {
+	available  bool
+	setErr     error
+	refreshErr error
+	access     map[string]string
+	refresh    map[string]string
+}
+
+func (s *stubOAuthTokenStore) IsAvailable() bool {
+	return s.available
+}
+
+func (s *stubOAuthTokenStore) Set(org, token string) error {
+	if s.setErr != nil {
+		return s.setErr
+	}
+	if s.access == nil {
+		s.access = make(map[string]string)
+	}
+	s.access[org] = token
+	return nil
+}
+
+func (s *stubOAuthTokenStore) SetRefreshToken(org, token string) error {
+	if s.refreshErr != nil {
+		return s.refreshErr
+	}
+	if s.refresh == nil {
+		s.refresh = make(map[string]string)
+	}
+	s.refresh[org] = token
+	return nil
+}
 
 func TestOrganizationIdentifier(t *testing.T) {
 	t.Parallel()
@@ -47,4 +87,61 @@ func TestOrganizationIdentifier(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPersistOAuthLogin(t *testing.T) {
+	newFactory := func(t *testing.T) *factory.Factory {
+		t.Helper()
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Chdir(t.TempDir())
+
+		f, err := factory.New()
+		if err != nil {
+			t.Fatalf("factory.New() error = %v", err)
+		}
+		return f
+	}
+
+	t.Run("requires an available keychain", func(t *testing.T) {
+		f := newFactory(t)
+		_, err := persistOAuthLogin(f, &stubOAuthTokenStore{}, "test-org", "access-token", "refresh-token")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "requires an available system keychain") {
+			t.Fatalf("expected keychain availability error, got %v", err)
+		}
+	})
+
+	t.Run("fails when refresh token cannot be stored", func(t *testing.T) {
+		f := newFactory(t)
+		store := &stubOAuthTokenStore{available: true, refreshErr: errors.New("boom")}
+
+		_, err := persistOAuthLogin(f, store, "test-org", "access-token", "refresh-token")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to store refresh token in keychain") {
+			t.Fatalf("expected refresh token storage error, got %v", err)
+		}
+		if got := store.access["test-org"]; got != "" {
+			t.Fatalf("expected access token not to be stored after refresh-token failure, got %q", got)
+		}
+	})
+
+	t.Run("reports automatic refresh only when refresh token is stored", func(t *testing.T) {
+		f := newFactory(t)
+		store := &stubOAuthTokenStore{available: true}
+
+		autoRefresh, err := persistOAuthLogin(f, store, "test-org", "access-token", "refresh-token")
+		if err != nil {
+			t.Fatalf("persistOAuthLogin() error = %v", err)
+		}
+		if !autoRefresh {
+			t.Fatal("expected autoRefresh to be true")
+		}
+		if got := store.refresh["test-org"]; got != "refresh-token" {
+			t.Fatalf("expected refresh token to be stored, got %q", got)
+		}
+	})
 }

--- a/cmd/pipeline/copy.go
+++ b/cmd/pipeline/copy.go
@@ -296,15 +296,16 @@ func (c *CopyCmd) runCopy(kongCtx *kong.Context, f *factory.Factory, source *bui
 
 // getClientForOrg creates a Buildkite client authenticated for the specified organization
 func (c *CopyCmd) getClientForOrg(f *factory.Factory, org string) (*buildkite.Client, error) {
-	token := f.Config.APITokenForOrg(org)
-	if token == "" {
+	if f.Config.APITokenForOrg(org) == "" {
 		return nil, fmt.Errorf("no API token configured for organization %q. Run 'bk configure' to add it", org)
 	}
 
-	return buildkite.NewOpts(
-		buildkite.WithBaseURL(f.Config.RESTAPIEndpoint()),
-		buildkite.WithTokenAuth(token),
-	)
+	targetFactory, err := factory.New(factory.WithDebug(f.Debug), factory.WithOrgOverride(org))
+	if err != nil {
+		return nil, fmt.Errorf("create factory for organization %q: %w", org, err)
+	}
+
+	return targetFactory.RestAPIClient, nil
 }
 
 func (c *CopyCmd) buildCreatePipeline(source *buildkite.Pipeline, targetName string, isCrossOrg bool, clusterID string) buildkite.CreatePipeline {

--- a/internal/http/refresh_transport.go
+++ b/internal/http/refresh_transport.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/buildkite/cli/v3/pkg/oauth"
 )
 
@@ -69,6 +69,15 @@ func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return base.RoundTrip(req)
 }
 
+type credentialStore interface {
+	Set(org, token string) error
+	GetRefreshToken(org string) (string, error)
+	SetRefreshToken(org, token string) error
+	DeleteRefreshToken(org string) error
+}
+
+var errCredentialPersistence = errors.New("credential persistence failed")
+
 // RefreshTransport wraps an http.RoundTripper to automatically refresh
 // expired OAuth access tokens using a stored refresh token.
 //
@@ -82,7 +91,7 @@ func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 type RefreshTransport struct {
 	Base        http.RoundTripper
 	Org         string
-	Keyring     *keyring.Keyring
+	Keyring     credentialStore
 	TokenSource *TokenSource
 
 	mu sync.Mutex
@@ -126,6 +135,11 @@ func (t *RefreshTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	t.mu.Unlock()
 
 	if refreshErr != nil {
+		if errors.Is(refreshErr, errCredentialPersistence) {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			return nil, refreshErr
+		}
 		fmt.Fprintf(os.Stderr, "Warning: token refresh failed: %v\n", refreshErr)
 		return resp, nil
 	}
@@ -177,18 +191,19 @@ func (t *RefreshTransport) doRefresh(ctx context.Context, failedToken string) (s
 		return "", err
 	}
 
-	// Persist the new access token
-	if err := t.Keyring.Set(t.Org, tokenResp.AccessToken); err != nil {
-		return "", fmt.Errorf("failed to store refreshed access token: %w", err)
-	}
-	t.TokenSource.SetToken(tokenResp.AccessToken)
-
-	// Rotate the refresh token if a new one was issued
+	// Rotate the refresh token before persisting the new access token so a
+	// failed refresh-token write does not leave us holding a newly-issued
+	// access token with a stale rotated refresh token.
 	if tokenResp.RefreshToken != "" {
 		if err := t.Keyring.SetRefreshToken(t.Org, tokenResp.RefreshToken); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to store rotated refresh token: %v\n", err)
+			return "", fmt.Errorf("%w: failed to store rotated refresh token: %w", errCredentialPersistence, err)
 		}
 	}
+
+	if err := t.Keyring.Set(t.Org, tokenResp.AccessToken); err != nil {
+		return "", fmt.Errorf("%w: failed to store refreshed access token: %w", errCredentialPersistence, err)
+	}
+	t.TokenSource.SetToken(tokenResp.AccessToken)
 
 	return tokenResp.AccessToken, nil
 }

--- a/internal/http/refresh_transport_test.go
+++ b/internal/http/refresh_transport_test.go
@@ -13,9 +13,39 @@ import (
 	"github.com/buildkite/cli/v3/pkg/keyring"
 )
 
-func TestRefreshTransport_PassesThroughNon401(t *testing.T) {
-	t.Parallel()
+type stubCredentialStore struct {
+	accessToken        string
+	refreshToken       string
+	setAccessErr       error
+	setRefreshTokenErr error
+}
 
+func (s *stubCredentialStore) Set(_ string, token string) error {
+	if s.setAccessErr != nil {
+		return s.setAccessErr
+	}
+	s.accessToken = token
+	return nil
+}
+
+func (s *stubCredentialStore) GetRefreshToken(string) (string, error) {
+	return s.refreshToken, nil
+}
+
+func (s *stubCredentialStore) SetRefreshToken(_ string, token string) error {
+	if s.setRefreshTokenErr != nil {
+		return s.setRefreshTokenErr
+	}
+	s.refreshToken = token
+	return nil
+}
+
+func (s *stubCredentialStore) DeleteRefreshToken(string) error {
+	s.refreshToken = ""
+	return nil
+}
+
+func TestRefreshTransport_PassesThroughNon401(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"ok":true}`))
@@ -51,8 +81,6 @@ func TestRefreshTransport_PassesThroughNon401(t *testing.T) {
 }
 
 func TestRefreshTransport_NoRefreshToken_PassesThrough401(t *testing.T) {
-	t.Parallel()
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{"message":"unauthorized"}`))
@@ -142,6 +170,60 @@ func TestRefreshTransport_CompareAfterLock_SkipsRedundantRefresh(t *testing.T) {
 	}
 }
 
+func TestRefreshTransport_RotatedRefreshTokenStoreFailureReturnsError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"new-token","refresh_token":"new-refresh-token","token_type":"Bearer","expires_in":3600}`))
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	store := &stubCredentialStore{
+		accessToken:        "old-token",
+		refreshToken:       "old-refresh-token",
+		setRefreshTokenErr: errors.New("boom"),
+	}
+	transport := &RefreshTransport{
+		Base:        server.Client().Transport,
+		Org:         "test-org",
+		Keyring:     store,
+		TokenSource: NewTokenSource("old-token"),
+	}
+
+	t.Setenv("BUILDKITE_HOST", strings.TrimPrefix(server.URL, "https://"))
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/test", nil)
+	req.Header.Set("Authorization", "Bearer old-token")
+
+	resp, err := transport.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on credential persistence failure, got %#v", resp)
+	}
+	if !errors.Is(err, errCredentialPersistence) {
+		t.Fatalf("expected credential persistence error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to store rotated refresh token") {
+		t.Fatalf("expected rotated refresh token storage error, got %v", err)
+	}
+	if store.accessToken != "old-token" {
+		t.Fatalf("expected access token to remain unchanged, got %q", store.accessToken)
+	}
+	if transport.TokenSource.Token() != "old-token" {
+		t.Fatalf("expected token source to remain unchanged, got %q", transport.TokenSource.Token())
+	}
+}
+
 func TestRefreshTransport_DoesNotDeleteRefreshTokenOnTransientError(t *testing.T) {
 	keyring.MockForTesting()
 	defer keyring.ResetForTesting()
@@ -188,8 +270,6 @@ func TestRefreshTransport_DoesNotDeleteRefreshTokenOnTransientError(t *testing.T
 }
 
 func TestRefreshTransport_BuffersAndRetriesPostBody(t *testing.T) {
-	t.Parallel()
-
 	keyring.MockForTesting()
 	defer keyring.ResetForTesting()
 

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -24,6 +24,7 @@ var baseUserAgent string
 type Factory struct {
 	Config        *config.Config
 	GitRepository *git.Repository
+	HTTPClient    *http.Client
 	GraphQLClient graphql.Client
 	RestAPIClient *buildkite.Client
 	Version       string
@@ -265,6 +266,7 @@ func New(opts ...FactoryOpt) (*Factory, error) {
 	return &Factory{
 		Config:        conf,
 		GitRepository: repo,
+		HTTPClient:    httpClient,
 		GraphQLClient: graphql.NewClient(conf.GetGraphQLEndpoint(), graphqlHTTPClient),
 		RestAPIClient: buildkiteClient,
 		Version:       version.Version,


### PR DESCRIPTION
### Description

It looks like refresh tokens aren't working as expected in the CLI, sometimes meaning that after 8 hours, users need to re-authenticate.

### Changes

- hard error on credential persistence failures
- persist rotated refresh tokens **before** refreshed access tokens to avoid keeping a new access token with a stale refresh token
- update OAuth login so it only reports automatic refresh when refresh-token persistence succeeds
- Add regression tests for:
  - rotated refresh-token storage failure
  - OAuth login refresh-token persistence
  - `bk api` using the refresh-aware factory HTTP client

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

Ensure the local auth is set, it doesn't need to be working. If any API tokens are in local env then they'll need unsetting

```sh
which bk
bk version
bk config get selected_org
bk config list
env | grep -E '^(BUILDKITE_API_TOKEN|BUILDKITE_ORGANIZATION_SLUG|BUILDKITE_NO_KEYRING|BUILDKITE=|CI=|XDG_CONFIG_HOME=)'
```

Build the CLI, then login and check status, it should output the logged in state.

```
go build -o /tmp/bk-refresh-test .
/tmp/bk-refresh-test auth login
/tmp/bk-refresh-test auth status
```

Force a refresh token to be used after a broken auth (tested on MacOS).

```sh
ORG=$(/tmp/bk-refresh-test config get selected_org)
security add-generic-password -U -s buildkite-cli -a "$ORG" -w intentionally-invalid-token
/tmp/bk-refresh-test --debug auth status
```

### Disclosures / Credits

Codex was used to review and refine the implementation.

