### PR TITLE
fix(renovate): fix the renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":disableDependencyDashboard",
-    "github>buildkite/renovate-config"
+    "config:recommended",
+    ":semanticCommits",
+    "schedule:weekdays",
+    "group:allNonMajor"
   ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies", "security"],
+    "minimumReleaseAge": "0 days",
+    "enabled": true
+  },
   "postUpdateOptions": ["gomodTidy"],
   "automerge": true,
   "automergeType": "pr",


### PR DESCRIPTION
## Description

We tried to use an internal renovate config via the `extends` field, but that's not seemingly possible when sourcing from a private repository, even when within the same organisation.

## Changes

Implements the imported configuration inline to fix Renovate sourcing errors.
