### PR TITLE
feat(Preflight): Classify Early Job Failures Server-Side via the Jobs Index

### DIFF
--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -17,8 +17,12 @@ const (
 	EventBuildStatus    EventType = "build_status"
 	EventJobFailure     EventType = "job_failure"
 	EventJobRetryPassed EventType = "job_retry_passed"
-	EventBuildSummary   EventType = "build_summary"
-	EventTestFailure    EventType = "test_failure"
+
+	// EventJobPromisedFailure is emitted when a still-running job declares an
+	// early (promised) failure, ahead of reaching a terminal state.
+	EventJobPromisedFailure EventType = "job_promised_failure"
+	EventBuildSummary       EventType = "build_summary"
+	EventTestFailure        EventType = "test_failure"
 )
 
 // Event is the single data model emitted by a preflight run.
@@ -75,28 +79,30 @@ type Event struct {
 // payloads that are useful for API clients but expensive and noisy for LLM
 // preflight consumers.
 type jsonJob struct {
-	ID             string `json:"id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	Command        string `json:"command,omitempty"`
-	State          string `json:"state,omitempty"`
-	ExitStatus     *int   `json:"exit_status,omitempty"`
-	SoftFailed     bool   `json:"soft_failed"`
-	Retried        bool   `json:"retried"`
-	RetriesCount   int    `json:"retries_count,omitempty"`
-	RetriedInJobID string `json:"retried_in_job_id,omitempty"`
+	ID                 string `json:"id,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Command            string `json:"command,omitempty"`
+	State              string `json:"state,omitempty"`
+	ExitStatus         *int   `json:"exit_status,omitempty"`
+	PromisedExitStatus *int   `json:"promised_exit_status,omitempty"`
+	SoftFailed         bool   `json:"soft_failed"`
+	Retried            bool   `json:"retried"`
+	RetriesCount       int    `json:"retries_count,omitempty"`
+	RetriedInJobID     string `json:"retried_in_job_id,omitempty"`
 }
 
 func newJSONJob(j buildkite.Job) jsonJob {
 	return jsonJob{
-		ID:             j.ID,
-		Name:           j.Name,
-		Command:        j.Command,
-		State:          j.State,
-		ExitStatus:     j.ExitStatus,
-		SoftFailed:     j.SoftFailed,
-		Retried:        j.Retried,
-		RetriesCount:   j.RetriesCount,
-		RetriedInJobID: j.RetriedInJobID,
+		ID:                 j.ID,
+		Name:               j.Name,
+		Command:            j.Command,
+		State:              j.State,
+		ExitStatus:         j.ExitStatus,
+		PromisedExitStatus: j.PromisedExitStatus,
+		SoftFailed:         j.SoftFailed,
+		Retried:            j.Retried,
+		RetriesCount:       j.RetriesCount,
+		RetriedInJobID:     j.RetriedInJobID,
 	}
 }
 

--- a/cmd/preflight/job_presenter.go
+++ b/cmd/preflight/job_presenter.go
@@ -45,6 +45,31 @@ func (p jobPresenter) Line(j buildkite.Job) string {
 	return fmt.Sprintf("%s %s %s", symbol, name, detail)
 }
 
+// PromisedFailureLine renders an early failure declaration on a running job.
+func (p jobPresenter) PromisedFailureLine(j buildkite.Job) string {
+	name := watch.NewFormattedJob(j).DisplayName()
+	return fmt.Sprintf("⚡ %s declared an early failure%s", name, promisedExitSuffix(j))
+}
+
+// ColoredPromisedFailureLine renders PromisedFailureLine with styling, keeping
+// any emoji prefix outside the ANSI colour span (see ColoredLine).
+func (p jobPresenter) ColoredPromisedFailureLine(j buildkite.Job) string {
+	emojiPrefix, textName := emoji.Split(watch.NewFormattedJob(j).DisplayName())
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	detail := fmt.Sprintf("declared an early failure%s", promisedExitSuffix(j))
+	if emojiPrefix != "" {
+		return style.Render("⚡ ") + emoji.Render(emojiPrefix) + " " + style.Render(fmt.Sprintf("%s %s", textName, detail))
+	}
+	return style.Render(fmt.Sprintf("⚡ %s %s", textName, detail))
+}
+
+func promisedExitSuffix(j buildkite.Job) string {
+	if j.PromisedExitStatus == nil {
+		return ""
+	}
+	return fmt.Sprintf(" (exit %d)", *j.PromisedExitStatus)
+}
+
 func (p jobPresenter) PassedLine(j buildkite.Job) string {
 	name := watch.NewFormattedJob(j).DisplayName()
 	return fmt.Sprintf("✔ %s", name)

--- a/cmd/preflight/job_presenter_test.go
+++ b/cmd/preflight/job_presenter_test.go
@@ -202,3 +202,18 @@ func assertStringContainsAll(t *testing.T, got string, want []string) {
 		}
 	}
 }
