### PR TITLE
fix(http): add missing `/builds` to branch filtered url

### DIFF
--- a/cmd/browse/browse.go
+++ b/cmd/browse/browse.go
@@ -205,5 +205,5 @@ func settingsURL(org, pipeline string) string {
 }
 
 func pipelineBranchURL(org, pipeline, branch string) string {
-	return fmt.Sprintf("https://buildkite.com/%s/%s?branch=%s", org, pipeline, url.QueryEscape(branch))
+	return fmt.Sprintf("https://buildkite.com/%s/%s/builds?branch=%s", org, pipeline, url.QueryEscape(branch))
 }

--- a/cmd/browse/browse_test.go
+++ b/cmd/browse/browse_test.go
@@ -35,12 +35,12 @@ func TestPipelineBranchURL(t *testing.T) {
 		{
 			name:   "simple branch",
 			branch: "main",
-			want:   "https://buildkite.com/my-org/my-pipeline?branch=main",
+			want:   "https://buildkite.com/my-org/my-pipeline/builds?branch=main",
 		},
 		{
 			name:   "branch with query delimiters",
 			branch: "this&that&query=hello+world",
-			want:   "https://buildkite.com/my-org/my-pipeline?branch=this%26that%26query%3Dhello%2Bworld",
+			want:   "https://buildkite.com/my-org/my-pipeline/builds?branch=this%26that%26query%3Dhello%2Bworld",
 		},
 	}
 


### PR DESCRIPTION
### Description

Forgot to include `/builds` in branch filtered URLs.
