### PR TITLE
fix(http): query param normalisation in branch

### DIFF
--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -3,6 +3,7 @@ package browse
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -204,5 +205,5 @@ func settingsURL(org, pipeline string) string {
 }
 
 func pipelineBranchURL(org, pipeline, branch string) string {
-	return fmt.Sprintf("https://buildkite.com/%s/%s?branch=%s", org, pipeline, branch)
+	return fmt.Sprintf("https://buildkite.com/%s/%s?branch=%s", org, pipeline, url.QueryEscape(branch))
 }

--- a/cmd/browse/browse_test.go
+++ b/cmd/browse/browse_test.go
@@ -27,10 +27,30 @@ func TestSettingsURL(t *testing.T) {
 }
 
 func TestPipelineBranchURL(t *testing.T) {
-	got := pipelineBranchURL("my-org", "my-pipeline", "main")
-	want := "https://buildkite.com/my-org/my-pipeline?branch=main"
-	if got != want {
-		t.Errorf("pipelineBranchURL = %q, want %q", got, want)
+	cases := []struct {
+		name   string
+		branch string
+		want   string
+	}{
+		{
+			name:   "simple branch",
+			branch: "main",
+			want:   "https://buildkite.com/my-org/my-pipeline?branch=main",
+		},
+		{
+			name:   "branch with query delimiters",
+			branch: "this&that&query=hello+world",
+			want:   "https://buildkite.com/my-org/my-pipeline?branch=this%26that%26query%3Dhello%2Bworld",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pipelineBranchURL("my-org", "my-pipeline", tc.branch)
+			if got != tc.want {
+				t.Errorf("pipelineBranchURL = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Description

Fixes the use of params in `browse` command so that they get normalised in full as the branch name

