### PR TITLE
chore(docker): never use `latest` image tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o bk .
 
-FROM alpine:latest
+FROM alpine:3.22.4
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
### Description

Dockerfiles shouldn't ever use `latest` tags.

### Changes

Changes the `alpine` image to use a pinned version.

### Testing
- [x] Run `docker build -t cli .`

