### PR TITLE
Build on branches and remove Mise from build step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,8 +39,6 @@ steps:
   - label: ":terminal: build ({{matrix}})"
     key: build
     depends_on: ["lint", "test", "vulncheck"]
-    branches:
-      - main
     matrix:
           - "darwin"
           - "linux"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,6 @@ steps:
     env:
       MISE_ENV: release
     secrets:
-      - MISE_GITHUB_TOKEN
       - POSTHOG_API_KEY
       - OAUTH_CLIENT_ID
     command: 'GOOS="{{matrix}}" .buildkite/release.sh release --clean --snapshot --split'


### PR DESCRIPTION
### Description

Reinstates building the binaries on branches as an early signal for failure on `main`.

### Changes

- removes the `branches` filter on the pipeline so we build on all branches
    - `main` being the first failure here isn't good
- removes the Mise token from the `build` step as it's not required and causing the failure
    - causes issue with go-releaser pro access

