### PR TITLE
fix: remove the mise token from release step

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -42,7 +42,6 @@ steps:
       AWS_REGION: us-east-1
       MISE_ENV: release
     secrets:
-      - MISE_GITHUB_TOKEN
       - POSTHOG_API_KEY
       - OAUTH_CLIENT_ID
     plugins:


### PR DESCRIPTION
### Description

Remove the use of the mise token from the `release` step, too.

