### PR TITLE
fix(config): only warn on BUILDKITE_API_TOKEN when it shadows a stored credential

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,10 @@ import (
 var (
 	legacyTokenWarningOnce sync.Once
 	envTokenWarningOnce    sync.Once
+
+	// warningOutput is where credential warnings are written. It is a variable
+	// so tests can capture and assert the warnings that actually fire.
+	warningOutput io.Writer = os.Stderr
 )
 
 const (
@@ -133,13 +137,33 @@ func (conf *Config) APIToken() string {
 	return conf.APITokenForOrg(conf.OrganizationSlug())
 }
 
+// hasStoredToken reports whether a token exists in the credential store
+// (keyring) or legacy config for org, without emitting warnings. Used to
+// decide whether a BUILDKITE_API_TOKEN env var is shadowing a real credential.
+func (conf *Config) hasStoredToken(org string) bool {
+	kr := keyring.New()
+	if kr.IsAvailable() {
+		if t, err := kr.Get(org); err == nil && t != "" {
+			return true
+		}
+	}
+	return firstNonEmpty(conf.user.getToken(org), conf.local.getToken(org)) != ""
+}
+
 // APITokenForOrg gets the API token for a specific organization.
 // Precedence: environment variable > credential store > config file (legacy, read-only with warning)
 func (conf *Config) APITokenForOrg(org string) string {
 	if token := os.Getenv("BUILDKITE_API_TOKEN"); token != "" {
-		envTokenWarningOnce.Do(func() {
-			fmt.Fprintln(os.Stderr, "Warning: using BUILDKITE_API_TOKEN environment variable for authentication.")
-		})
+		// Warn only when the env var shadows a stored credential; when it is the
+		// sole credential the warning is just noise. The hasStoredToken gate must
+		// stay outside the once: orgs are resolved across multiple calls, so a
+		// non-shadowing org must not consume the once and silence a later
+		// shadowing one.
+		if conf.hasStoredToken(org) {
+			envTokenWarningOnce.Do(func() {
+				fmt.Fprintln(warningOutput, "Warning: BUILDKITE_API_TOKEN is overriding the credential stored for this organization.")
+			})
+		}
 		return token
 	}
 
@@ -156,7 +180,7 @@ func (conf *Config) APITokenForOrg(org string) string {
 		conf.local.getToken(org),
 	); token != "" {
 		legacyTokenWarningOnce.Do(func() {
-			fmt.Fprintln(os.Stderr, "Warning: reading API token from config file is deprecated. Run `bk auth login` to store your token in the configured credential store.")
+			fmt.Fprintln(warningOutput, "Warning: reading API token from config file is deprecated. Run `bk auth login` to store your token in the configured credential store.")
 		})
 		return token
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/buildkite/cli/v3/pkg/keyring"
@@ -352,6 +355,127 @@ func TestAPITokenForOrgNoKeyring(t *testing.T) {
 	if kr.IsAvailable() {
 		t.Error("expected keyring to be unavailable when BUILDKITE_NO_KEYRING=1")
 	}
+}
+
+func TestHasStoredToken(t *testing.T) {
+	// Force the keyring off so we exercise the legacy config path deterministically.
+	setEnv(t, "BUILDKITE_NO_KEYRING", "1")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+	keyring.ResetForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	t.Run("legacy token present", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		content := []byte("organizations:\n  my-org:\n    api_token: legacy-token\n")
+		if err := afero.WriteFile(fs, configFile(), content, 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+		conf := New(fs, nil)
+
+		if !conf.hasStoredToken("my-org") {
+			t.Error("hasStoredToken() = false, want true when legacy config has a token")
+		}
+	})
+
+	t.Run("no stored token", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		conf := New(fs, nil)
+
+		if conf.hasStoredToken("my-org") {
+			t.Error("hasStoredToken() = true, want false when no credential is stored")
+		}
+	})
+}
+
+const shadowWarning = "Warning: BUILDKITE_API_TOKEN is overriding the credential stored for this organization."
+
+// captureWarnings redirects credential warnings to a buffer and resets the
+// warning once-guards so each test observes the warnings its own calls emit.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := warningOutput
+	warningOutput = buf
+	envTokenWarningOnce = sync.Once{}
+	legacyTokenWarningOnce = sync.Once{}
+	t.Cleanup(func() {
+		warningOutput = prev
+		envTokenWarningOnce = sync.Once{}
+		legacyTokenWarningOnce = sync.Once{}
+	})
+	return buf
+}
+
+func TestAPITokenForOrgEnvVar(t *testing.T) {
+	// Force the keyring off so the only possible stored credential is legacy config.
+	setEnv(t, "BUILDKITE_NO_KEYRING", "1")
+	setEnv(t, "CI", "")
+	setEnv(t, "BUILDKITE", "")
+	setEnv(t, "BUILDKITE_API_TOKEN", "env-token")
+	keyring.ResetForTesting()
+	t.Cleanup(keyring.ResetForTesting)
+
+	t.Run("env var is the only credential: returned without a warning", func(t *testing.T) {
+		warnings := captureWarnings(t)
+		fs := afero.NewMemMapFs()
+		conf := New(fs, nil)
+
+		if got := conf.APITokenForOrg("my-org"); got != "env-token" {
+			t.Errorf("APITokenForOrg() = %q, want %q", got, "env-token")
+		}
+		if got := warnings.String(); got != "" {
+			t.Errorf("expected no warning when env var is the sole credential, got %q", got)
+		}
+	})
+
+	t.Run("env var shadows a stored credential: returned with a warning", func(t *testing.T) {
+		warnings := captureWarnings(t)
+		fs := afero.NewMemMapFs()
+		content := []byte("organizations:\n  my-org:\n    api_token: legacy-token\n")
+		if err := afero.WriteFile(fs, configFile(), content, 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+		conf := New(fs, nil)
+
+		// Env var still wins for the returned token.
+		if got := conf.APITokenForOrg("my-org"); got != "env-token" {
+			t.Errorf("APITokenForOrg() = %q, want %q", got, "env-token")
+		}
+		if got := warnings.String(); !strings.Contains(got, shadowWarning) {
+			t.Errorf("expected shadowing warning, got %q", got)
+		}
+	})
+
+	// Regression for the factory's two-step org resolution: a lookup against an
+	// org with no stored credential must not consume the once, otherwise a later
+	// lookup against an org the env var *does* shadow would be silenced.
+	t.Run("non-shadowing lookup does not suppress a later shadowing warning", func(t *testing.T) {
+		warnings := captureWarnings(t)
+		fs := afero.NewMemMapFs()
+		content := []byte("organizations:\n  stored-org:\n    api_token: legacy-token\n")
+		if err := afero.WriteFile(fs, configFile(), content, 0o600); err != nil {
+			t.Fatalf("failed to write config: %v", err)
+		}
+		conf := New(fs, nil)
+
+		// env-only-org has no stored credential: env token returned, no warning.
+		if got := conf.APITokenForOrg("env-only-org"); got != "env-token" {
+			t.Errorf("APITokenForOrg(env-only-org) = %q, want %q", got, "env-token")
+		}
+		if got := warnings.String(); got != "" {
+			t.Errorf("expected no warning for non-shadowing org, got %q", got)
+		}
+
+		// stored-org IS shadowed: the warning must still fire, proving the
+		// earlier non-shadowing lookup did not consume the once.
+		if got := conf.APITokenForOrg("stored-org"); got != "env-token" {
+			t.Errorf("APITokenForOrg(stored-org) = %q, want %q", got, "env-token")
+		}
+		if got := warnings.String(); !strings.Contains(got, shadowWarning) {
+			t.Errorf("expected shadowing warning after non-shadowing lookup, got %q", got)
+		}
+	})
 }
 
 func TestExperiments(t *testing.T) {

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -215,11 +215,19 @@ func New(opts ...FactoryOpt) (*Factory, error) {
 
 	ApplyCredentialStoreFromConfig(conf)
 
-	token := conf.APIToken()
+	// Resolve the org the command will actually use before the token lookup, so
+	// any shadowing warning reflects the credential that gets used and a single
+	// lookup consumes the warning's once at most once.
+	org := conf.OrganizationSlug()
 	if cfg.orgOverride != "" {
-		if t := conf.APITokenForOrg(cfg.orgOverride); t != "" {
-			token = t
-		}
+		org = cfg.orgOverride
+	}
+
+	token := conf.APITokenForOrg(org)
+	if token == "" && cfg.orgOverride != "" {
+		// The override org has no credential of its own; fall back to the
+		// selected org's token.
+		token = conf.APIToken()
 	}
 
 	userAgent := buildUserAgent(cfg.userAgentSuffix)
@@ -249,11 +257,6 @@ func New(opts ...FactoryOpt) (*Factory, error) {
 	}
 
 	// Add refresh transport if a refresh token is available for this org.
-	org := conf.OrganizationSlug()
-	if cfg.orgOverride != "" {
-		org = cfg.orgOverride
-	}
-
 	kr := keyring.New()
 	if refreshToken, err := kr.GetRefreshToken(org); err == nil && refreshToken != "" {
 		transport = &bkhttp.RefreshTransport{

--- a/pkg/cmd/validation/config.go
+++ b/pkg/cmd/validation/config.go
@@ -27,13 +27,19 @@ func ValidateConfigurationForOrg(conf *config.Config, commandPath, org string) e
 }
 
 func validateConfiguration(conf *config.Config, commandPath, orgOverride string) error {
+	// Resolve the org the command will actually use before the token lookup, so
+	// any shadowing warning reflects the credential that gets used rather than
+	// the selected org's.
 	org := conf.OrganizationSlug()
-	token := conf.APIToken()
 	if orgOverride != "" {
 		org = orgOverride
-		if t := conf.APITokenForOrg(org); t != "" {
-			token = t
-		}
+	}
+
+	token := conf.APITokenForOrg(org)
+	if token == "" && orgOverride != "" {
+		// The override org has no credential of its own; fall back to the
+		// selected org's token.
+		token = conf.APIToken()
 	}
 
 	missingToken := token == ""

--- a/pkg/cmd/validation/config_test.go
+++ b/pkg/cmd/validation/config_test.go
@@ -80,6 +80,38 @@ func TestValidateConfiguration_MissingValues(t *testing.T) {
 	})
 }
 
+func TestValidateConfigurationForOrg_TokenResolution(t *testing.T) {
+	t.Run("uses the override org's credential", func(t *testing.T) {
+		t.Setenv("BUILDKITE_API_TOKEN", "")
+		t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "selected-org")
+		conf := newTestConfig(t)
+		if err := bkKeyring.New().Set("override-org", "override-token"); err != nil {
+			t.Fatalf("failed to seed keyring: %v", err)
+		}
+
+		// selected-org has no credential; the override org does, so validation
+		// must resolve a token for the org the command will actually use.
+		if err := ValidateConfigurationForOrg(conf, "pipeline view", "override-org"); err != nil {
+			t.Fatalf("expected no error when the override org has a credential, got %v", err)
+		}
+	})
+
+	t.Run("falls back to the selected org when the override has none", func(t *testing.T) {
+		t.Setenv("BUILDKITE_API_TOKEN", "")
+		t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "selected-org")
+		conf := newTestConfig(t)
+		if err := bkKeyring.New().Set("selected-org", "selected-token"); err != nil {
+			t.Fatalf("failed to seed keyring: %v", err)
+		}
+
+		// The override org has no credential of its own; validation falls back
+		// to the selected org's token rather than failing as unauthenticated.
+		if err := ValidateConfigurationForOrg(conf, "pipeline view", "override-org"); err != nil {
+			t.Fatalf("expected fallback to the selected org's token, got %v", err)
+		}
+	})
+}
+
 func newTestConfig(t *testing.T) *config.Config {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())


### PR DESCRIPTION
The `BUILDKITE_API_TOKEN` warning fired on every invocation. In ephemeral/CI environments, injecting the env var is the intended auth path (no OAuth, no stored credential) — so the warning is pure noise.

Now it only fires when the env var actually overrides a stored keyring/legacy credential for the resolved org — the shadowing case [#684](https://github.com/buildkite/cli/pull/684) targeted. Env-only usage stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)