### PR TITLE
Remove deprecated `BUILDKITE_PREFLIGHT` env var

### DIFF
--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -197,7 +197,6 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	env := map[string]string{
 		"PREFLIGHT":               "true",
-		"BUILDKITE_PREFLIGHT":     "true", // deprecated
 		"PREFLIGHT_SOURCE_COMMIT": sourceContext.Commit,
 	}
 	if sourceContext.Branch != "" {

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -384,9 +384,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 		if gotReq.Env["PREFLIGHT"] != "true" {
 			t.Errorf("expected PREFLIGHT=true, got %#v", gotReq.Env)
 		}
-		if gotReq.Env["BUILDKITE_PREFLIGHT"] != "true" {
-			t.Errorf("expected BUILDKITE_PREFLIGHT=true (deprecated), got %#v", gotReq.Env)
-		}
 		if gotReq.Env["PREFLIGHT_SOURCE_BRANCH"] != expectedSourceBranch {
 			t.Errorf("expected PREFLIGHT_SOURCE_BRANCH=%q, got %#v", expectedSourceBranch, gotReq.Env)
 		}


### PR DESCRIPTION
### Description

The preflight command set both `PREFLIGHT` and `BUILDKITE_PREFLIGHT`
environment variables on created builds, with `BUILDKITE_PREFLIGHT` marked as
deprecated in favour of `PREFLIGHT`. Now that `PREFLIGHT` is the established
variable, this removes the deprecated alias.

### Changes

- Drop `BUILDKITE_PREFLIGHT` from the env set on preflight builds
- Remove the corresponding test assertion

### Testing
- [x] Tests have run locally (`go test ./cmd/preflight/` passes)
- [x] Code is formatted (with `gofumpt`/`go fmt`)

### Disclosures / Credits

Amp (Sourcegraph) made the code change and wrote this PR description; I reviewed and directed it.