+
+func TestJobPresenter_PromisedFailureLine(t *testing.T) {
+	startedAt := buildkite.Timestamp{Time: time.Now().Add(-30 * time.Second)}
+	exitStatus := 1
+	job := scriptJob("node-test", "Test", "running", false, &startedAt, nil, nil)
+	job.PromisedExitStatus = &exitStatus
+
+	line := jobPresenter{pipeline: "buildkite/cli", buildNumber: 183663}.PromisedFailureLine(job)
+
+	assertStringContainsAll(t, line, []string{
+		"⚡ Test",
+		"declared an early failure",
+		"(exit 1)",
+	})
+}

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -230,14 +230,19 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	finalBuild, err := watch.WatchBuild(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, interval, func(b buildkite.Build) error {
 		// Ask the server which still-running jobs it classifies as hard-failing
 		// promised failures (the jobs index "failed" scope). This is soft-fail
-		// aware, unlike the raw promised_exit_status on the build payload. It's
-		// best-effort: on error we leave the tracker to fall back to the
-		// client-side declaration heuristic for this poll.
+		// aware, unlike the raw promised_exit_status on the build payload.
+		//
+		// Best-effort and recomputed every poll: a successful fetch yields an
+		// authoritative (non-nil) set; on a skip or error we pass nil so the
+		// tracker falls back to the client-side declaration heuristic for this
+		// poll rather than trusting a stale set from an earlier poll.
+		var serverFailing map[string]bool
 		if hasRunningScriptJob(b) {
 			if failing, ferr := watch.FetchPromisedHardFailures(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number); ferr == nil {
-				tracker.SetServerClassifiedFailures(failing)
+				serverFailing = failing
 			}
 		}
+		tracker.SetServerClassifiedFailures(serverFailing)
 		status := tracker.Update(b)
 		for _, failed := range status.NewlyFailed {
 			if err := renderer.Render(Event{

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -255,6 +255,19 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 				return err
 			}
 		}
+		for _, promised := range status.NewlyPromisedFailure {
+			if err := renderer.Render(Event{
+				Type:        EventJobPromisedFailure,
+				Time:        time.Now(),
+				PreflightID: preflightID.String(),
+				Pipeline:    pipelineName,
+				BuildNumber: build.Number,
+				BuildURL:    build.WebURL,
+				Job:         &promised,
+			}); err != nil {
+				return err
+			}
+		}
 		if err := renderer.Render(Event{
 			Type:        EventBuildStatus,
 			Time:        time.Now(),

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -228,6 +228,16 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	tracker := watch.NewJobTracker()
 
 	finalBuild, err := watch.WatchBuild(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number, interval, func(b buildkite.Build) error {
+		// Ask the server which still-running jobs it classifies as hard-failing
+		// promised failures (the jobs index "failed" scope). This is soft-fail
+		// aware, unlike the raw promised_exit_status on the build payload. It's
+		// best-effort: on error we leave the tracker to fall back to the
+		// client-side declaration heuristic for this poll.
+		if hasRunningScriptJob(b) {
+			if failing, ferr := watch.FetchPromisedHardFailures(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, build.Number); ferr == nil {
+				tracker.SetServerClassifiedFailures(failing)
+			}
+		}
 		status := tracker.Update(b)
 		for _, failed := range status.NewlyFailed {
 			if err := renderer.Render(Event{
@@ -352,6 +362,18 @@ func (c *RunCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	return finalErr
+}
+
+// hasRunningScriptJob reports whether the build has at least one still-running
+// script job. Used to avoid the extra jobs-index request when nothing is
+// running and so no promised failure could be declared yet.
+func hasRunningScriptJob(b buildkite.Build) bool {
+	for _, j := range b.Jobs {
+		if j.Type == "script" && (j.State == "running" || j.State == "canceling" || j.State == "timing_out") {
+			return true
+		}
+	}
+	return false
 }
 
 func cleanupRemoteBranch(renderer renderer, repoRoot, branch, ref, preflightID string, debug bool) {

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -172,6 +172,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+				return
+
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
 				poll := buildPolls.Add(1)
 				exitOne := 1
@@ -579,6 +583,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+				return
+
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
 				poll := buildPolls.Add(1)
 				build := buildkite.Build{
@@ -712,6 +720,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+				return
+
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
 				exitOne := 1
 				json.NewEncoder(w).Encode(buildkite.Build{
@@ -800,6 +812,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 					State:  "scheduled",
 					WebURL: "https://buildkite.com/test-org/test-pipeline/builds/1",
 				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
 				return
 
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
@@ -922,6 +938,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 						Slug: "test-pipeline",
 					},
 				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
 				return
 
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
@@ -1057,6 +1077,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+				return
+
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
 				if buildRequests.Add(1) == 1 {
 					json.NewEncoder(w).Encode(buildkite.Build{
@@ -1145,6 +1169,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 						Slug: "test-pipeline",
 					},
 				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
 				return
 
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
@@ -1293,6 +1321,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+				return
+
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):
 				json.NewEncoder(w).Encode(buildkite.Build{
 					ID:         "build-id-123",
@@ -1397,6 +1429,10 @@ func TestPreflightCmd_Run(t *testing.T) {
 						Slug: "test-pipeline",
 					},
 				})
+				return
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1/jobs"):
+				json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
 				return
 
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/builds/1"):

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -83,6 +83,13 @@ func (r *plainRenderer) Render(e Event) error {
 			return err
 		}
 
+	case EventJobPromisedFailure:
+		if e.Job != nil {
+			presenter := jobPresenter{pipeline: e.Pipeline, buildNumber: e.BuildNumber, buildURL: e.BuildURL}
+			_, err := fmt.Fprintf(r.stdout, "%s%s\n", prefix, presenter.PromisedFailureLine(*e.Job))
+			return err
+		}
+
 	case EventBuildSummary:
 		header := summaryHeader(e)
 		if _, err := fmt.Fprintf(r.stdout, "\n%s\n", header); err != nil {

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -80,6 +80,13 @@ func (m ttyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Printf("%s", m.hardwrapLine(line))
 			}
 
+		case EventJobPromisedFailure:
+			if msg.Job != nil {
+				presenter := jobPresenter{pipeline: msg.Pipeline, buildNumber: msg.BuildNumber, buildURL: msg.BuildURL}
+				line := timestampPrefix(msg.Time) + presenter.ColoredPromisedFailureLine(*msg.Job)
+				return m, tea.Printf("%s", m.hardwrapLine(line))
+			}
+
 		case EventBuildSummary:
 			// Print the summary via Printf (which scrolls it above the
 			// view) instead of rendering it through View(). Inline-image

--- a/internal/build/watch/job.go
+++ b/internal/build/watch/job.go
@@ -50,3 +50,19 @@ func (j FormattedJob) IsSoftFailed() bool {
 func (j FormattedJob) IsFailed() bool {
 	return j.IsTerminalFailureState()
 }
+
+// IsRunning reports whether the job is still actively executing.
+func (j FormattedJob) IsRunning() bool {
+	return isActiveState(j.State)
+}
+
+// HasPromisedFailure reports whether the job has declared an early (promised)
+// failure: a non-zero promised exit status recorded before the job finished.
+//
+// This is intentionally retry-blind and does not consult soft-fail rules — the
+// build-show payload doesn't carry them. It surfaces the raw declaration only.
+// Precise hard-vs-soft classification is owned server-side (the jobs index
+// "failed" scope) and arrives in a later iteration.
+func (j FormattedJob) HasPromisedFailure() bool {
+	return j.PromisedExitStatus != nil && *j.PromisedExitStatus != 0
+}

--- a/internal/build/watch/job.go
+++ b/internal/build/watch/job.go
@@ -62,7 +62,8 @@ func (j FormattedJob) IsRunning() bool {
 // This is intentionally retry-blind and does not consult soft-fail rules — the
 // build-show payload doesn't carry them. It surfaces the raw declaration only.
 // Precise hard-vs-soft classification is owned server-side (the jobs index
-// "failed" scope) and arrives in a later iteration.
+// "failed" scope); this client-side check is the fallback used by the tracker
+// when no server classification is available for a poll.
 func (j FormattedJob) HasPromisedFailure() bool {
 	return j.PromisedExitStatus != nil && *j.PromisedExitStatus != 0
 }

--- a/internal/build/watch/promised.go
+++ b/internal/build/watch/promised.go
@@ -1,0 +1,57 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+
+	buildkite "github.com/buildkite/go-buildkite/v5"
+)
+
+// FetchPromisedHardFailures returns the set of job UUIDs that the server
+// classifies as failing *and* are still running — i.e. running jobs that have
+// declared a hard-failing promised exit status (an early failure declaration).
+//
+// It queries the build-scoped jobs index with state=failed. When
+// PROMISED_EXIT_STATUS_FOR_FAILING is enabled server-side, that filter folds
+// running script jobs with a hard-failing promised exit status into the failed
+// results (soft-fails excluded), so the server — not the client — owns the
+// precise "will fail" classification. We keep only the still-running jobs;
+// finished failures are surfaced through the normal failed path.
+//
+// Best-effort by design: until the server change ships (or for orgs without the
+// flag), state=failed returns only finished jobs, so the running-job filter
+// yields an empty set and this is a no-op. Callers should treat an error as
+// "no promised failures this poll" rather than fatal.
+func FetchPromisedHardFailures(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (map[string]bool, error) {
+	result := make(map[string]bool)
+	opts := &buildkite.JobsListOptions{
+		State:   []string{"failed"},
+		PerPage: 100,
+	}
+
+	for {
+		reqCtx, cancel := context.WithTimeout(ctx, DefaultRequestTimeout)
+		list, _, err := client.Jobs.ListByBuild(reqCtx, org, pipeline, fmt.Sprint(buildNumber), opts)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, j := range list.Items {
+			if isActiveState(j.State) {
+				result[j.ID] = true
+			}
+		}
+
+		if list.Links.Next == "" {
+			break
+		}
+		next, err := list.Links.Next.ToOptions()
+		if err != nil {
+			return result, err
+		}
+		opts = next
+	}
+
+	return result, nil
+}

--- a/internal/build/watch/promised_test.go
+++ b/internal/build/watch/promised_test.go
@@ -1,0 +1,75 @@
+package watch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	buildkite "github.com/buildkite/go-buildkite/v5"
+)
+
+func TestFetchPromisedHardFailures(t *testing.T) {
+	t.Run("keeps only running jobs from the failed scope", func(t *testing.T) {
+		var gotState []string
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotState = r.URL.Query()["state[]"]
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(buildkite.JobsList{
+				Items: []buildkite.Job{
+					{ID: "running-fail", State: "running"},
+					{ID: "finished-fail", State: "failed"},
+					{ID: "canceling-fail", State: "canceling"},
+				},
+			})
+		}))
+		defer s.Close()
+
+		failing, err := FetchPromisedHardFailures(context.Background(), newTestClient(t, s.URL), "org", "pipe", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(failing) != 2 || !failing["running-fail"] || !failing["canceling-fail"] {
+			t.Fatalf("expected only running/canceling jobs, got %#v", failing)
+		}
+		if failing["finished-fail"] {
+			t.Error("finished job should not be in the running promised set")
+		}
+		if len(gotState) != 1 || gotState[0] != "failed" {
+			t.Errorf("expected state=failed query, got %#v", gotState)
+		}
+	})
+
+	t.Run("empty failed scope yields empty set", func(t *testing.T) {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(buildkite.JobsList{Items: []buildkite.Job{}})
+		}))
+		defer s.Close()
+
+		failing, err := FetchPromisedHardFailures(context.Background(), newTestClient(t, s.URL), "org", "pipe", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(failing) != 0 {
+			t.Fatalf("expected empty set, got %#v", failing)
+		}
+	})
+
+	t.Run("server error is propagated", func(t *testing.T) {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+		}))
+		defer s.Close()
+
+		_, err := FetchPromisedHardFailures(context.Background(), newTestClient(t, s.URL), "org", "pipe", 1)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "boom") && !strings.Contains(err.Error(), "500") {
+			t.Errorf("expected API error, got %v", err)
+		}
+	})
+}

--- a/internal/build/watch/tracker.go
+++ b/internal/build/watch/tracker.go
@@ -10,10 +10,11 @@ import (
 
 // trackedJob holds a job and its lifecycle state across polls.
 type trackedJob struct {
-	Job           buildkite.Job
-	PrevState     string // state from previous poll, "" if first seen
-	Reported      bool   // true once surfaced to caller as failed
-	RetryReported bool   // true once surfaced to caller as retry-passed
+	Job             buildkite.Job
+	PrevState       string // state from previous poll, "" if first seen
+	Reported        bool   // true once surfaced to caller as failed
+	RetryReported   bool   // true once surfaced to caller as retry-passed
+	PromiseReported bool   // true once surfaced to caller as a promised failure
 }
 
 // JobSummary aggregates job counts by high-level state.
@@ -55,12 +56,13 @@ func (s JobSummary) String() string {
 
 // BuildStatus is the output of JobTracker.Update().
 type BuildStatus struct {
-	NewlyFailed      []buildkite.Job
-	NewlyRetryPassed []buildkite.Job
-	Running          []buildkite.Job
-	TotalRunning     int
-	Summary          JobSummary
-	Build            buildkite.Build
+	NewlyFailed          []buildkite.Job
+	NewlyRetryPassed     []buildkite.Job
+	NewlyPromisedFailure []buildkite.Job
+	Running              []buildkite.Job
+	TotalRunning         int
+	Summary              JobSummary
+	Build                buildkite.Build
 }
 
 // JobTracker tracks job state changes across polls.
@@ -101,6 +103,13 @@ func (t *JobTracker) Update(b buildkite.Build) BuildStatus {
 		if job.IsFailed() && !prevJob.IsTerminalFailureState() && !tj.Reported {
 			status.NewlyFailed = append(status.NewlyFailed, j)
 			tj.Reported = true
+		}
+
+		// Surface an early failure declaration on a still-running job once, before
+		// the job reaches a terminal state and the normal failure path takes over.
+		if job.IsRunning() && job.HasPromisedFailure() && !tj.PromiseReported {
+			status.NewlyPromisedFailure = append(status.NewlyPromisedFailure, j)
+			tj.PromiseReported = true
 		}
 
 		if isActiveState(j.State) {

--- a/internal/build/watch/tracker.go
+++ b/internal/build/watch/tracker.go
@@ -68,6 +68,13 @@ type BuildStatus struct {
 // JobTracker tracks job state changes across polls.
 type JobTracker struct {
 	jobs map[string]*trackedJob
+
+	// serverClassified is the set of running job IDs the server classifies as
+	// hard-failing promised failures (the jobs index "failed" scope). When nil,
+	// no server classification is available for this poll and the tracker falls
+	// back to the client-side declaration heuristic. When non-nil (even empty),
+	// the server's verdict is trusted exclusively.
+	serverClassified map[string]bool
 }
 
 // NewJobTracker creates a new JobTracker.
@@ -75,6 +82,30 @@ func NewJobTracker() *JobTracker {
 	return &JobTracker{
 		jobs: make(map[string]*trackedJob),
 	}
+}
+
+// SetServerClassifiedFailures records the server's precise set of running jobs
+// that are hard-failing promised failures, keyed by job ID. Call this before
+// Update on each poll. Passing a non-nil map (even empty) makes the tracker
+// trust the server's classification for promised-failure surfacing; passing nil
+// (the default) falls back to the client-side declaration heuristic.
+//
+// The server set is soft-fail-aware, so it avoids surfacing jobs that declared a
+// promised exit status which would actually be soft-failed — something the
+// build-show payload alone can't determine.
+func (t *JobTracker) SetServerClassifiedFailures(set map[string]bool) {
+	t.serverClassified = set
+}
+
+// promisedFailing reports whether a still-running job should be surfaced as an
+// early (promised) failure. When server classification is available it is
+// trusted exclusively; otherwise it falls back to the raw client-side
+// declaration on the build payload.
+func (t *JobTracker) promisedFailing(job FormattedJob) bool {
+	if t.serverClassified != nil {
+		return t.serverClassified[job.ID]
+	}
+	return job.HasPromisedFailure()
 }
 
 // Update processes a build and returns the current status with any state changes.
@@ -107,7 +138,7 @@ func (t *JobTracker) Update(b buildkite.Build) BuildStatus {
 
 		// Surface an early failure declaration on a still-running job once, before
 		// the job reaches a terminal state and the normal failure path takes over.
-		if job.IsRunning() && job.HasPromisedFailure() && !tj.PromiseReported {
+		if job.IsRunning() && t.promisedFailing(job) && !tj.PromiseReported {
 			status.NewlyPromisedFailure = append(status.NewlyPromisedFailure, j)
 			tj.PromiseReported = true
 		}

--- a/internal/build/watch/tracker_test.go
+++ b/internal/build/watch/tracker_test.go
@@ -733,3 +733,54 @@ func TestJob_Duration(t *testing.T) {
 		}
 	})
 }
+
+func TestJobTracker_PromisedFailure(t *testing.T) {
+	intPtr := func(i int) *int { return &i }
+
+	t.Run("running job with promised exit status reported once", func(t *testing.T) {
+		tracker := NewJobTracker()
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 1 || status.NewlyPromisedFailure[0].ID != "1" {
+			t.Fatalf("expected job 1 promised, got %#v", status.NewlyPromisedFailure)
+		}
+
+		// Same promise on the next poll must not re-report.
+		status = tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 0 {
+			t.Errorf("expected no re-report, got %d", len(status.NewlyPromisedFailure))
+		}
+	})
+
+	t.Run("nil or zero promised exit status is not a promised failure", func(t *testing.T) {
+		tracker := NewJobTracker()
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running"},
+				{ID: "2", Type: "script", State: "running", PromisedExitStatus: intPtr(0)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 0 {
+			t.Errorf("expected 0 promised, got %d", len(status.NewlyPromisedFailure))
+		}
+	})
+
+	t.Run("non-running job with promised exit status is not surfaced", func(t *testing.T) {
+		tracker := NewJobTracker()
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "failed", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 0 {
+			t.Errorf("expected 0 promised for finished job, got %d", len(status.NewlyPromisedFailure))
+		}
+	})
+}

--- a/internal/build/watch/tracker_test.go
+++ b/internal/build/watch/tracker_test.go
@@ -829,4 +829,30 @@ func TestJobTracker_ServerClassifiedFailures(t *testing.T) {
 			t.Fatalf("expected client fallback to surface job 1, got %#v", status.NewlyPromisedFailure)
 		}
 	})
+
+	t.Run("resetting to nil after a server set restores client fallback", func(t *testing.T) {
+		tracker := NewJobTracker()
+		// Poll 1: server set present and empty, so the declared job is suppressed.
+		tracker.SetServerClassifiedFailures(map[string]bool{})
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 0 {
+			t.Fatalf("expected empty server set to suppress, got %#v", status.NewlyPromisedFailure)
+		}
+
+		// Poll 2: server fetch failed/skipped, so nil restores the client
+		// fallback and the still-declared job is surfaced.
+		tracker.SetServerClassifiedFailures(nil)
+		status = tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 1 || status.NewlyPromisedFailure[0].ID != "1" {
+			t.Fatalf("expected client fallback after reset to surface job 1, got %#v", status.NewlyPromisedFailure)
+		}
+	})
 }

--- a/internal/build/watch/tracker_test.go
+++ b/internal/build/watch/tracker_test.go
@@ -784,3 +784,49 @@ func TestJobTracker_PromisedFailure(t *testing.T) {
 		}
 	})
 }
+
+func TestJobTracker_ServerClassifiedFailures(t *testing.T) {
+	intPtr := func(i int) *int { return &i }
+
+	t.Run("server set is trusted over client declaration", func(t *testing.T) {
+		tracker := NewJobTracker()
+		// job 1 declared a promised failure on the payload, but the server does
+		// not classify it as failing (e.g. it would soft-fail). job 2 carries no
+		// promised status on the payload, but the server says it is failing.
+		tracker.SetServerClassifiedFailures(map[string]bool{"2": true})
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+				{ID: "2", Type: "script", State: "running"},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 1 || status.NewlyPromisedFailure[0].ID != "2" {
+			t.Fatalf("expected only job 2 surfaced from server set, got %#v", status.NewlyPromisedFailure)
+		}
+	})
+
+	t.Run("empty non-nil server set suppresses client declaration", func(t *testing.T) {
+		tracker := NewJobTracker()
+		tracker.SetServerClassifiedFailures(map[string]bool{})
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 0 {
+			t.Fatalf("expected server to suppress client declaration, got %#v", status.NewlyPromisedFailure)
+		}
+	})
+
+	t.Run("nil server set falls back to client declaration", func(t *testing.T) {
+		tracker := NewJobTracker()
+		status := tracker.Update(buildkite.Build{
+			Jobs: []buildkite.Job{
+				{ID: "1", Type: "script", State: "running", PromisedExitStatus: intPtr(1)},
+			},
+		})
+		if len(status.NewlyPromisedFailure) != 1 || status.NewlyPromisedFailure[0].ID != "1" {
+			t.Fatalf("expected client fallback to surface job 1, got %#v", status.NewlyPromisedFailure)
+		}
+	})
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,5 +12,8 @@ pre-commit:
       stage_fixed: true
     lint:
       glob: "*.go"
-      run: golangci-lint run --fix {staged_files}
+      # Lint by directory, not by file: golangci-lint rejects individual file
+      # paths spanning more than one directory ("named files must all be in one
+      # directory"), which breaks any commit touching multiple packages.
+      run: golangci-lint run --fix $(echo {staged_files} | tr ' ' '\n' | xargs -n1 dirname | sort -u)
       stage_fixed: true


### PR DESCRIPTION
### Description

When watching a build, `bk preflight` surfaces "early failure" declarations which is a still-running job that has already declared it will finish with a hard-failing exit status. So you learn a build is doomed without waiting for it to finish.

Until now preflight decided what counted as an early failure on the client, from the raw `promised_exit_status` on the build payload. That signal is soft-fail blind: a job can declare a promised exit status that would actually be soft-failed (and so wouldn't fail the build), which preflight would surface as a false positive. The build payload doesn't carry soft-fail rules, so the client can't tell the difference on its own.

This moves the decision to the server, which is the authoritative source. On each poll where a script job is still running, preflight queries the build's jobs index with `state=failed`. That filter includes running script jobs with a hard-failing promised exit status and excludes soft-fails, so preflight surfaces exactly the jobs the server considers "will fail".

The change is best-effort and backwards-compatible. If the jobs-index request fails, the tracker falls back to the previous client-side behaviour, so nothing regresses. On servers that don't yet return running jobs from `state=failed`, the filter yields no running jobs, so the result is simply the previous behaviour with no early-failure noise.

Alternatives considered: keeping the classification fully client-side (rejected. But it can't access soft-fail rules, so it can't be accurate), and adding a dedicated "will fail" query parameter (heavier API surface for the same outcome that `state=failed` already expresses).

### Changes

- Add `watch.FetchPromisedHardFailures`, which queries the jobs index `?state=failed` and returns the still-running jobs in that set.
- Add `JobTracker.SetServerClassifiedFailures`: when a server-classified set is provided it is trusted exclusively; otherwise the tracker falls back to the client-side `promised_exit_status` heuristic.
- Wire the per-poll fetch into `preflight`, guarded by a cheap "is any script job running?" check to avoid an extra request when nothing is running.
- Tests for the new fetch helper and tracker behaviour; preflight HTTP mock now serves the jobs-index route.

No changes to CLI arguments or `bk preflight --help` output.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

Also ran `mise run lint` (golangci-lint) — 0 issues.

### Disclosures / Credits

Implemented with Amp (Sourcegraph): it bumped the dependency, wrote the jobs-index fetch helper, tracker wiring, and tests, and updated the preflight HTTP mock. I reviewed and verified the changes and test runs.
