### PR TITLE
Update go-buildkite to v5

### DIFF
--- a/cmd/agent/list.go
+++ b/cmd/agent/list.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 const (

--- a/cmd/agent/list_test.go
+++ b/cmd/agent/list_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func testFilterAgents(agents []buildkite.Agent, state string, tags []string) []buildkite.Agent {

--- a/cmd/agent/pause.go
+++ b/cmd/agent/pause.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/cli"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type PauseCmd struct {

--- a/cmd/agent/view.go
+++ b/cmd/agent/view.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/pkg/browser"
 )
 

--- a/cmd/artifacts/download.go
+++ b/cmd/artifacts/download.go
@@ -16,7 +16,7 @@ import (
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type DownloadCmd struct {

--- a/cmd/artifacts/list.go
+++ b/cmd/artifacts/list.go
@@ -16,7 +16,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ListCmd struct {

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 
 	"github.com/buildkite/cli/v3/internal/cli"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/buildkite/cli/v3/pkg/oauth"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	oskeyring "github.com/zalando/go-keyring"
 )
 

--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 type StatusOutput struct {

--- a/cmd/build/cancel.go
+++ b/cmd/build/cancel.go
@@ -12,7 +12,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CancelCmd struct {

--- a/cmd/build/create.go
+++ b/cmd/build/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -18,7 +18,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 const (

--- a/cmd/build/list_test.go
+++ b/cmd/build/list_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type buildListOptions struct {

--- a/cmd/build/rebuild.go
+++ b/cmd/build/rebuild.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type RebuildCmd struct {

--- a/cmd/build/view.go
+++ b/cmd/build/view.go
@@ -16,7 +16,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/pkg/browser"
 )
 

--- a/cmd/build/watch.go
+++ b/cmd/build/watch.go
@@ -17,7 +17,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/validation"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	pkgValidation "github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/mattn/go-isatty"
 )
 

--- a/cmd/cluster/cluster_test.go
+++ b/cmd/cluster/cluster_test.go
@@ -214,24 +214,24 @@ func TestUpdateCluster(t *testing.T) {
 				t.Errorf("unexpected path: %s", r.URL.Path)
 			}
 
-			var input buildkite.ClusterUpdate
+			var input map[string]string
 			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 				t.Fatal(err)
 			}
 
-			if input.Name != "Updated Name" {
-				t.Errorf("expected name 'Updated Name', got %q", input.Name)
+			if input["name"] != "Updated Name" {
+				t.Errorf("expected name 'Updated Name', got %q", input["name"])
 			}
 
-			if input.Description != "Updated description" {
-				t.Errorf("expected description 'Updated description', got %q", input.Description)
+			if input["description"] != "Updated description" {
+				t.Errorf("expected description 'Updated description', got %q", input["description"])
 			}
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(buildkite.Cluster{
 				ID:          "cluster-1",
-				Name:        input.Name,
-				Description: input.Description,
+				Name:        input["name"],
+				Description: input["description"],
 			})
 		}))
 		defer s.Close()
@@ -242,8 +242,8 @@ func TestUpdateCluster(t *testing.T) {
 		}
 
 		result, _, err := client.Clusters.Update(context.Background(), "test-org", "cluster-1", buildkite.ClusterUpdate{
-			Name:        "Updated Name",
-			Description: "Updated description",
+			Name:        buildkite.Some("Updated Name"),
+			Description: buildkite.Some("Updated description"),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -266,20 +266,20 @@ func TestUpdateCluster(t *testing.T) {
 				t.Errorf("expected PATCH, got %s", r.Method)
 			}
 
-			var input buildkite.ClusterUpdate
+			var input map[string]string
 			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 				t.Fatal(err)
 			}
 
-			if input.DefaultQueueID != "queue-123" {
-				t.Errorf("expected default_queue_id 'queue-123', got %q", input.DefaultQueueID)
+			if input["default_queue_id"] != "queue-123" {
+				t.Errorf("expected default_queue_id 'queue-123', got %q", input["default_queue_id"])
 			}
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(buildkite.Cluster{
 				ID:             "cluster-1",
 				Name:           "Production",
-				DefaultQueueID: input.DefaultQueueID,
+				DefaultQueueID: input["default_queue_id"],
 			})
 		}))
 		defer s.Close()
@@ -290,7 +290,7 @@ func TestUpdateCluster(t *testing.T) {
 		}
 
 		result, _, err := client.Clusters.Update(context.Background(), "test-org", "cluster-1", buildkite.ClusterUpdate{
-			DefaultQueueID: "queue-123",
+			DefaultQueueID: buildkite.Some("queue-123"),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/cluster/cluster_test.go
+++ b/cmd/cluster/cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestListClusters(t *testing.T) {

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -16,7 +16,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ListCmd struct {

--- a/cmd/cluster/update.go
+++ b/cmd/cluster/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type UpdateCmd struct {

--- a/cmd/cluster/update.go
+++ b/cmd/cluster/update.go
@@ -74,12 +74,21 @@ func (c *UpdateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	input := buildkite.ClusterUpdate{
-		Name:           c.Name,
-		Description:    c.Description,
-		Emoji:          c.Emoji,
-		Color:          c.Color,
-		DefaultQueueID: c.DefaultQueueID,
+	input := buildkite.ClusterUpdate{}
+	if c.Name != "" {
+		input.Name = buildkite.Some(c.Name)
+	}
+	if c.Description != "" {
+		input.Description = buildkite.Some(c.Description)
+	}
+	if c.Emoji != "" {
+		input.Emoji = buildkite.Some(c.Emoji)
+	}
+	if c.Color != "" {
+		input.Color = buildkite.Some(c.Color)
+	}
+	if c.DefaultQueueID != "" {
+		input.DefaultQueueID = buildkite.Some(c.DefaultQueueID)
 	}
 
 	var cluster buildkite.Cluster

--- a/cmd/cluster/view.go
+++ b/cmd/cluster/view.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ViewCmd struct {

--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -19,7 +19,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 const (

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestDisplayJobs_EmptyJSON(t *testing.T) {

--- a/cmd/job/reprioritize.go
+++ b/cmd/job/reprioritize.go
@@ -9,7 +9,7 @@ import (
 	bkIO "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ReprioritizeCmd struct {

--- a/cmd/job/rest.go
+++ b/cmd/job/rest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type unblockJobOptions struct {

--- a/cmd/job/retry.go
+++ b/cmd/job/retry.go
@@ -9,7 +9,7 @@ import (
 	bkIO "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type RetryCmd struct {

--- a/cmd/job/retry_test.go
+++ b/cmd/job/retry_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestRetryJobUsesOrganizationEndpoint(t *testing.T) {

--- a/cmd/job/unblock.go
+++ b/cmd/job/unblock.go
@@ -14,7 +14,7 @@ import (
 	bkIO "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type UnblockCmd struct {

--- a/cmd/job/unblock_test.go
+++ b/cmd/job/unblock_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestParseUnblockFields(t *testing.T) {

--- a/cmd/maintainer/create.go
+++ b/cmd/maintainer/create.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/maintainer/list.go
+++ b/cmd/maintainer/list.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ListCmd struct {

--- a/cmd/maintainer/maintainer_test.go
+++ b/cmd/maintainer/maintainer_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestListMaintainers(t *testing.T) {

--- a/cmd/pipeline/copy.go
+++ b/cmd/pipeline/copy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CopyCmd struct {

--- a/cmd/pipeline/create.go
+++ b/cmd/pipeline/create.go
@@ -16,7 +16,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 const (

--- a/cmd/pipeline/view.go
+++ b/cmd/pipeline/view.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/pkg/browser"
 )
 

--- a/cmd/pkg/push.go
+++ b/cmd/pkg/push.go
@@ -12,7 +12,7 @@ import (
 	bkIO "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/util"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/cmd/preflight/cleanup_cmd_test.go
+++ b/cmd/preflight/cleanup_cmd_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/config"
 	bkErrors "github.com/buildkite/cli/v3/internal/errors"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestCleanupCmd_Run(t *testing.T) {

--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // EventType identifies the kind of preflight event.

--- a/cmd/preflight/event_test.go
+++ b/cmd/preflight/event_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestEvent_Operation(t *testing.T) {

--- a/cmd/preflight/job_presenter.go
+++ b/cmd/preflight/job_presenter.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
 	"github.com/buildkite/cli/v3/internal/emoji"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/charmbracelet/lipgloss"
 )
 

--- a/cmd/preflight/job_presenter_test.go
+++ b/cmd/preflight/job_presenter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestJobPresenter_FailedLine(t *testing.T) {

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -26,7 +26,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type RunCmd struct {

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/config"
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
 	bkErrors "github.com/buildkite/cli/v3/internal/errors"

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/build/watch"
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 var ansiCodesPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)

--- a/cmd/preflight/result.go
+++ b/cmd/preflight/result.go
@@ -5,7 +5,7 @@ import (
 
 	buildstate "github.com/buildkite/cli/v3/internal/build/state"
 	bkErrors "github.com/buildkite/cli/v3/internal/errors"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type resultKind int

--- a/cmd/preflight/result_test.go
+++ b/cmd/preflight/result_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	bkErrors "github.com/buildkite/cli/v3/internal/errors"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestResult(t *testing.T) {

--- a/cmd/preflight/test_presenter.go
+++ b/cmd/preflight/test_presenter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type testPresenter struct{}

--- a/cmd/preflight/tty_test.go
+++ b/cmd/preflight/tty_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestBuildSummaryView_ReturnsOutput(t *testing.T) {

--- a/cmd/queue/create.go
+++ b/cmd/queue/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/queue/list.go
+++ b/cmd/queue/list.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ListCmd struct {

--- a/cmd/queue/pause.go
+++ b/cmd/queue/pause.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type PauseCmd struct {

--- a/cmd/queue/queue_test.go
+++ b/cmd/queue/queue_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func newTestQueue(key, id string, paused bool) buildkite.ClusterQueue {

--- a/cmd/queue/queue_test.go
+++ b/cmd/queue/queue_test.go
@@ -252,7 +252,7 @@ func TestCmdQueueUpdate(t *testing.T) {
 
 		ctx := context.Background()
 		got, _, err := client.ClusterQueues.Update(ctx, "test-org", "cluster-1", "queue-abc", buildkite.ClusterQueueUpdate{
-			Description: "Updated description",
+			Description: buildkite.Some("Updated description"),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/queue/resume.go
+++ b/cmd/queue/resume.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ResumeCmd struct {

--- a/cmd/queue/update.go
+++ b/cmd/queue/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type UpdateCmd struct {

--- a/cmd/queue/update.go
+++ b/cmd/queue/update.go
@@ -81,11 +81,12 @@ func (c *UpdateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	input := buildkite.ClusterQueueUpdate{
-		Description: c.Description,
+	input := buildkite.ClusterQueueUpdate{}
+	if c.Description != "" {
+		input.Description = buildkite.Some(c.Description)
 	}
 	if c.RetryAgentAffinity != "" {
-		input.RetryAgentAffinity = buildkite.RetryAgentAffinity(c.RetryAgentAffinity)
+		input.RetryAgentAffinity = buildkite.Some(buildkite.RetryAgentAffinity(c.RetryAgentAffinity))
 	}
 
 	var queue buildkite.ClusterQueue

--- a/cmd/queue/view.go
+++ b/cmd/queue/view.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ViewCmd struct {

--- a/cmd/secret/create.go
+++ b/cmd/secret/create.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type CreateCmd struct {

--- a/cmd/secret/get.go
+++ b/cmd/secret/get.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type GetCmd struct {

--- a/cmd/secret/list.go
+++ b/cmd/secret/list.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type ListCmd struct {

--- a/cmd/secret/secret_test.go
+++ b/cmd/secret/secret_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestListSecrets(t *testing.T) {

--- a/cmd/secret/secret_test.go
+++ b/cmd/secret/secret_test.go
@@ -224,20 +224,20 @@ func TestUpdateSecret(t *testing.T) {
 				t.Errorf("expected PUT, got %s", r.Method)
 			}
 
-			var input buildkite.ClusterSecretUpdate
+			var input map[string]string
 			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 				t.Fatal(err)
 			}
 
-			if input.Description != "Updated description" {
-				t.Errorf("expected description 'Updated description', got %q", input.Description)
+			if input["description"] != "Updated description" {
+				t.Errorf("expected description 'Updated description', got %q", input["description"])
 			}
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(buildkite.ClusterSecret{
 				ID:          "secret-1",
 				Key:         "MY_SECRET",
-				Description: input.Description,
+				Description: input["description"],
 			})
 		}))
 		defer s.Close()
@@ -248,7 +248,7 @@ func TestUpdateSecret(t *testing.T) {
 		}
 
 		result, _, err := client.ClusterSecrets.Update(context.Background(), "test-org", "cluster-123", "secret-1", buildkite.ClusterSecretUpdate{
-			Description: "Updated description",
+			Description: buildkite.Some("Updated description"),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/secret/update.go
+++ b/cmd/secret/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type UpdateCmd struct {

--- a/cmd/secret/update.go
+++ b/cmd/secret/update.go
@@ -96,12 +96,17 @@ func (c *UpdateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	var secret buildkite.ClusterSecret
 	if c.Description != "" || c.Policy != "" {
+		input := buildkite.ClusterSecretUpdate{}
+		if c.Description != "" {
+			input.Description = buildkite.Some(c.Description)
+		}
+		if c.Policy != "" {
+			input.Policy = buildkite.Some(c.Policy)
+		}
+
 		if err = bkIO.SpinWhile(f, "Updating secret", func() error {
 			var apiErr error
-			secret, _, apiErr = f.RestAPIClient.ClusterSecrets.Update(ctx, org, c.ClusterUUID, c.SecretID, buildkite.ClusterSecretUpdate{
-				Description: c.Description,
-				Policy:      c.Policy,
-			})
+			secret, _, apiErr = f.RestAPIClient.ClusterSecrets.Update(ctx, org, c.ClusterUUID, c.SecretID, input)
 			return apiErr
 		}); err != nil {
 			return fmt.Errorf("error updating secret: %v", err)

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 type WhoAmIOutput struct {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	github.com/buildkite/go-buildkite/v4 v4.23.0
+	github.com/buildkite/go-buildkite/v5 v5.0.1
 	github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -28,6 +28,7 @@ require (
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
+	github.com/buildkite/go-buildkite/v5 v5.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,10 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v4 v4.23.0 h1:GlLgPzGz/+B/4Fc5CphIxynoQn00SdSu6QQp4PlAI3M=
-github.com/buildkite/go-buildkite/v4 v4.23.0/go.mod h1:t/M4DUcs7qyebtzm3nkyZ1zUB/svWnKtR+uRU2Ca8tQ=
+github.com/buildkite/go-buildkite/v5 v4.23.0 h1:GlLgPzGz/+B/4Fc5CphIxynoQn00SdSu6QQp4PlAI3M=
+github.com/buildkite/go-buildkite/v5 v4.23.0/go.mod h1:t/M4DUcs7qyebtzm3nkyZ1zUB/svWnKtR+uRU2Ca8tQ=
+github.com/buildkite/go-buildkite/v5 v5.0.1 h1:JCN5NTtcyRbg0jJ4vaNUO2Jca/BWUrJC+4ugEFjHkdw=
+github.com/buildkite/go-buildkite/v5 v5.0.1/go.mod h1:wsKNPQmX0vAAR+RcGLyDJkSTsHXrHpnwSURaMckM7Wg=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1 h1:aaEl0QZURcwC+KOfFTzSp66xknw5eTmFZ1NgB87s2xk=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1/go.mod h1:ZTEvQlMN3+qzjROvjRb1p0X+xDQxxKpkMFhMSnaTrpw=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/agent/token.go
+++ b/internal/agent/token.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // FindCluster resolves a cluster for the given org. If clusterID is provided,

--- a/internal/agent/token.go
+++ b/internal/agent/token.go
@@ -33,7 +33,7 @@ func FindCluster(ctx context.Context, f *factory.Factory, org, clusterID string)
 
 // CreateAgentToken creates an agent token on the given cluster and returns the token string.
 func CreateAgentToken(ctx context.Context, f *factory.Factory, org, clusterID, description string) (string, error) {
-	token, _, err := f.RestAPIClient.ClusterTokens.Create(ctx, org, clusterID, buildkite.ClusterTokenCreateUpdate{
+	token, _, err := f.RestAPIClient.ClusterTokens.Create(ctx, org, clusterID, buildkite.ClusterTokenCreate{
 		Description: description,
 	})
 	if err != nil {

--- a/internal/annotation/list.go
+++ b/internal/annotation/list.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // AnnotationSummary renders a summary of a build annotation

--- a/internal/artifact/view.go
+++ b/internal/artifact/view.go
@@ -2,7 +2,7 @@ package artifact
 
 import (
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // ArtifactSummary renders a summary of a build artifact

--- a/internal/build/resolver/options/options.go
+++ b/internal/build/resolver/options/options.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 )
 

--- a/internal/build/resolver/options/options_test.go
+++ b/internal/build/resolver/options/options_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 )

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/build/resolver/options"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.PipelineResolverFn, listOpts ...options.OptionsFn) BuildResolverFn {

--- a/internal/build/view/shared/summary.go
+++ b/internal/build/view/shared/summary.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"github.com/buildkite/cli/v3/internal/build/view"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // BuildSummary renders a build summary that can be used by multiple commands

--- a/internal/build/view/view.go
+++ b/internal/build/view/view.go
@@ -9,7 +9,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/emoji"
 	"github.com/buildkite/cli/v3/internal/validation"
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // ViewOptions represents options for viewing a build

--- a/internal/build/view/view_test.go
+++ b/internal/build/view/view_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestBuildSummary_NilBuild(t *testing.T) {

--- a/internal/build/watch/job.go
+++ b/internal/build/watch/job.go
@@ -3,7 +3,7 @@ package watch
 import (
 	"time"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // FormattedJob wraps a Buildkite job with watch-specific formatting and classification helpers.

--- a/internal/build/watch/test_tracker.go
+++ b/internal/build/watch/test_tracker.go
@@ -1,7 +1,7 @@
 package watch
 
 import (
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // TestTracker tracks which test executions have already been reported,

--- a/internal/build/watch/test_tracker_test.go
+++ b/internal/build/watch/test_tracker_test.go
@@ -3,7 +3,7 @@ package watch
 import (
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestTestTracker_Update(t *testing.T) {

--- a/internal/build/watch/tracker.go
+++ b/internal/build/watch/tracker.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // trackedJob holds a job and its lifecycle state across polls.

--- a/internal/build/watch/tracker_test.go
+++ b/internal/build/watch/tracker_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestJobTracker_Update(t *testing.T) {

--- a/internal/build/watch/watch.go
+++ b/internal/build/watch/watch.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	buildstate "github.com/buildkite/cli/v3/internal/build/state"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 const (

--- a/internal/build/watch/watch_test.go
+++ b/internal/build/watch/watch_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestWatchBuild(t *testing.T) {

--- a/internal/cluster/query.go
+++ b/internal/cluster/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/graphql"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func GetQueues(ctx context.Context, f *factory.Factory, orgSlug string, clusterID string, lo *buildkite.ClusterQueuesListOptions) ([]buildkite.ClusterQueue, error) {

--- a/internal/cluster/view.go
+++ b/internal/cluster/view.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // ClusterViewTable renders a table view of one or more clusters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/keyring"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/afero"

--- a/internal/job/view.go
+++ b/internal/job/view.go
@@ -2,7 +2,7 @@ package job
 
 import (
 	"github.com/buildkite/cli/v3/internal/build/view"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type Job buildkite.Job

--- a/internal/pipeline/resolver/repository.go
+++ b/internal/pipeline/resolver/repository.go
@@ -9,7 +9,7 @@ import (
 	bkIO "github.com/buildkite/cli/v3/internal/io"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 )
 

--- a/internal/pipeline/resolver/repository_test.go
+++ b/internal/pipeline/resolver/repository_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/spf13/afero"

--- a/internal/preflight/branch_build.go
+++ b/internal/preflight/branch_build.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	buildstate "github.com/buildkite/cli/v3/internal/build/state"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // BranchBuild represents a preflight branch and its associated build status.

--- a/internal/preflight/branch_build_test.go
+++ b/internal/preflight/branch_build_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestResolveBuilds_BatchesRequestsToAvoidLongQuery(t *testing.T) {

--- a/internal/preflight/cleanup_test.go
+++ b/internal/preflight/cleanup_test.go
@@ -3,7 +3,7 @@ package preflight
 import (
 	"testing"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/google/uuid"
 )
 

--- a/internal/preflight/run_summary.go
+++ b/internal/preflight/run_summary.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type SummaryOptions struct {

--- a/internal/secret/view.go
+++ b/internal/secret/view.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"github.com/buildkite/cli/v3/pkg/output"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 // SecretViewTable renders a table view of one or more cluster secrets

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/config"
 	bkhttp "github.com/buildkite/cli/v3/internal/http"
 	"github.com/buildkite/cli/v3/pkg/keyring"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	git "github.com/go-git/go-git/v5"
 )
 

--- a/pkg/cmd/factory/factory_test.go
+++ b/pkg/cmd/factory/factory_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/pkg/keyring"
-	buildkite "github.com/buildkite/go-buildkite/v4"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/spf13/afero"
 )
 


### PR DESCRIPTION
### Description

I'd like the CLI to upgrade to go-buildkite `v5.x.x` so that it can take advantage of some of the newer additions. It'll also be a requirement for using `buildkite-logs` so that local log caching can happen.

### Changes

- updates the go-buildkite dependency to `v5`
- adjusts go-buildkite API interactions to match new function names

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Did this myself. Look at me go.

