### PR TITLE
feat: Add shm credential store for headless auth

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -19,10 +20,11 @@ import (
 )
 
 type LoginCmd struct {
-	Scopes string `help:"OAuth scopes to request" default:""`
-	Org    string `help:"Organization slug or UUID to request access for" optional:""`
-	Token  string `help:"API token to store (non-OAuth login, requires --org)" optional:""`
-	Device bool   `help:"Authenticate using OAuth device authorization instead of opening a browser callback" optional:""`
+	Scopes          string `help:"OAuth scopes to request" default:""`
+	Org             string `help:"Organization slug or UUID to request access for" optional:""`
+	Token           string `help:"API token to store (non-OAuth login, requires --org)" optional:""`
+	Device          bool   `help:"Authenticate using OAuth device authorization instead of opening a browser callback" optional:""`
+	CredentialStore string `help:"Credential store for tokens: auto, keyring, or shm" enum:"auto,keyring,shm" default:"auto"`
 }
 
 func organizationIdentifier(org string) (orgSlug, orgUUID string) {
@@ -60,6 +62,9 @@ Examples:
   # Login on a headless machine or remote shell
   $ bk auth login --device
 
+  # Login on a headless Linux host using an in-memory /dev/shm credential store
+  $ bk auth login --device --credential-store shm
+
   # Login with read-only access
   $ bk auth login --scopes read_only
 
@@ -71,11 +76,15 @@ Examples:
 `
 }
 
-// LoginWithToken stores a token for an organization in the system keychain.
-// When the keychain is unavailable (e.g. BUILDKITE_NO_KEYRING=1 is set), it
-// still registers the org and selects it in config so that commands resolve the
-// org correctly; the caller is expected to supply the token via BUILDKITE_API_TOKEN.
+// LoginWithToken stores a token for an organization in the default credential
+// store. When the store is unavailable (e.g. BUILDKITE_NO_KEYRING=1 is set), it
+// still registers the org and selects it in config so commands resolve the org
+// correctly; the caller is expected to supply the token via BUILDKITE_API_TOKEN.
 func LoginWithToken(f *factory.Factory, org, token string) error {
+	return loginWithToken(f, org, token, keyring.New())
+}
+
+func loginWithToken(f *factory.Factory, org, token string, kr oauthTokenStore) error {
 	if org == "" {
 		return errors.New("--org is required when --token is provided")
 	}
@@ -83,14 +92,13 @@ func LoginWithToken(f *factory.Factory, org, token string) error {
 		return errors.New("--token cannot be empty")
 	}
 
-	kr := keyring.New()
 	if kr.IsAvailable() {
 		if err := kr.Set(org, token); err != nil {
-			return fmt.Errorf("failed to store token in keychain: %w", err)
+			return fmt.Errorf("failed to store token in credential store: %w", err)
 		}
-		fmt.Println("Token stored securely in system keychain.")
+		fmt.Printf("Token stored in %s.\n", credentialStoreDescription(kr))
 	} else {
-		fmt.Println("Keychain unavailable; token not stored. Use BUILDKITE_API_TOKEN to supply your token at runtime.")
+		fmt.Println("Credential store unavailable; token not stored. Use BUILDKITE_API_TOKEN to supply your token at runtime.")
 	}
 
 	if err := f.Config.EnsureOrganization(org); err != nil {
@@ -118,15 +126,15 @@ func persistOAuthLogin(f *factory.Factory, store oauthTokenStore, org, accessTok
 		return false, errors.New("access token cannot be empty")
 	}
 	if !store.IsAvailable() {
-		return false, errors.New("OAuth login requires an available system keychain to persist your access token and refresh token")
+		return false, errors.New("OAuth login requires an available credential store to persist your access token and refresh token")
 	}
 	if refreshToken != "" {
 		if err := store.SetRefreshToken(org, refreshToken); err != nil {
-			return false, fmt.Errorf("failed to store refresh token in keychain: %w", err)
+			return false, fmt.Errorf("failed to store refresh token in credential store: %w", err)
 		}
 	}
 	if err := store.Set(org, accessToken); err != nil {
-		return false, fmt.Errorf("failed to store token in keychain: %w", err)
+		return false, fmt.Errorf("failed to store token in credential store: %w", err)
 	}
 	if err := f.Config.EnsureOrganization(org); err != nil {
 		return false, fmt.Errorf("failed to register organization in config: %w", err)
@@ -143,12 +151,17 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return err
 	}
 
-	if err := c.validate(); err != nil {
+	if err := c.validate(kongCtx); err != nil {
+		return err
+	}
+
+	credentialStore, err := c.newCredentialStore(kongCtx)
+	if err != nil {
 		return err
 	}
 
 	if c.Token != "" {
-		if err := LoginWithToken(f, c.Org, c.Token); err != nil {
+		if err := loginWithToken(f, c.Org, c.Token, credentialStore); err != nil {
 			return err
 		}
 
@@ -162,7 +175,7 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	resolvedScopes := oauth.ResolveScopes(c.Scopes)
 
 	if c.Device {
-		return c.runDeviceLogin(context.Background(), f, resolvedScopes)
+		return c.runDeviceLogin(context.Background(), f, resolvedScopes, credentialStore)
 	}
 
 	orgSlug, orgUUID := organizationIdentifier(c.Org)
@@ -212,7 +225,7 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return fmt.Errorf("token exchange failed: %w", err)
 	}
 
-	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp)
+	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp, credentialStore)
 	if err != nil {
 		return err
 	}
@@ -222,7 +235,22 @@ func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	return nil
 }
 
-func (c *LoginCmd) validate() error {
+func (c *LoginCmd) newCredentialStore(kongCtx *kong.Context) (*keyring.Keyring, error) {
+	if !c.credentialStoreFlagProvided(kongCtx) {
+		return keyring.New(), nil
+	}
+	return keyring.NewWithCredentialStore(c.CredentialStore)
+}
+
+func (c *LoginCmd) validate(kongCtx *kong.Context) error {
+	if err := keyring.ValidateCredentialStore(c.CredentialStore); err != nil {
+		return err
+	}
+	if envStore := os.Getenv(keyring.CredentialStoreEnv); !c.credentialStoreFlagProvided(kongCtx) && envStore != "" {
+		if err := keyring.ValidateCredentialStore(envStore); err != nil {
+			return err
+		}
+	}
 	if c.Device && c.Token != "" {
 		return errors.New("--device cannot be used with --token")
 	}
@@ -232,7 +260,19 @@ func (c *LoginCmd) validate() error {
 	return nil
 }
 
-func (c *LoginCmd) runDeviceLogin(ctx context.Context, f *factory.Factory, resolvedScopes string) error {
+func (c *LoginCmd) credentialStoreFlagProvided(kongCtx *kong.Context) bool {
+	if kongCtx == nil {
+		return c.CredentialStore != ""
+	}
+	for _, trace := range kongCtx.Path {
+		if trace.Flag != nil && trace.Flag.Name == "credential-store" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *LoginCmd) runDeviceLogin(ctx context.Context, f *factory.Factory, resolvedScopes string, credentialStore oauthTokenStore) error {
 	cfg := &oauth.Config{
 		ClientID: oauth.DefaultClientID,
 		Scopes:   resolvedScopes,
@@ -266,7 +306,7 @@ func (c *LoginCmd) runDeviceLogin(ctx context.Context, f *factory.Factory, resol
 		return fmt.Errorf("device authorization failed: %w", err)
 	}
 
-	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp)
+	org, autoRefreshConfigured, err := completeOAuthLogin(ctx, f, tokenResp, credentialStore)
 	if err != nil {
 		return err
 	}
@@ -276,7 +316,7 @@ func (c *LoginCmd) runDeviceLogin(ctx context.Context, f *factory.Factory, resol
 	return nil
 }
 
-func completeOAuthLogin(ctx context.Context, f *factory.Factory, tokenResp *oauth.TokenResponse) (string, bool, error) {
+func completeOAuthLogin(ctx context.Context, f *factory.Factory, tokenResp *oauth.TokenResponse, credentialStore oauthTokenStore) (string, bool, error) {
 	// Resolve org from the API using the new token
 	client, err := buildkite.NewOpts(
 		buildkite.WithTokenAuth(tokenResp.AccessToken),
@@ -296,13 +336,24 @@ func completeOAuthLogin(ctx context.Context, f *factory.Factory, tokenResp *oaut
 
 	org := orgs[0]
 
-	autoRefreshConfigured, err := persistOAuthLogin(f, keyring.New(), org.Slug, tokenResp.AccessToken, tokenResp.RefreshToken)
+	autoRefreshConfigured, err := persistOAuthLogin(f, credentialStore, org.Slug, tokenResp.AccessToken, tokenResp.RefreshToken)
 	if err != nil {
 		return "", false, err
 	}
-	fmt.Println("Token stored securely in system keychain.")
+	fmt.Printf("Tokens stored in %s.\n", credentialStoreDescription(credentialStore))
 
 	return org.Slug, autoRefreshConfigured, nil
+}
+
+type describedCredentialStore interface {
+	Description() string
+}
+
+func credentialStoreDescription(store oauthTokenStore) string {
+	if described, ok := store.(describedCredentialStore); ok {
+		return described.Description()
+	}
+	return "the configured credential store"
 }
 
 func printOAuthLoginSuccess(org string, tokenResp *oauth.TokenResponse, autoRefreshConfigured bool) {

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -146,16 +146,22 @@ func persistOAuthLogin(f *factory.Factory, store oauthTokenStore, org, accessTok
 }
 
 func (c *LoginCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
-	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
-	if err != nil {
-		return err
-	}
-
 	if err := c.validate(kongCtx); err != nil {
 		return err
 	}
 
 	credentialStore, err := c.newCredentialStore(kongCtx)
+	if err != nil {
+		return err
+	}
+
+	restoreCredentialStoreEnv, err := c.applyCredentialStoreEnv(kongCtx)
+	if err != nil {
+		return err
+	}
+	defer restoreCredentialStoreEnv()
+
+	f, err := factory.New(factory.WithDebug(globals.EnableDebug()))
 	if err != nil {
 		return err
 	}
@@ -240,6 +246,24 @@ func (c *LoginCmd) newCredentialStore(kongCtx *kong.Context) (*keyring.Keyring, 
 		return keyring.New(), nil
 	}
 	return keyring.NewWithCredentialStore(c.CredentialStore)
+}
+
+func (c *LoginCmd) applyCredentialStoreEnv(kongCtx *kong.Context) (func(), error) {
+	if !c.credentialStoreFlagProvided(kongCtx) {
+		return func() {}, nil
+	}
+
+	original, hadOriginal := os.LookupEnv(keyring.CredentialStoreEnv)
+	if err := os.Setenv(keyring.CredentialStoreEnv, c.CredentialStore); err != nil {
+		return nil, err
+	}
+	return func() {
+		if hadOriginal {
+			_ = os.Setenv(keyring.CredentialStoreEnv, original)
+			return
+		}
+		_ = os.Unsetenv(keyring.CredentialStoreEnv)
+	}, nil
 }
 
 func (c *LoginCmd) validate(kongCtx *kong.Context) error {

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -96,6 +96,9 @@ func loginWithToken(f *factory.Factory, org, token string, kr oauthTokenStore) e
 		if err := kr.Set(org, token); err != nil {
 			return fmt.Errorf("failed to store token in credential store: %w", err)
 		}
+		if err := keyring.ClearRefreshToken(org); err != nil {
+			return fmt.Errorf("failed to clear stale OAuth refresh token from credential store: %w", err)
+		}
 		fmt.Printf("Token stored in %s.\n", credentialStoreDescription(kr))
 	} else {
 		fmt.Println("Credential store unavailable; token not stored. Use BUILDKITE_API_TOKEN to supply your token at runtime.")

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -239,8 +239,16 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnv(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
 	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
 	t.Setenv(keyring.CredentialStorePathEnv, path)
-	keyring.ResetForTesting()
+	keyring.MockForTesting()
 	t.Cleanup(keyring.ResetForTesting)
+
+	keyringStore, err := keyring.NewWithCredentialStore(keyring.StoreKeyring)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreKeyring, err)
+	}
+	if err := keyringStore.SetRefreshToken("test-org", "old-keyring-refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() keyring error = %v", err)
+	}
 
 	cmd := &LoginCmd{Org: "test-org", Token: "access-token"}
 	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
@@ -257,6 +265,9 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnv(t *testing.T) {
 	}
 	if token != "access-token" {
 		t.Fatalf("stored token = %q, want access-token", token)
+	}
+	if _, err := keyringStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("keyring GetRefreshToken() error = %v, want ErrNotFound", err)
 	}
 }
 
@@ -304,47 +315,6 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnvWhenFlagOmitted(t *testing.T)
 	}
 	if token != "access-token" {
 		t.Fatalf("stored token = %q, want access-token", token)
-	}
-}
-
-func TestLoginCmdRunWithTokenClearsStaleOAuthRefreshTokens(t *testing.T) {
-	t.Chdir(t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("BUILDKITE_API_TOKEN", "")
-	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
-
-	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
-	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
-	t.Setenv(keyring.CredentialStorePathEnv, path)
-	keyring.MockForTesting()
-	t.Cleanup(keyring.ResetForTesting)
-
-	keyringStore, err := keyring.NewWithCredentialStore(keyring.StoreKeyring)
-	if err != nil {
-		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreKeyring, err)
-	}
-	if err := keyringStore.SetRefreshToken("test-org", "old-keyring-refresh-token"); err != nil {
-		t.Fatalf("SetRefreshToken() keyring error = %v", err)
-	}
-
-	shmStore, err := keyring.NewWithCredentialStore(keyring.StoreSHM)
-	if err != nil {
-		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
-	}
-	cmd := &LoginCmd{Org: "test-org", Token: "access-token"}
-	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-
-	token, err := shmStore.Get("test-org")
-	if err != nil {
-		t.Fatalf("Get() error = %v", err)
-	}
-	if token != "access-token" {
-		t.Fatalf("stored token = %q, want access-token", token)
-	}
-	if _, err := keyringStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
-		t.Fatalf("keyring GetRefreshToken() error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -331,10 +331,6 @@ func TestLoginCmdRunWithTokenClearsStaleOAuthRefreshTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
 	}
-	if err := shmStore.SetRefreshToken("test-org", "old-shm-refresh-token"); err != nil {
-		t.Fatalf("SetRefreshToken() shm error = %v", err)
-	}
-
 	cmd := &LoginCmd{Org: "test-org", Token: "access-token"}
 	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -349,9 +345,6 @@ func TestLoginCmdRunWithTokenClearsStaleOAuthRefreshTokens(t *testing.T) {
 	}
 	if _, err := keyringStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
 		t.Fatalf("keyring GetRefreshToken() error = %v, want ErrNotFound", err)
-	}
-	if _, err := shmStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
-		t.Fatalf("shm GetRefreshToken() error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -350,6 +350,34 @@ func TestLoginCmdRunWithTokenCredentialStoreFlagOverridesEnv(t *testing.T) {
 	}
 }
 
+func TestLoginCmdApplyCredentialStoreEnvForExplicitFlag(t *testing.T) {
+	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreKeyring)
+
+	var cli struct {
+		Login LoginCmd `cmd:""`
+	}
+	parser, err := kong.New(&cli)
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	ctx, err := parser.Parse([]string{"login", "--credential-store", "shm"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	restore, err := cli.Login.applyCredentialStoreEnv(ctx)
+	if err != nil {
+		t.Fatalf("applyCredentialStoreEnv() error = %v", err)
+	}
+	if got := os.Getenv(keyring.CredentialStoreEnv); got != keyring.StoreSHM {
+		t.Fatalf("%s = %q, want %q", keyring.CredentialStoreEnv, got, keyring.StoreSHM)
+	}
+	restore()
+	if got := os.Getenv(keyring.CredentialStoreEnv); got != keyring.StoreKeyring {
+		t.Fatalf("restored %s = %q, want %q", keyring.CredentialStoreEnv, got, keyring.StoreKeyring)
+	}
+}
+
 func TestLoginCmdRunDeviceFlow(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -235,7 +235,7 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnv(t *testing.T) {
 	t.Setenv("BUILDKITE_API_TOKEN", "")
 	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
 
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
 	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
 	t.Setenv(keyring.CredentialStorePathEnv, path)
 	keyring.ResetForTesting()
@@ -265,7 +265,7 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnvWhenFlagOmitted(t *testing.T)
 	t.Setenv("BUILDKITE_API_TOKEN", "")
 	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
 
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
 	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
 	t.Setenv(keyring.CredentialStorePathEnv, path)
 	keyring.ResetForTesting()
@@ -312,7 +312,7 @@ func TestLoginCmdRunWithTokenCredentialStoreFlagOverridesEnv(t *testing.T) {
 	t.Setenv("BUILDKITE_API_TOKEN", "")
 	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
 
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
 	t.Setenv(keyring.CredentialStoreEnv, "disk")
 	t.Setenv(keyring.CredentialStorePathEnv, path)
 	keyring.ResetForTesting()

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/buildkite/cli/v3/pkg/oauth"
@@ -118,14 +119,14 @@ func TestPersistOAuthLogin(t *testing.T) {
 		return f
 	}
 
-	t.Run("requires an available keychain", func(t *testing.T) {
+	t.Run("requires an available credential store", func(t *testing.T) {
 		f := newFactory(t)
 		_, err := persistOAuthLogin(f, &stubOAuthTokenStore{}, "test-org", "access-token", "refresh-token")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "requires an available system keychain") {
-			t.Fatalf("expected keychain availability error, got %v", err)
+		if !strings.Contains(err.Error(), "requires an available credential store") {
+			t.Fatalf("expected credential store availability error, got %v", err)
 		}
 	})
 
@@ -137,7 +138,7 @@ func TestPersistOAuthLogin(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "failed to store refresh token in keychain") {
+		if !strings.Contains(err.Error(), "failed to store refresh token in credential store") {
 			t.Fatalf("expected refresh token storage error, got %v", err)
 		}
 		if got := store.access["test-org"]; got != "" {
@@ -188,13 +189,18 @@ func TestLoginCmdValidateDeviceIncompatibleFlags(t *testing.T) {
 			name: "token with org",
 			cmd:  LoginCmd{Token: "token", Org: "buildkite"},
 		},
+		{
+			name:    "invalid credential store",
+			cmd:     LoginCmd{CredentialStore: "disk"},
+			wantErr: "unsupported credential store",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tt.cmd.validate()
+			err := tt.cmd.validate(nil)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("validate() error = %v, want nil", err)
@@ -204,10 +210,143 @@ func TestLoginCmdValidateDeviceIncompatibleFlags(t *testing.T) {
 			if err == nil {
 				t.Fatal("validate() error = nil, want error")
 			}
-			if got := err.Error(); got != tt.wantErr {
-				t.Fatalf("validate() error = %q, want %q", got, tt.wantErr)
+			if got := err.Error(); !strings.Contains(got, tt.wantErr) {
+				t.Fatalf("validate() error = %q, want substring %q", got, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestLoginCmdValidateCredentialStoreEnv(t *testing.T) {
+	t.Setenv(keyring.CredentialStoreEnv, "disk")
+
+	err := (&LoginCmd{}).validate(nil)
+	if err == nil {
+		t.Fatal("validate() error = nil, want error")
+	}
+	if got := err.Error(); !strings.Contains(got, "unsupported credential store") {
+		t.Fatalf("validate() error = %q, want unsupported credential store", got)
+	}
+}
+
+func TestLoginCmdRunWithTokenUsesCredentialStoreEnv(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
+	t.Setenv(keyring.CredentialStorePathEnv, path)
+	keyring.ResetForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	cmd := &LoginCmd{Org: "test-org", Token: "access-token"}
+	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	kr, err := keyring.NewWithCredentialStore(keyring.StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
+	}
+	token, err := kr.Get("test-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("stored token = %q, want access-token", token)
+	}
+}
+
+func TestLoginCmdRunWithTokenUsesCredentialStoreEnvWhenFlagOmitted(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
+	t.Setenv(keyring.CredentialStorePathEnv, path)
+	keyring.ResetForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	var cli struct {
+		Login LoginCmd `cmd:""`
+	}
+	parser, err := kong.New(&cli)
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	ctx, err := parser.Parse([]string{"login", "--org", "test-org", "--token", "access-token"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cli.Login.CredentialStore != keyring.StoreAuto {
+		t.Fatalf("parsed credential store = %q, want %q", cli.Login.CredentialStore, keyring.StoreAuto)
+	}
+	if cli.Login.credentialStoreFlagProvided(ctx) {
+		t.Fatal("credentialStoreFlagProvided() = true, want false")
+	}
+
+	if err := cli.Login.Run(ctx, authStubGlobals{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	kr, err := keyring.NewWithCredentialStore(keyring.StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
+	}
+	token, err := kr.Get("test-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("stored token = %q, want access-token", token)
+	}
+}
+
+func TestLoginCmdRunWithTokenCredentialStoreFlagOverridesEnv(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	t.Setenv(keyring.CredentialStoreEnv, "disk")
+	t.Setenv(keyring.CredentialStorePathEnv, path)
+	keyring.ResetForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	var cli struct {
+		Login LoginCmd `cmd:""`
+	}
+	parser, err := kong.New(&cli)
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	ctx, err := parser.Parse([]string{"login", "--org", "test-org", "--token", "access-token", "--credential-store", "shm"})
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !cli.Login.credentialStoreFlagProvided(ctx) {
+		t.Fatal("credentialStoreFlagProvided() = false, want true")
+	}
+
+	if err := cli.Login.Run(ctx, authStubGlobals{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	kr, err := keyring.NewWithCredentialStore(keyring.StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
+	}
+	token, err := kr.Get("test-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("stored token = %q, want access-token", token)
 	}
 }
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/buildkite/cli/v3/pkg/oauth"
 	buildkite "github.com/buildkite/go-buildkite/v4"
+	oskeyring "github.com/zalando/go-keyring"
 )
 
 type stubOAuthTokenStore struct {
@@ -303,6 +304,54 @@ func TestLoginCmdRunWithTokenUsesCredentialStoreEnvWhenFlagOmitted(t *testing.T)
 	}
 	if token != "access-token" {
 		t.Fatalf("stored token = %q, want access-token", token)
+	}
+}
+
+func TestLoginCmdRunWithTokenClearsStaleOAuthRefreshTokens(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BUILDKITE_API_TOKEN", "")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+
+	path := filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
+	t.Setenv(keyring.CredentialStoreEnv, keyring.StoreSHM)
+	t.Setenv(keyring.CredentialStorePathEnv, path)
+	keyring.MockForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	keyringStore, err := keyring.NewWithCredentialStore(keyring.StoreKeyring)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreKeyring, err)
+	}
+	if err := keyringStore.SetRefreshToken("test-org", "old-keyring-refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() keyring error = %v", err)
+	}
+
+	shmStore, err := keyring.NewWithCredentialStore(keyring.StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", keyring.StoreSHM, err)
+	}
+	if err := shmStore.SetRefreshToken("test-org", "old-shm-refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() shm error = %v", err)
+	}
+
+	cmd := &LoginCmd{Org: "test-org", Token: "access-token"}
+	if err := cmd.Run(nil, authStubGlobals{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	token, err := shmStore.Get("test-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("stored token = %q, want access-token", token)
+	}
+	if _, err := keyringStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("keyring GetRefreshToken() error = %v, want ErrNotFound", err)
+	}
+	if _, err := shmStore.GetRefreshToken("test-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("shm GetRefreshToken() error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -34,9 +34,11 @@ func (c *LogoutCmd) logoutAll(f *factory.Factory) error {
 	if kr.IsAvailable() {
 		for _, org := range orgs {
 			if err := kr.Delete(org); err != nil {
-				fmt.Printf("Warning: could not remove token from keychain for %q: %v\n", org, err)
+				fmt.Printf("Warning: could not remove token from credential store for %q: %v\n", org, err)
 			}
-			_ = kr.DeleteRefreshToken(org)
+			if err := kr.DeleteRefreshToken(org); err != nil {
+				fmt.Printf("Warning: could not remove refresh token from credential store for %q: %v\n", org, err)
+			}
 		}
 	}
 
@@ -61,11 +63,13 @@ func (c *LogoutCmd) logoutOrg(f *factory.Factory) error {
 	kr := keyring.New()
 	if kr.IsAvailable() {
 		if err := kr.Delete(org); err != nil {
-			fmt.Printf("Warning: could not remove token from keychain: %v\n", err)
+			fmt.Printf("Warning: could not remove token from credential store: %v\n", err)
 		} else {
-			fmt.Println("Token removed from system keychain.")
+			fmt.Println("Token removed from credential store.")
 		}
-		_ = kr.DeleteRefreshToken(org)
+		if err := kr.DeleteRefreshToken(org); err != nil {
+			fmt.Printf("Warning: could not remove refresh token from credential store: %v\n", err)
+		}
 	}
 
 	fmt.Printf("Logged out of organization %q\n", org)

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -15,9 +15,9 @@ func (c *TokenCmd) Help() string {
 	return `
 Prints the stored API token for the currently selected organization to stdout.
 
-The token is retrieved from the system keychain (or the BUILDKITE_API_TOKEN
-environment variable if set). This is useful for passing the token to other
-tools, for example:
+The token is retrieved from the configured credential store (or the
+BUILDKITE_API_TOKEN environment variable if set). This is useful for passing
+the token to other tools, for example:
 
 Examples:
 	# Print the current token

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,13 +127,13 @@ func (conf *Config) SelectOrganization(org string, inGitRepo bool) error {
 }
 
 // APIToken gets the API token configured for the currently selected organization.
-// Precedence: environment variable > keyring > config file (legacy, read-only with warning)
+// Precedence: environment variable > credential store > config file (legacy, read-only with warning)
 func (conf *Config) APIToken() string {
 	return conf.APITokenForOrg(conf.OrganizationSlug())
 }
 
 // APITokenForOrg gets the API token for a specific organization.
-// Precedence: environment variable > keyring > config file (legacy, read-only with warning)
+// Precedence: environment variable > credential store > config file (legacy, read-only with warning)
 func (conf *Config) APITokenForOrg(org string) string {
 	if token := os.Getenv("BUILDKITE_API_TOKEN"); token != "" {
 		envTokenWarningOnce.Do(func() {
@@ -155,7 +155,7 @@ func (conf *Config) APITokenForOrg(org string) string {
 		conf.local.getToken(org),
 	); token != "" {
 		legacyTokenWarningOnce.Do(func() {
-			fmt.Fprintln(os.Stderr, "Warning: reading API token from config file is deprecated. Run `bk auth login` to store your token securely in the system keychain.")
+			fmt.Fprintln(os.Stderr, "Warning: reading API token from config file is deprecated. Run `bk auth login` to store your token in the configured credential store.")
 		})
 		return token
 	}
@@ -163,7 +163,7 @@ func (conf *Config) APITokenForOrg(org string) string {
 	return ""
 }
 
-// RefreshTokenForOrg gets the refresh token for a specific organization from the keyring.
+// RefreshTokenForOrg gets the refresh token for a specific organization from the credential store.
 func (conf *Config) RefreshTokenForOrg(org string) string {
 	if org == "" {
 		return ""
@@ -182,7 +182,7 @@ func (conf *Config) RefreshToken() string {
 	return conf.RefreshTokenForOrg(conf.OrganizationSlug())
 }
 
-// HasStoredTokenForOrg reports whether a token is stored for org in keyring
+// HasStoredTokenForOrg reports whether a token is stored for org in the credential store
 // or config files, excluding environment variable overrides.
 func (conf *Config) HasStoredTokenForOrg(org string) bool {
 	if org == "" {
@@ -204,8 +204,8 @@ func (conf *Config) HasStoredTokenForOrg(org string) bool {
 }
 
 // EnsureOrganization records an organization in user config without requiring
-// a token value. This keeps org switching/listing functional for keychain-only
-// token storage.
+// a token value. This keeps org switching/listing functional for
+// credential-store token storage.
 func (conf *Config) EnsureOrganization(org string) error {
 	if org == "" {
 		return nil

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -1,94 +1,271 @@
-// Package keyring provides secure credential storage using the OS keychain.
-// It falls back to file-based storage when the keychain is unavailable (e.g., in CI environments).
+// Package keyring provides credential storage using the OS keychain, with an
+// optional tmpfs-backed store for headless Linux hosts.
 package keyring
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
-	"github.com/zalando/go-keyring"
+	oskeyring "github.com/zalando/go-keyring"
 )
 
 const (
 	serviceName        = "buildkite-cli"
 	refreshServiceName = "buildkite-cli-refresh"
+
+	// CredentialStoreEnv selects the credential store used by keyring.New.
+	// Supported values are "auto", "keyring", and "shm".
+	CredentialStoreEnv = "BUILDKITE_CREDENTIAL_STORE"
+
+	// CredentialStorePathEnv overrides the tmpfs credential file path. It is
+	// mainly useful for tests and controlled environments.
+	CredentialStorePathEnv = "BUILDKITE_CREDENTIAL_STORE_PATH"
+
+	StoreAuto    = "auto"
+	StoreKeyring = "keyring"
+	StoreSHM     = "shm"
 )
 
 var (
 	keyringAvailableOnce sync.Once
 	keyringAvailable     bool
+	keyringMocked        bool
+	shmCredentialMu      sync.Mutex
+
+	errCredentialStoreUnavailable = errors.New("credential store unavailable")
 )
 
-// Keyring provides secure credential storage with fallback support
+// Keyring provides credential storage with fallback support.
 type Keyring struct {
+	store      string
 	useKeyring bool
+	lastStore  string
 }
 
-// New creates a new Keyring instance.
-// It automatically detects if the system keyring is available.
+// New creates a new Keyring instance using the default credential store mode.
 func New() *Keyring {
+	kr, err := NewWithCredentialStore(os.Getenv(CredentialStoreEnv))
+	if err != nil {
+		kr, _ = NewWithCredentialStore(StoreAuto)
+	}
+	return kr
+}
+
+// NewWithCredentialStore creates a keyring using the requested credential
+// store. An empty store uses the default auto mode.
+func NewWithCredentialStore(store string) (*Keyring, error) {
+	store = normalizeCredentialStore(store)
+	if err := ValidateCredentialStore(store); err != nil {
+		return nil, err
+	}
 	return &Keyring{
-		useKeyring: isKeyringAvailable(),
+		store:      store,
+		useKeyring: store != StoreSHM && isKeyringAvailable(),
+	}, nil
+}
+
+func ValidateCredentialStore(store string) error {
+	switch normalizeCredentialStore(store) {
+	case StoreAuto, StoreKeyring, StoreSHM:
+		return nil
+	default:
+		return fmt.Errorf("unsupported credential store %q (expected %s, %s, or %s)", store, StoreAuto, StoreKeyring, StoreSHM)
 	}
 }
 
 // Set stores a token for the given organization
 func (k *Keyring) Set(org, token string) error {
-	if !k.useKeyring {
-		return nil // Fallback handled by config file
-	}
-	return keyring.Set(serviceName, org, token)
+	return k.set(serviceName, org, token)
 }
 
 // Get retrieves a token for the given organization
 func (k *Keyring) Get(org string) (string, error) {
-	if !k.useKeyring {
-		return "", keyring.ErrNotFound
-	}
-	return keyring.Get(serviceName, org)
+	return k.get(serviceName, org)
 }
 
 // Delete removes a token for the given organization
 func (k *Keyring) Delete(org string) error {
-	if !k.useKeyring {
-		return nil
-	}
-	return keyring.Delete(serviceName, org)
+	return k.delete(serviceName, org)
 }
 
 // SetRefreshToken stores a refresh token for the given organization
 func (k *Keyring) SetRefreshToken(org, token string) error {
-	if !k.useKeyring {
-		return nil
-	}
-	return keyring.Set(refreshServiceName, org, token)
+	return k.set(refreshServiceName, org, token)
 }
 
 // GetRefreshToken retrieves a refresh token for the given organization
 func (k *Keyring) GetRefreshToken(org string) (string, error) {
-	if !k.useKeyring {
-		return "", keyring.ErrNotFound
-	}
-	return keyring.Get(refreshServiceName, org)
+	return k.get(refreshServiceName, org)
 }
 
 // DeleteRefreshToken removes a refresh token for the given organization
 func (k *Keyring) DeleteRefreshToken(org string) error {
-	if !k.useKeyring {
-		return nil
-	}
-	return keyring.Delete(refreshServiceName, org)
+	return k.delete(refreshServiceName, org)
 }
 
-// IsAvailable returns true if the system keyring is available
+// IsAvailable returns true if the configured credential store is available.
 func (k *Keyring) IsAvailable() bool {
-	return k.useKeyring
+	switch k.store {
+	case StoreSHM:
+		return shmStoreAvailable()
+	case StoreKeyring:
+		return k.useKeyring
+	default:
+		if credentialStorageDisabledByEnv() {
+			return shmCredentialFileExists()
+		}
+		return k.useKeyring || shmStoreAvailable()
+	}
+}
+
+// Description returns a user-facing description of the active credential store.
+func (k *Keyring) Description() string {
+	if k.lastStore == StoreSHM || k.store == StoreSHM {
+		return "the /dev/shm credential store"
+	}
+	return "the system keychain"
+}
+
+func (k *Keyring) set(service, org, token string) error {
+	if org == "" {
+		return errors.New("organization cannot be empty")
+	}
+	if token == "" {
+		return errors.New("token cannot be empty")
+	}
+	if k.store == StoreAuto && !k.canWriteAuto() {
+		return nil
+	}
+
+	var keyringErr error
+	if k.canUseKeyring() {
+		if err := oskeyring.Set(service, org, token); err == nil {
+			k.lastStore = StoreKeyring
+			return nil
+		} else {
+			keyringErr = err
+			if k.store == StoreKeyring {
+				return err
+			}
+		}
+	}
+
+	if k.canUseSHMForWrite() {
+		if err := setSHMCredential(service, org, token); err == nil {
+			k.lastStore = StoreSHM
+			return nil
+		} else if keyringErr == nil {
+			return err
+		}
+	}
+
+	if keyringErr != nil {
+		return keyringErr
+	}
+	return errCredentialStoreUnavailable
+}
+
+func (k *Keyring) get(service, org string) (string, error) {
+	if org == "" {
+		return "", oskeyring.ErrNotFound
+	}
+
+	var keyringErr error
+	if k.canUseKeyring() {
+		token, err := oskeyring.Get(service, org)
+		if err == nil {
+			k.lastStore = StoreKeyring
+			return token, nil
+		}
+		keyringErr = err
+		if k.store == StoreKeyring {
+			return "", err
+		}
+	}
+
+	if k.canUseSHMForRead() {
+		token, err := getSHMCredential(service, org)
+		if err == nil {
+			k.lastStore = StoreSHM
+			return token, nil
+		}
+		if keyringErr == nil || !errors.Is(err, oskeyring.ErrNotFound) {
+			return "", err
+		}
+	}
+
+	if keyringErr != nil {
+		return "", keyringErr
+	}
+	return "", oskeyring.ErrNotFound
+}
+
+func (k *Keyring) delete(service, org string) error {
+	var deleteErr error
+	if k.canUseKeyring() {
+		if err := oskeyring.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+			deleteErr = err
+		}
+	}
+	if k.canUseSHMForRead() {
+		if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+			return err
+		}
+	}
+	return deleteErr
+}
+
+func (k *Keyring) canUseKeyring() bool {
+	if k.store == StoreAuto && k.lastStore == StoreSHM {
+		return false
+	}
+	return k.useKeyring && k.store != StoreSHM
+}
+
+func (k *Keyring) canWriteAuto() bool {
+	if !credentialStorageDisabledByEnv() {
+		return k.useKeyring || shmStoreAvailable()
+	}
+	return shmCredentialFileExists()
+}
+
+func (k *Keyring) canUseSHMForRead() bool {
+	switch k.store {
+	case StoreSHM:
+		return true
+	case StoreAuto:
+		if credentialStorageDisabledByEnv() {
+			return shmCredentialFileExists()
+		}
+		return shmStoreAvailable()
+	default:
+		return false
+	}
+}
+
+func (k *Keyring) canUseSHMForWrite() bool {
+	switch k.store {
+	case StoreSHM:
+		return true
+	case StoreAuto:
+		if credentialStorageDisabledByEnv() {
+			return shmCredentialFileExists()
+		}
+		return shmStoreAvailable()
+	default:
+		return false
+	}
 }
 
 // MockForTesting replaces the keyring backend with an in-memory store
 // and marks it as available so subsequent New() calls use the mock.
 func MockForTesting() {
-	keyring.MockInit()
+	oskeyring.MockInit()
+	keyringMocked = true
 	keyringAvailableOnce = sync.Once{}
 	keyringAvailableOnce.Do(func() {
 		keyringAvailable = true
@@ -100,25 +277,284 @@ func MockForTesting() {
 func ResetForTesting() {
 	keyringAvailableOnce = sync.Once{}
 	keyringAvailable = false
+	keyringMocked = false
 }
 
 // isKeyringAvailable checks if the system keyring can be used
 func isKeyringAvailable() bool {
+	if keyringMocked {
+		return true
+	}
 	keyringAvailableOnce.Do(func() {
-		// Disable keyring if explicitly opted out
-		if os.Getenv("BUILDKITE_NO_KEYRING") != "" {
+		if credentialStorageDisabledByEnv() {
 			keyringAvailable = false
 			return
 		}
-
-		// Disable keyring in CI environments
-		if os.Getenv("CI") != "" || os.Getenv("BUILDKITE") != "" {
-			keyringAvailable = false
-			return
-		}
-
 		// Assume keyring is available; callers can handle errors
 		keyringAvailable = true
 	})
 	return keyringAvailable
+}
+
+func credentialStorageDisabledByEnv() bool {
+	if keyringMocked {
+		return false
+	}
+	return os.Getenv("BUILDKITE_NO_KEYRING") != "" ||
+		os.Getenv("CI") != "" ||
+		os.Getenv("BUILDKITE") != ""
+}
+
+func normalizeCredentialStore(store string) string {
+	if store == "" {
+		return StoreAuto
+	}
+	return store
+}
+
+type shmCredentials struct {
+	Services map[string]map[string]string `json:"services,omitempty"`
+}
+
+func newSHMCredentials() shmCredentials {
+	return shmCredentials{Services: make(map[string]map[string]string)}
+}
+
+func shmCredentialPath() string {
+	if path := os.Getenv(CredentialStorePathEnv); path != "" {
+		return path
+	}
+	uid := os.Getuid()
+	if uid < 0 {
+		uid = 0
+	}
+	return filepath.Join("/dev/shm", fmt.Sprintf("buildkite-cli-%d", uid), "credentials.json")
+}
+
+func shmCredentialLockPath(path string) string {
+	return filepath.Join(filepath.Dir(path), ".credentials.lock")
+}
+
+func shmStoreAvailable() bool {
+	path := shmCredentialPath()
+	if os.Getenv(CredentialStorePathEnv) == "" {
+		if info, err := os.Stat("/dev/shm"); err != nil || !info.IsDir() {
+			return false
+		}
+	}
+	return ensureSHMStoreDir(path) == nil
+}
+
+func shmCredentialFileExists() bool {
+	path := shmCredentialPath()
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return validateSHMFile(path, info) == nil
+}
+
+func setSHMCredential(service, org, token string) error {
+	return withSHMCredentialLock(func() error {
+		creds, err := loadSHMCredentials()
+		if err != nil {
+			return err
+		}
+		if creds.Services[service] == nil {
+			creds.Services[service] = make(map[string]string)
+		}
+		creds.Services[service][org] = token
+		return saveSHMCredentials(creds)
+	})
+}
+
+func getSHMCredential(service, org string) (string, error) {
+	creds, err := loadSHMCredentials()
+	if err != nil {
+		return "", err
+	}
+	if token := creds.Services[service][org]; token != "" {
+		return token, nil
+	}
+	return "", oskeyring.ErrNotFound
+}
+
+func deleteSHMCredential(service, org string) error {
+	return withSHMCredentialLock(func() error {
+		creds, err := loadSHMCredentials()
+		if err != nil {
+			return err
+		}
+		if creds.Services[service] == nil {
+			return oskeyring.ErrNotFound
+		}
+		if _, ok := creds.Services[service][org]; !ok {
+			return oskeyring.ErrNotFound
+		}
+		delete(creds.Services[service], org)
+		return saveSHMCredentials(creds)
+	})
+}
+
+func withSHMCredentialLock(fn func() error) error {
+	shmCredentialMu.Lock()
+	defer shmCredentialMu.Unlock()
+
+	path := shmCredentialPath()
+	if err := ensureSHMStoreDir(path); err != nil {
+		return err
+	}
+
+	lockPath := shmCredentialLockPath(path)
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
+	info, err := os.Lstat(lockPath)
+	if err != nil {
+		return err
+	}
+	if err := validateSHMFile(lockPath, info); err != nil {
+		return err
+	}
+
+	if err := lockFile(lock); err != nil {
+		return err
+	}
+	defer func() { _ = unlockFile(lock) }()
+
+	return fn()
+}
+
+func loadSHMCredentials() (shmCredentials, error) {
+	path := shmCredentialPath()
+	if err := ensureSHMStoreDir(path); err != nil {
+		return shmCredentials{}, err
+	}
+
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return newSHMCredentials(), nil
+	}
+	if err != nil {
+		return shmCredentials{}, err
+	}
+	if err := validateSHMFile(path, info); err != nil {
+		return shmCredentials{}, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return shmCredentials{}, err
+	}
+	if len(data) == 0 {
+		return newSHMCredentials(), nil
+	}
+
+	creds := newSHMCredentials()
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return shmCredentials{}, err
+	}
+	if creds.Services == nil {
+		creds.Services = make(map[string]map[string]string)
+	}
+	return creds, nil
+}
+
+func saveSHMCredentials(creds shmCredentials) error {
+	path := shmCredentialPath()
+	if err := ensureSHMStoreDir(path); err != nil {
+		return err
+	}
+	if creds.Services == nil {
+		creds.Services = make(map[string]map[string]string)
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credentials-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func ensureSHMStoreDir(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("credential store directory %s cannot be a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("credential store path %s is not a directory", dir)
+	}
+	if err := validateCurrentUserOwner(dir, info); err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSHMFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("credential store file %s cannot be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("credential store file %s is not a regular file", path)
+	}
+	if err := validateCurrentUserOwner(path, info); err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(path, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCurrentUserOwner(path string, info os.FileInfo) error {
+	uid := os.Getuid()
+	if uid < 0 {
+		return nil
+	}
+	ownerUID, ok := fileOwnerUID(info)
+	if !ok {
+		return nil
+	}
+	if ownerUID != uint32(uid) {
+		return fmt.Errorf("credential store path %s is owned by uid %d, not current uid %d", path, ownerUID, uid)
+	}
+	return nil
 }

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -155,7 +155,9 @@ func (k *Keyring) set(service, org, token string) error {
 	if k.canUseKeyring() {
 		if err := oskeyring.Set(service, org, token); err == nil {
 			k.lastStore = StoreKeyring
-			_ = deleteSHMCredentialIfPresent(service, org)
+			if err := deleteSHMCredentialIfPresent(service, org); err != nil {
+				return err
+			}
 			return nil
 		} else {
 			keyringErr = err
@@ -287,6 +289,18 @@ func (k *Keyring) canUseSHMForWrite() bool {
 	default:
 		return false
 	}
+}
+
+// ClearRefreshToken removes any stored OAuth refresh token for an organization.
+// This is used when replacing OAuth credentials with a non-OAuth API token.
+func ClearRefreshToken(org string) error {
+	if org == "" {
+		return errors.New("organization cannot be empty")
+	}
+	if err := deleteReadableKeyringCredential(refreshServiceName, org); err != nil {
+		return err
+	}
+	return deleteReadableSHMCredential(refreshServiceName, org)
 }
 
 // MockForTesting replaces the keyring backend with an in-memory store
@@ -450,39 +464,75 @@ func deleteSHMCredential(service, org string) error {
 		if err != nil {
 			return err
 		}
+		removed := creds.clearPreferredStore(service, org)
 		if creds.Services[service] == nil {
+			if removed {
+				return saveSHMCredentials(creds)
+			}
 			return oskeyring.ErrNotFound
 		}
 		if _, ok := creds.Services[service][org]; !ok {
+			if removed {
+				return saveSHMCredentials(creds)
+			}
 			return oskeyring.ErrNotFound
 		}
 		delete(creds.Services[service], org)
-		creds.clearPreferredStore(service, org)
+		if len(creds.Services[service]) == 0 {
+			delete(creds.Services, service)
+		}
 		return saveSHMCredentials(creds)
 	})
 }
 
 func preferredSHMStore(service, org string) bool {
+	store, ok, err := preferredStore(service, org)
+	return err == nil && ok && store == StoreSHM
+}
+
+func preferredStore(service, org string) (string, bool, error) {
 	path := shmCredentialPath()
 	info, err := os.Lstat(path)
 	if err != nil {
-		return false
+		return "", false, err
 	}
 	if err := validateSHMFile(path, info); err != nil {
-		return false
+		return "", false, err
 	}
 	creds, err := readSHMCredentialsFile(path)
 	if err != nil {
-		return false
+		return "", false, err
 	}
-	return creds.PreferredStores[service][org] == StoreSHM
+	store, ok := creds.PreferredStores[service][org]
+	return store, ok, nil
 }
 
 func deleteSHMCredentialIfPresent(service, org string) error {
+	store, ok, err := preferredStore(service, org)
+	if err != nil || !ok || store != StoreSHM {
+		return nil
+	}
+	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func deleteReadableKeyringCredential(service, org string) error {
+	if _, err := oskeyring.Get(service, org); err != nil {
+		return nil
+	}
+	if err := oskeyring.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func deleteReadableSHMCredential(service, org string) error {
 	if !shmCredentialFileExists() {
 		return nil
 	}
-	if !shmStoreAvailable() {
+	if _, err := getSHMCredential(service, org); err != nil {
 		return nil
 	}
 	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -464,52 +464,42 @@ func deleteSHMCredential(service, org string) error {
 		if err != nil {
 			return err
 		}
-		removed := creds.clearPreferredStore(service, org)
 		if creds.Services[service] == nil {
-			if removed {
-				return saveSHMCredentials(creds)
-			}
 			return oskeyring.ErrNotFound
 		}
 		if _, ok := creds.Services[service][org]; !ok {
-			if removed {
-				return saveSHMCredentials(creds)
-			}
 			return oskeyring.ErrNotFound
 		}
 		delete(creds.Services[service], org)
-		if len(creds.Services[service]) == 0 {
-			delete(creds.Services, service)
-		}
+		creds.clearPreferredStore(service, org)
 		return saveSHMCredentials(creds)
 	})
 }
 
 func preferredSHMStore(service, org string) bool {
-	store, ok, err := preferredStore(service, org)
-	return err == nil && ok && store == StoreSHM
+	preferred, err := preferredSHMStoreWithError(service, org)
+	return err == nil && preferred
 }
 
-func preferredStore(service, org string) (string, bool, error) {
+func preferredSHMStoreWithError(service, org string) (bool, error) {
 	path := shmCredentialPath()
 	info, err := os.Lstat(path)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
 	if err := validateSHMFile(path, info); err != nil {
-		return "", false, err
+		return false, err
 	}
 	creds, err := readSHMCredentialsFile(path)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
-	store, ok := creds.PreferredStores[service][org]
-	return store, ok, nil
+	return creds.PreferredStores[service][org] == StoreSHM, nil
 }
 
 func deleteSHMCredentialIfPresent(service, org string) error {
-	store, ok, err := preferredStore(service, org)
-	if err != nil || !ok || store != StoreSHM {
+	preferred, err := preferredSHMStoreWithError(service, org)
+	if err != nil || !preferred {
 		return nil
 	}
 	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -155,7 +155,9 @@ func (k *Keyring) set(service, org, token string) error {
 	if k.canUseKeyring() {
 		if err := oskeyring.Set(service, org, token); err == nil {
 			k.lastStore = StoreKeyring
-			_ = clearSHMPreferredStore(service, org)
+			if err := deleteSHMCredentialIfPresent(service, org); err != nil {
+				return err
+			}
 			return nil
 		} else {
 			keyringErr = err
@@ -478,20 +480,17 @@ func preferredSHMStore(service, org string) bool {
 	return creds.PreferredStores[service][org] == StoreSHM
 }
 
-func clearSHMPreferredStore(service, org string) error {
+func deleteSHMCredentialIfPresent(service, org string) error {
 	if !shmCredentialFileExists() {
 		return nil
 	}
-	return withSHMCredentialLock(func() error {
-		creds, err := loadSHMCredentials()
-		if err != nil {
-			return err
-		}
-		if !creds.clearPreferredStore(service, org) {
-			return nil
-		}
-		return saveSHMCredentials(creds)
-	})
+	if !shmStoreAvailable() {
+		return nil
+	}
+	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		return err
+	}
+	return nil
 }
 
 func withSHMCredentialLock(fn func() error) error {

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -68,7 +68,7 @@ func NewWithCredentialStore(store string) (*Keyring, error) {
 	}
 	return &Keyring{
 		store:      store,
-		useKeyring: store != StoreSHM && isKeyringAvailable(),
+		useKeyring: store == StoreKeyring || (store == StoreAuto && isKeyringAvailable()),
 	}, nil
 }
 
@@ -155,9 +155,7 @@ func (k *Keyring) set(service, org, token string) error {
 	if k.canUseKeyring() {
 		if err := oskeyring.Set(service, org, token); err == nil {
 			k.lastStore = StoreKeyring
-			if err := deleteSHMCredentialIfPresent(service, org); err != nil {
-				return err
-			}
+			_ = deleteSHMCredentialIfPresent(service, org)
 			return nil
 		} else {
 			keyringErr = err

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -47,6 +47,31 @@ type Keyring struct {
 	err        error
 }
 
+type credentialBackend interface {
+	Set(service, user, pass string) error
+	Get(service, user string) (string, error)
+	Delete(service, user string) error
+}
+
+var (
+	keyringBackend credentialBackend = osCredentialBackend{}
+	shmBackend                       = shmCredentialBackend{}
+)
+
+type osCredentialBackend struct{}
+
+func (osCredentialBackend) Set(service, user, pass string) error {
+	return oskeyring.Set(service, user, pass)
+}
+
+func (osCredentialBackend) Get(service, user string) (string, error) {
+	return oskeyring.Get(service, user)
+}
+
+func (osCredentialBackend) Delete(service, user string) error {
+	return oskeyring.Delete(service, user)
+}
+
 // New creates a new Keyring instance using the default credential store mode.
 func New() *Keyring {
 	kr, err := NewWithCredentialStore(os.Getenv(CredentialStoreEnv))
@@ -153,9 +178,9 @@ func (k *Keyring) set(service, org, token string) error {
 
 	var keyringErr error
 	if k.canUseKeyring() {
-		if err := oskeyring.Set(service, org, token); err == nil {
+		if err := keyringBackend.Set(service, org, token); err == nil {
 			k.lastStore = StoreKeyring
-			if err := deleteSHMCredentialIfPresent(service, org); err != nil {
+			if err := k.deletePreferredSHMCredential(service, org); err != nil {
 				return err
 			}
 			return nil
@@ -168,7 +193,7 @@ func (k *Keyring) set(service, org, token string) error {
 	}
 
 	if k.canUseSHMForWrite() {
-		if err := setSHMCredential(service, org, token); err == nil {
+		if err := shmBackend.Set(service, org, token); err == nil {
 			k.lastStore = StoreSHM
 			return nil
 		} else if keyringErr == nil {
@@ -190,8 +215,8 @@ func (k *Keyring) get(service, org string) (string, error) {
 		return "", oskeyring.ErrNotFound
 	}
 
-	if k.store == StoreAuto && preferredSHMStore(service, org) {
-		token, err := getSHMCredential(service, org)
+	if k.store == StoreAuto && k.preferredSHMStore(service, org) {
+		token, err := shmBackend.Get(service, org)
 		if err == nil {
 			k.lastStore = StoreSHM
 			return token, nil
@@ -203,7 +228,7 @@ func (k *Keyring) get(service, org string) (string, error) {
 
 	var keyringErr error
 	if k.canUseKeyring() {
-		token, err := oskeyring.Get(service, org)
+		token, err := keyringBackend.Get(service, org)
 		if err == nil {
 			k.lastStore = StoreKeyring
 			return token, nil
@@ -215,7 +240,7 @@ func (k *Keyring) get(service, org string) (string, error) {
 	}
 
 	if k.canUseSHMForRead() {
-		token, err := getSHMCredential(service, org)
+		token, err := shmBackend.Get(service, org)
 		if err == nil {
 			k.lastStore = StoreSHM
 			return token, nil
@@ -237,12 +262,12 @@ func (k *Keyring) delete(service, org string) error {
 	}
 	var deleteErr error
 	if k.canUseKeyring() {
-		if err := oskeyring.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		if err := keyringBackend.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
 			deleteErr = err
 		}
 	}
 	if k.canUseSHMForRead() {
-		if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		if err := shmBackend.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
 			return err
 		}
 	}
@@ -291,16 +316,45 @@ func (k *Keyring) canUseSHMForWrite() bool {
 	}
 }
 
+func (k *Keyring) preferredSHMStore(service, org string) bool {
+	preferred, err := shmBackend.Preferred(service, org)
+	return err == nil && preferred
+}
+
+func (k *Keyring) deletePreferredSHMCredential(service, org string) error {
+	preferred, err := shmBackend.Preferred(service, org)
+	if err != nil || !preferred {
+		return nil
+	}
+	if err := shmBackend.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
 // ClearRefreshToken removes any stored OAuth refresh token for an organization.
 // This is used when replacing OAuth credentials with a non-OAuth API token.
 func ClearRefreshToken(org string) error {
 	if org == "" {
 		return errors.New("organization cannot be empty")
 	}
-	if err := deleteReadableKeyringCredential(refreshServiceName, org); err != nil {
-		return err
+	backends := []credentialBackend{keyringBackend}
+	if shmCredentialFileExists() {
+		backends = append(backends, shmBackend)
 	}
-	return deleteReadableSHMCredential(refreshServiceName, org)
+	return deleteReadableCredentials(refreshServiceName, org, backends...)
+}
+
+func deleteReadableCredentials(service, user string, backends ...credentialBackend) error {
+	for _, backend := range backends {
+		if _, err := backend.Get(service, user); err != nil {
+			continue
+		}
+		if err := backend.Delete(service, user); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
+			return err
+		}
+	}
+	return nil
 }
 
 // MockForTesting replaces the keyring backend with an in-memory store
@@ -432,7 +486,9 @@ func shmCredentialFileExists() bool {
 	return validateSHMFile(path, info) == nil
 }
 
-func setSHMCredential(service, org, token string) error {
+type shmCredentialBackend struct{}
+
+func (shmCredentialBackend) Set(service, org, token string) error {
 	return withSHMCredentialLock(func() error {
 		creds, err := loadSHMCredentials()
 		if err != nil {
@@ -447,7 +503,7 @@ func setSHMCredential(service, org, token string) error {
 	})
 }
 
-func getSHMCredential(service, org string) (string, error) {
+func (shmCredentialBackend) Get(service, org string) (string, error) {
 	creds, err := loadSHMCredentials()
 	if err != nil {
 		return "", err
@@ -458,7 +514,7 @@ func getSHMCredential(service, org string) (string, error) {
 	return "", oskeyring.ErrNotFound
 }
 
-func deleteSHMCredential(service, org string) error {
+func (shmCredentialBackend) Delete(service, org string) error {
 	return withSHMCredentialLock(func() error {
 		creds, err := loadSHMCredentials()
 		if err != nil {
@@ -476,12 +532,7 @@ func deleteSHMCredential(service, org string) error {
 	})
 }
 
-func preferredSHMStore(service, org string) bool {
-	preferred, err := preferredSHMStoreWithError(service, org)
-	return err == nil && preferred
-}
-
-func preferredSHMStoreWithError(service, org string) (bool, error) {
+func (shmCredentialBackend) Preferred(service, org string) (bool, error) {
 	path := shmCredentialPath()
 	info, err := os.Lstat(path)
 	if err != nil {
@@ -495,40 +546,6 @@ func preferredSHMStoreWithError(service, org string) (bool, error) {
 		return false, err
 	}
 	return creds.PreferredStores[service][org] == StoreSHM, nil
-}
-
-func deleteSHMCredentialIfPresent(service, org string) error {
-	preferred, err := preferredSHMStoreWithError(service, org)
-	if err != nil || !preferred {
-		return nil
-	}
-	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
-		return err
-	}
-	return nil
-}
-
-func deleteReadableKeyringCredential(service, org string) error {
-	if _, err := oskeyring.Get(service, org); err != nil {
-		return nil
-	}
-	if err := oskeyring.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
-		return err
-	}
-	return nil
-}
-
-func deleteReadableSHMCredential(service, org string) error {
-	if !shmCredentialFileExists() {
-		return nil
-	}
-	if _, err := getSHMCredential(service, org); err != nil {
-		return nil
-	}
-	if err := deleteSHMCredential(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
-		return err
-	}
-	return nil
 }
 
 func withSHMCredentialLock(fn func() error) error {

--- a/pkg/keyring/keyring.go
+++ b/pkg/keyring/keyring.go
@@ -44,13 +44,17 @@ type Keyring struct {
 	store      string
 	useKeyring bool
 	lastStore  string
+	err        error
 }
 
 // New creates a new Keyring instance using the default credential store mode.
 func New() *Keyring {
 	kr, err := NewWithCredentialStore(os.Getenv(CredentialStoreEnv))
 	if err != nil {
-		kr, _ = NewWithCredentialStore(StoreAuto)
+		return &Keyring{
+			store: normalizeCredentialStore(os.Getenv(CredentialStoreEnv)),
+			err:   err,
+		}
 	}
 	return kr
 }
@@ -109,6 +113,9 @@ func (k *Keyring) DeleteRefreshToken(org string) error {
 
 // IsAvailable returns true if the configured credential store is available.
 func (k *Keyring) IsAvailable() bool {
+	if k.err != nil {
+		return false
+	}
 	switch k.store {
 	case StoreSHM:
 		return shmStoreAvailable()
@@ -131,6 +138,9 @@ func (k *Keyring) Description() string {
 }
 
 func (k *Keyring) set(service, org, token string) error {
+	if k.err != nil {
+		return k.err
+	}
 	if org == "" {
 		return errors.New("organization cannot be empty")
 	}
@@ -145,6 +155,7 @@ func (k *Keyring) set(service, org, token string) error {
 	if k.canUseKeyring() {
 		if err := oskeyring.Set(service, org, token); err == nil {
 			k.lastStore = StoreKeyring
+			_ = clearSHMPreferredStore(service, org)
 			return nil
 		} else {
 			keyringErr = err
@@ -170,8 +181,22 @@ func (k *Keyring) set(service, org, token string) error {
 }
 
 func (k *Keyring) get(service, org string) (string, error) {
+	if k.err != nil {
+		return "", k.err
+	}
 	if org == "" {
 		return "", oskeyring.ErrNotFound
+	}
+
+	if k.store == StoreAuto && preferredSHMStore(service, org) {
+		token, err := getSHMCredential(service, org)
+		if err == nil {
+			k.lastStore = StoreSHM
+			return token, nil
+		}
+		if !errors.Is(err, oskeyring.ErrNotFound) {
+			return "", err
+		}
 	}
 
 	var keyringErr error
@@ -205,6 +230,9 @@ func (k *Keyring) get(service, org string) (string, error) {
 }
 
 func (k *Keyring) delete(service, org string) error {
+	if k.err != nil {
+		return k.err
+	}
 	var deleteErr error
 	if k.canUseKeyring() {
 		if err := oskeyring.Delete(service, org); err != nil && !errors.Is(err, oskeyring.ErrNotFound) {
@@ -313,11 +341,47 @@ func normalizeCredentialStore(store string) string {
 }
 
 type shmCredentials struct {
-	Services map[string]map[string]string `json:"services,omitempty"`
+	Services        map[string]map[string]string `json:"services,omitempty"`
+	PreferredStores map[string]map[string]string `json:"preferred_stores,omitempty"`
 }
 
 func newSHMCredentials() shmCredentials {
-	return shmCredentials{Services: make(map[string]map[string]string)}
+	return shmCredentials{
+		Services:        make(map[string]map[string]string),
+		PreferredStores: make(map[string]map[string]string),
+	}
+}
+
+func (c *shmCredentials) ensureMaps() {
+	if c.Services == nil {
+		c.Services = make(map[string]map[string]string)
+	}
+	if c.PreferredStores == nil {
+		c.PreferredStores = make(map[string]map[string]string)
+	}
+}
+
+func (c *shmCredentials) preferStore(service, org, store string) {
+	c.ensureMaps()
+	if c.PreferredStores[service] == nil {
+		c.PreferredStores[service] = make(map[string]string)
+	}
+	c.PreferredStores[service][org] = store
+}
+
+func (c *shmCredentials) clearPreferredStore(service, org string) bool {
+	c.ensureMaps()
+	if c.PreferredStores[service] == nil {
+		return false
+	}
+	if _, ok := c.PreferredStores[service][org]; !ok {
+		return false
+	}
+	delete(c.PreferredStores[service], org)
+	if len(c.PreferredStores[service]) == 0 {
+		delete(c.PreferredStores, service)
+	}
+	return true
 }
 
 func shmCredentialPath() string {
@@ -364,6 +428,7 @@ func setSHMCredential(service, org, token string) error {
 			creds.Services[service] = make(map[string]string)
 		}
 		creds.Services[service][org] = token
+		creds.preferStore(service, org, StoreSHM)
 		return saveSHMCredentials(creds)
 	})
 }
@@ -392,6 +457,39 @@ func deleteSHMCredential(service, org string) error {
 			return oskeyring.ErrNotFound
 		}
 		delete(creds.Services[service], org)
+		creds.clearPreferredStore(service, org)
+		return saveSHMCredentials(creds)
+	})
+}
+
+func preferredSHMStore(service, org string) bool {
+	path := shmCredentialPath()
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	if err := validateSHMFile(path, info); err != nil {
+		return false
+	}
+	creds, err := readSHMCredentialsFile(path)
+	if err != nil {
+		return false
+	}
+	return creds.PreferredStores[service][org] == StoreSHM
+}
+
+func clearSHMPreferredStore(service, org string) error {
+	if !shmCredentialFileExists() {
+		return nil
+	}
+	return withSHMCredentialLock(func() error {
+		creds, err := loadSHMCredentials()
+		if err != nil {
+			return err
+		}
+		if !creds.clearPreferredStore(service, org) {
+			return nil
+		}
 		return saveSHMCredentials(creds)
 	})
 }
@@ -449,6 +547,18 @@ func loadSHMCredentials() (shmCredentials, error) {
 	if err != nil {
 		return shmCredentials{}, err
 	}
+	return readSHMCredentials(data)
+}
+
+func readSHMCredentialsFile(path string) (shmCredentials, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return shmCredentials{}, err
+	}
+	return readSHMCredentials(data)
+}
+
+func readSHMCredentials(data []byte) (shmCredentials, error) {
 	if len(data) == 0 {
 		return newSHMCredentials(), nil
 	}
@@ -457,9 +567,7 @@ func loadSHMCredentials() (shmCredentials, error) {
 	if err := json.Unmarshal(data, &creds); err != nil {
 		return shmCredentials{}, err
 	}
-	if creds.Services == nil {
-		creds.Services = make(map[string]map[string]string)
-	}
+	creds.ensureMaps()
 	return creds, nil
 }
 
@@ -468,9 +576,7 @@ func saveSHMCredentials(creds shmCredentials) error {
 	if err := ensureSHMStoreDir(path); err != nil {
 		return err
 	}
-	if creds.Services == nil {
-		creds.Services = make(map[string]map[string]string)
-	}
+	creds.ensureMaps()
 
 	data, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
@@ -501,11 +607,16 @@ func saveSHMCredentials(creds shmCredentials) error {
 
 func ensureSHMStoreDir(path string) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
+	createdDir := false
 
 	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		createdDir = true
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		info, err = os.Lstat(dir)
+	}
 	if err != nil {
 		return err
 	}
@@ -519,9 +630,13 @@ func ensureSHMStoreDir(path string) error {
 		return err
 	}
 	if info.Mode().Perm()&0o077 != 0 {
-		if err := os.Chmod(dir, 0o700); err != nil {
-			return err
+		if createdDir || os.Getenv(CredentialStorePathEnv) == "" {
+			if err := os.Chmod(dir, 0o700); err != nil {
+				return err
+			}
+			return nil
 		}
+		return fmt.Errorf("credential store directory %s must not be accessible by group or others", dir)
 	}
 	return nil
 }

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -214,6 +214,28 @@ func TestNewInvalidCredentialStoreEnvDoesNotFallbackToKeyring(t *testing.T) {
 	}
 }
 
+func TestExplicitKeyringCredentialStoreIgnoresCIDisable(t *testing.T) {
+	setEnv(t, "CI", "true")
+	setEnv(t, "BUILDKITE", "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, CredentialStorePathEnv, "")
+
+	kr, err := NewWithCredentialStore(StoreKeyring)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreKeyring, err)
+	}
+	if !kr.IsAvailable() {
+		t.Fatal("explicit keyring store reported unavailable under CI")
+	}
+
+	setEnv(t, CredentialStoreEnv, StoreKeyring)
+	kr = New()
+	if !kr.IsAvailable() {
+		t.Fatal("env-selected keyring store reported unavailable under CI")
+	}
+}
+
 func TestSHMCredentialStore(t *testing.T) {
 	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
@@ -490,6 +512,37 @@ func TestAutoCredentialStoreKeyringWriteDeletesSHMCredential(t *testing.T) {
 	}
 	if _, err := shmStore.Get("my-org"); !errors.Is(err, oskeyring.ErrNotFound) {
 		t.Fatalf("forced shm Get() after keyring Set() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestKeyringWriteIgnoresMalformedSHMCleanup(t *testing.T) {
+	path := shmCredentialPathForTest(t)
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create credential dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("write malformed credential file: %v", err)
+	}
+
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	if err := kr.Set("my-org", "keyring-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "keyring-token" {
+		t.Fatalf("Get() = %q, want keyring-token", token)
 	}
 }
 

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -34,6 +34,20 @@ func setEnv(t *testing.T, key, value string) {
 	ResetForTesting()
 }
 
+func shmCredentialPathForTest(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "bk-credentials", "credentials.json")
+}
+
+func privateTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod temp dir: %v", err)
+	}
+	return dir
+}
+
 func TestIsKeyringAvailable(t *testing.T) {
 	// These tests manipulate package-level state (sync.Once) so must not run
 	// in parallel with each other.
@@ -109,7 +123,7 @@ func TestNoKeyringSet(t *testing.T) {
 }
 
 func TestNoKeyringSetDoesNotCreateSHMStore(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 	setEnv(t, "CI", "true")
 	setEnv(t, "BUILDKITE_NO_KEYRING", "")
@@ -181,8 +195,27 @@ func TestValidateCredentialStore(t *testing.T) {
 	}
 }
 
+func TestNewInvalidCredentialStoreEnvDoesNotFallbackToKeyring(t *testing.T) {
+	setEnv(t, CredentialStoreEnv, "disk")
+	setEnv(t, CredentialStorePathEnv, "")
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	if kr.IsAvailable() {
+		t.Fatal("New() with invalid credential store env reported available")
+	}
+
+	if err := kr.Set("my-org", "token-123"); err == nil || !strings.Contains(err.Error(), "unsupported credential store") {
+		t.Fatalf("Set() error = %v, want unsupported credential store", err)
+	}
+	if _, err := kr.Get("my-org"); err == nil || !strings.Contains(err.Error(), "unsupported credential store") {
+		t.Fatalf("Get() error = %v, want unsupported credential store", err)
+	}
+}
+
 func TestSHMCredentialStore(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 
 	kr, err := NewWithCredentialStore(StoreSHM)
@@ -243,8 +276,42 @@ func TestSHMCredentialStore(t *testing.T) {
 	}
 }
 
+func TestSHMCredentialStoreRejectsUnsafeExistingEnvDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod credential dir: %v", err)
+	}
+	path := filepath.Join(dir, "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+
+	kr, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+
+	err = kr.Set("my-org", "access-token")
+	if err == nil {
+		t.Fatal("Set() error = nil, want unsafe directory rejection")
+	}
+	if !strings.Contains(err.Error(), "must not be accessible by group or others") {
+		t.Fatalf("Set() error = %v, want unsafe directory rejection", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat credential dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("credential dir mode = %#o, want unchanged 0755", got)
+	}
+}
+
 func TestSHMCredentialStoreSerializesConcurrentWrites(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 
 	kr, err := NewWithCredentialStore(StoreSHM)
@@ -291,7 +358,7 @@ func TestSHMCredentialStoreRejectsSymlinkFile(t *testing.T) {
 		t.Skip("symlink handling differs on Windows")
 	}
 
-	dir := t.TempDir()
+	dir := privateTempDir(t)
 	path := filepath.Join(dir, "credentials.json")
 	target := filepath.Join(dir, "target.json")
 
@@ -318,7 +385,7 @@ func TestSHMCredentialStoreRejectsSymlinkFile(t *testing.T) {
 }
 
 func TestAutoCredentialStoreReadsSHMFallback(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 	setEnv(t, CredentialStoreEnv, "")
 	setEnv(t, "BUILDKITE_NO_KEYRING", "")
@@ -357,8 +424,74 @@ func TestAutoCredentialStoreReadsSHMFallback(t *testing.T) {
 	}
 }
 
+func TestAutoCredentialStorePrefersMarkedSHMOverKeyring(t *testing.T) {
+	path := shmCredentialPathForTest(t)
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+
+	shmStore, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if err := shmStore.Set("my-org", "new-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+	if err := oskeyring.Set(serviceName, "my-org", "old-token"); err != nil {
+		t.Fatalf("seed keyring token: %v", err)
+	}
+
+	kr := New()
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "new-token" {
+		t.Fatalf("Get() = %q, want new-token", token)
+	}
+}
+
+func TestAutoCredentialStoreKeyringWriteClearsSHMPreference(t *testing.T) {
+	path := shmCredentialPathForTest(t)
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+
+	shmStore, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if err := shmStore.Set("my-org", "shm-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	if err := kr.Set("my-org", "keyring-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	fresh := New()
+	token, err := fresh.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "keyring-token" {
+		t.Fatalf("Get() = %q, want keyring-token", token)
+	}
+}
+
 func TestAutoCredentialStoreUsesExistingSHMWhenDisabledByEnv(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "credentials.json")
+	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 	setEnv(t, CredentialStoreEnv, "")
 	setEnv(t, "CI", "")

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -1,8 +1,16 @@
 package keyring
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
+
+	oskeyring "github.com/zalando/go-keyring"
 )
 
 // setEnv sets an environment variable for the duration of the test and
@@ -34,6 +42,8 @@ func TestIsKeyringAvailable(t *testing.T) {
 		setEnv(t, "BUILDKITE_NO_KEYRING", "1")
 		setEnv(t, "CI", "")
 		setEnv(t, "BUILDKITE", "")
+		setEnv(t, CredentialStoreEnv, "")
+		setEnv(t, CredentialStorePathEnv, "")
 
 		kr := New()
 		if kr.IsAvailable() {
@@ -45,6 +55,8 @@ func TestIsKeyringAvailable(t *testing.T) {
 		setEnv(t, "CI", "true")
 		setEnv(t, "BUILDKITE_NO_KEYRING", "")
 		setEnv(t, "BUILDKITE", "")
+		setEnv(t, CredentialStoreEnv, "")
+		setEnv(t, CredentialStorePathEnv, "")
 
 		kr := New()
 		if kr.IsAvailable() {
@@ -56,6 +68,8 @@ func TestIsKeyringAvailable(t *testing.T) {
 		setEnv(t, "BUILDKITE", "true")
 		setEnv(t, "BUILDKITE_NO_KEYRING", "")
 		setEnv(t, "CI", "")
+		setEnv(t, CredentialStoreEnv, "")
+		setEnv(t, CredentialStorePathEnv, "")
 
 		kr := New()
 		if kr.IsAvailable() {
@@ -68,6 +82,8 @@ func TestNoKeyringGet(t *testing.T) {
 	setEnv(t, "BUILDKITE_NO_KEYRING", "1")
 	setEnv(t, "CI", "")
 	setEnv(t, "BUILDKITE", "")
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, CredentialStorePathEnv, "")
 
 	kr := New()
 	token, err := kr.Get("my-org")
@@ -83,6 +99,8 @@ func TestNoKeyringSet(t *testing.T) {
 	setEnv(t, "BUILDKITE_NO_KEYRING", "1")
 	setEnv(t, "CI", "")
 	setEnv(t, "BUILDKITE", "")
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, CredentialStorePathEnv, "")
 
 	kr := New()
 	if err := kr.Set("my-org", "token-123"); err != nil {
@@ -90,13 +108,319 @@ func TestNoKeyringSet(t *testing.T) {
 	}
 }
 
+func TestNoKeyringSetDoesNotCreateSHMStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, "CI", "true")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "BUILDKITE", "")
+	setEnv(t, CredentialStoreEnv, "")
+
+	kr := New()
+	if kr.IsAvailable() {
+		t.Fatal("expected auto credential store to be unavailable without an existing shm store")
+	}
+	if err := kr.Set("my-org", "token-123"); err != nil {
+		t.Errorf("Set() returned unexpected error with keyring disabled: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("credential file exists after auto Set() with keyring disabled, err=%v", err)
+	}
+}
+
 func TestNoKeyringDelete(t *testing.T) {
 	setEnv(t, "BUILDKITE_NO_KEYRING", "1")
 	setEnv(t, "CI", "")
 	setEnv(t, "BUILDKITE", "")
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, CredentialStorePathEnv, "")
 
 	kr := New()
 	if err := kr.Delete("my-org"); err != nil {
 		t.Errorf("Delete() returned unexpected error with keyring disabled: %v", err)
+	}
+}
+
+func TestMockForTestingBypassesCredentialStorageDisabledEnv(t *testing.T) {
+	setEnv(t, "BUILDKITE", "true")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, CredentialStorePathEnv, "")
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	if !kr.IsAvailable() {
+		t.Fatal("expected mocked keyring to be available when BUILDKITE is set")
+	}
+
+	if err := kr.Set("my-org", "token-123"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "token-123" {
+		t.Fatalf("Get() = %q, want token-123", token)
+	}
+}
+
+func TestValidateCredentialStore(t *testing.T) {
+	t.Parallel()
+
+	for _, store := range []string{"", StoreAuto, StoreKeyring, StoreSHM} {
+		if err := ValidateCredentialStore(store); err != nil {
+			t.Fatalf("ValidateCredentialStore(%q) error = %v", store, err)
+		}
+	}
+
+	if err := ValidateCredentialStore("disk"); err == nil {
+		t.Fatal("ValidateCredentialStore(\"disk\") error = nil, want error")
+	}
+}
+
+func TestSHMCredentialStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+
+	kr, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if !kr.IsAvailable() {
+		t.Fatal("expected shm credential store to be available")
+	}
+
+	if err := kr.Set("my-org", "access-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := kr.SetRefreshToken("my-org", "refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() error = %v", err)
+	}
+	if got := kr.Description(); got != "the /dev/shm credential store" {
+		t.Fatalf("Description() = %q, want shm description", got)
+	}
+
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("Get() = %q, want access-token", token)
+	}
+
+	refreshToken, err := kr.GetRefreshToken("my-org")
+	if err != nil {
+		t.Fatalf("GetRefreshToken() error = %v", err)
+	}
+	if refreshToken != "refresh-token" {
+		t.Fatalf("GetRefreshToken() = %q, want refresh-token", refreshToken)
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat credential dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("credential dir mode = %#o, want 0700", got)
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential file mode = %#o, want 0600", got)
+	}
+
+	if err := kr.Delete("my-org"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := kr.Get("my-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("Get() after delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSHMCredentialStoreSerializesConcurrentWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+
+	kr, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+
+	const writeCount = 50
+	var wg sync.WaitGroup
+	errCh := make(chan error, writeCount)
+	for i := range writeCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			org := fmt.Sprintf("org-%02d", i)
+			token := fmt.Sprintf("token-%02d", i)
+			errCh <- kr.Set(org, token)
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+	}
+
+	for i := range writeCount {
+		org := fmt.Sprintf("org-%02d", i)
+		want := fmt.Sprintf("token-%02d", i)
+		got, err := kr.Get(org)
+		if err != nil {
+			t.Fatalf("Get(%q) error = %v", org, err)
+		}
+		if got != want {
+			t.Fatalf("Get(%q) = %q, want %q", org, got, want)
+		}
+	}
+}
+
+func TestSHMCredentialStoreRejectsSymlinkFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink handling differs on Windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.json")
+	target := filepath.Join(dir, "target.json")
+
+	if err := os.WriteFile(target, []byte(`{"services":{}}`), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	setEnv(t, CredentialStorePathEnv, path)
+
+	kr, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+
+	err = kr.Set("my-org", "token")
+	if err == nil {
+		t.Fatal("Set() error = nil, want symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "cannot be a symlink") {
+		t.Fatalf("Set() error = %v, want symlink rejection", err)
+	}
+}
+
+func TestAutoCredentialStoreReadsSHMFallback(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+
+	shmStore, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if err := shmStore.Set("my-org", "access-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := shmStore.SetRefreshToken("my-org", "refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() error = %v", err)
+	}
+
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("Get() = %q, want access-token", token)
+	}
+
+	refreshToken, err := kr.GetRefreshToken("my-org")
+	if err != nil {
+		t.Fatalf("GetRefreshToken() error = %v", err)
+	}
+	if refreshToken != "refresh-token" {
+		t.Fatalf("GetRefreshToken() = %q, want refresh-token", refreshToken)
+	}
+}
+
+func TestAutoCredentialStoreUsesExistingSHMWhenDisabledByEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+
+	shmStore, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if err := shmStore.Set("my-org", "access-token"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := shmStore.SetRefreshToken("my-org", "refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() error = %v", err)
+	}
+
+	setEnv(t, "CI", "true")
+	kr := New()
+	if !kr.IsAvailable() {
+		t.Fatal("expected auto credential store to use existing shm store when CI disables new storage")
+	}
+
+	token, err := kr.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if token != "access-token" {
+		t.Fatalf("Get() = %q, want access-token", token)
+	}
+
+	refreshToken, err := kr.GetRefreshToken("my-org")
+	if err != nil {
+		t.Fatalf("GetRefreshToken() error = %v", err)
+	}
+	if refreshToken != "refresh-token" {
+		t.Fatalf("GetRefreshToken() = %q, want refresh-token", refreshToken)
+	}
+
+	if err := kr.Set("my-org", "rotated-access-token"); err != nil {
+		t.Fatalf("Set() under disabled env error = %v", err)
+	}
+	if err := kr.SetRefreshToken("my-org", "rotated-refresh-token"); err != nil {
+		t.Fatalf("SetRefreshToken() under disabled env error = %v", err)
+	}
+	if token, err := shmStore.Get("my-org"); err != nil || token != "rotated-access-token" {
+		t.Fatalf("forced shm Get() after auto Set() = %q, %v; want rotated-access-token, nil", token, err)
+	}
+	if token, err := shmStore.GetRefreshToken("my-org"); err != nil || token != "rotated-refresh-token" {
+		t.Fatalf("forced shm GetRefreshToken() after auto SetRefreshToken() = %q, %v; want rotated-refresh-token, nil", token, err)
+	}
+
+	if err := kr.Delete("my-org"); err != nil {
+		t.Fatalf("Delete() under disabled env error = %v", err)
+	}
+	if err := kr.DeleteRefreshToken("my-org"); err != nil {
+		t.Fatalf("DeleteRefreshToken() under disabled env error = %v", err)
+	}
+	if _, err := shmStore.Get("my-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("forced shm Get() after auto Delete() error = %v, want ErrNotFound", err)
+	}
+	if _, err := shmStore.GetRefreshToken("my-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("forced shm GetRefreshToken() after auto DeleteRefreshToken() error = %v, want ErrNotFound", err)
 	}
 }

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -456,7 +456,7 @@ func TestAutoCredentialStorePrefersMarkedSHMOverKeyring(t *testing.T) {
 	}
 }
 
-func TestAutoCredentialStoreKeyringWriteClearsSHMPreference(t *testing.T) {
+func TestAutoCredentialStoreKeyringWriteDeletesSHMCredential(t *testing.T) {
 	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)
 	setEnv(t, CredentialStoreEnv, "")
@@ -487,6 +487,9 @@ func TestAutoCredentialStoreKeyringWriteClearsSHMPreference(t *testing.T) {
 	}
 	if token != "keyring-token" {
 		t.Fatalf("Get() = %q, want keyring-token", token)
+	}
+	if _, err := shmStore.Get("my-org"); !errors.Is(err, oskeyring.ErrNotFound) {
+		t.Fatalf("forced shm Get() after keyring Set() error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/pkg/keyring/keyring_test.go
+++ b/pkg/keyring/keyring_test.go
@@ -515,6 +515,53 @@ func TestAutoCredentialStoreKeyringWriteDeletesSHMCredential(t *testing.T) {
 	}
 }
 
+func TestAutoCredentialStoreKeyringWriteSurfacesPreferredSHMCleanupFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod semantics differ on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root can write through read-only directory permissions")
+	}
+
+	path := shmCredentialPathForTest(t)
+	setEnv(t, CredentialStorePathEnv, path)
+	setEnv(t, CredentialStoreEnv, "")
+	setEnv(t, "BUILDKITE_NO_KEYRING", "")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+
+	shmStore, err := NewWithCredentialStore(StoreSHM)
+	if err != nil {
+		t.Fatalf("NewWithCredentialStore(%q) error = %v", StoreSHM, err)
+	}
+	if err := shmStore.Set("my-org", "shm-token"); err != nil {
+		t.Fatalf("Set() shm error = %v", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod credential dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	MockForTesting()
+	t.Cleanup(ResetForTesting)
+
+	kr := New()
+	if err := kr.Set("my-org", "keyring-token"); err == nil {
+		t.Fatal("Set() error = nil, want SHM cleanup failure")
+	}
+
+	fresh := New()
+	token, err := fresh.Get("my-org")
+	if err != nil {
+		t.Fatalf("Get() after failed cleanup error = %v", err)
+	}
+	if token != "shm-token" {
+		t.Fatalf("Get() after failed cleanup = %q, want stale shm-token", token)
+	}
+}
+
 func TestKeyringWriteIgnoresMalformedSHMCleanup(t *testing.T) {
 	path := shmCredentialPathForTest(t)
 	setEnv(t, CredentialStorePathEnv, path)

--- a/pkg/keyring/owner_unix.go
+++ b/pkg/keyring/owner_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package keyring
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileOwnerUID(info os.FileInfo) (uint32, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return stat.Uid, true
+}
+
+func lockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/keyring/owner_windows.go
+++ b/pkg/keyring/owner_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package keyring
+
+import "os"
+
+func fileOwnerUID(os.FileInfo) (uint32, bool) {
+	return 0, false
+}
+
+func lockFile(*os.File) error {
+	return nil
+}
+
+func unlockFile(*os.File) error {
+	return nil
+}


### PR DESCRIPTION
Headless Linux users can complete OAuth device auth now, but the CLI still tries to persist tokens in a desktop keyring. On machines without a working keyring, or where gnome-keyring loses the login item, users fall back to `BUILDKITE_API_TOKEN`.

This adds an explicit `--credential-store shm` mode for `bk auth login` that stores access and refresh tokens in a 0600 JSON file under a per-user `/dev/shm/buildkite-cli-<uid>/` directory. The default `auto` mode still prefers the OS keyring, but can fall back to the shm store and read it later so users do not need to pass a flag on every command.

Example:

```sh
bk auth login --device --credential-store shm
```

The shm store is ephemeral and clears on reboot, which matches the issue request for a headless/session-like credential store without writing tokens to shell env or persistent config.

Fixes #807