### PR TITLE
fix(config): release archive formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,8 +83,7 @@ archives:
     ids: [macos]
     name_template: "bk_{{ .Version }}_macOS_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
-    format_overrides:
-      - formats: ["zip"]
+    formats: ["zip"]
     files:
       - LICENSE.md
       - README.md
@@ -93,8 +92,7 @@ archives:
     ids: [linux]
     name_template: "bk_{{ .Version }}_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
-    format_overrides:
-      - formats: ["tar.gz"]
+    formats: ["tar.gz"]
     files:
       - LICENSE.md
       - README.md
@@ -103,8 +101,7 @@ archives:
     ids: [windows]
     name_template: "bk_{{ .Version }}_windows_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: false
-    format_overrides:
-      - formats: ["zip"]
+    formats: ["zip"]
     files:
       - LICENSE.md
       - README.md


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

Fixes a regression in release formats, so Windows and macOS archives ship as .zip instead of .tar.gz. This allows support for the Windows Package Manager via a [third-party tool](https://github.com/UnownPlain/anthelion/actions/runs/27487884706).

### Changes

<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `bk <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->

The `format` GoReleaser config has been deprecated in favour of `formats`, but #864 introduced `format_overrides` instead. This swaps to `formats`

### Testing
- `MISE_ENV=release mise exec -- goreleaser check`


### Disclosures / Credits

<!--
If you used AI in any way to produce this PR (beyond typo fixes or small amounts of tab-autocompletion), please describe the extent of the contribution here, and the tools used.
Feel free to claim credit for work _not_ done by an AI here too, or to give credit to others who helped in any meaningful way.

Examples:
 - "Claude Code wrote the unit tests, then I implemented the rest of the change"
 - "I consulted ChatGPT on potential approaches, then wrote the implementation myself"
 - "I used Gemini to write the code and Midjourney to produce the diagrams"
 - "Special thanks to the Wikipedia page on ANSI escape codes"
 - "I did not use AI tools at all"
-->
Discovery and fix by Claude Opus 4.8, reviewed by me
