### PR TITLE
Fix package upload to packages.buildkite.com

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -39,4 +39,4 @@ steps:
     plugins:
       - artifacts#v1.9.4:
           download:
-            - dist/linux/*
+            - dist/*

--- a/.buildkite/upload-packages.sh
+++ b/.buildkite/upload-packages.sh
@@ -37,7 +37,7 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-for FILE in dist/linux/*.${PACKAGE}; do
+for FILE in dist/*.${PACKAGE}; do
     echo "--- Pushing $FILE"
     if [[ $PACKAGE = "apk" ]]; then
         curl -s -X POST $(upload_url $ORGANIZATION $REGISTRY) \


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Non-split `goreleaser release` writes artifacts flat to dist/ instead of dist/$GOOS/ (see https://github.com/buildkite/cli/pull/864 for context). Update path in the pipeline and script to reflect that.

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing
- [ ] Tests have run locally (with `go test ./...`)
- [ ] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
