### PR TITLE
feat(job): add exclusion options

### DIFF
--- a/cmd/build/download.go
+++ b/cmd/build/download.go
@@ -16,6 +16,7 @@ import (
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type DownloadCmd struct {
@@ -121,7 +122,11 @@ func (c *DownloadCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error 
 func download(ctx context.Context, build *build.Build, f *factory.Factory) (string, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	b, _, err := f.RestAPIClient.Builds.Get(ctx, build.Organization, build.Pipeline, fmt.Sprint(build.BuildNumber), nil)
+	// Jobs are needed for log downloads, but the pipeline payload is unused.
+	getOpts := &buildkite.BuildGetOptions{
+		BuildsListOptions: buildkite.BuildsListOptions{ExcludePipeline: true},
+	}
+	b, _, err := f.RestAPIClient.Builds.Get(ctx, build.Organization, build.Pipeline, fmt.Sprint(build.BuildNumber), getOpts)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -142,6 +142,14 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 
+	// The text table only renders top-level build attributes, so skip the
+	// heavyweight job and pipeline payloads (important for large builds).
+	// Structured formats (json/yaml) keep the full payload for compatibility.
+	if format == output.FormatText {
+		listOpts.ExcludeJobs = true
+		listOpts.ExcludePipeline = true
+	}
+
 	if format == output.FormatText {
 		writer, cleanup := bkIO.Pager(f.NoPager, f.Config.Pager())
 		defer func() { _ = cleanup() }()

--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -651,6 +651,9 @@ func jobListOptionsFromFlags(opts *jobListOptions) (*buildkite.BuildsListOptions
 		ListOptions: buildkite.ListOptions{
 			PerPage: pageSize,
 		},
+		// Jobs are extracted from each build; the pipeline payload is unused,
+		// so exclude it to keep responses small (important for large builds).
+		ExcludePipeline: true,
 	}
 
 	now := time.Now()

--- a/cmd/preflight/preflight.go
+++ b/cmd/preflight/preflight.go
@@ -412,7 +412,15 @@ func cancelBuild(f *factory.Factory, renderer renderer, org, pipeline string, bu
 }
 
 func (c *RunCmd) loadFinalResult(ctx context.Context, client *buildkite.Client, org, pipeline string, buildNumber int) (internalpreflight.SummaryResult, error) {
-	buildWithTests, _, buildErr := client.Builds.Get(ctx, org, pipeline, strconv.Itoa(buildNumber), &buildkite.BuildGetOptions{IncludeTestEngine: true})
+	// Only the build ID and Test Engine data are used here, so skip the
+	// heavyweight job and pipeline payloads (important for large builds).
+	buildWithTests, _, buildErr := client.Builds.Get(ctx, org, pipeline, strconv.Itoa(buildNumber), &buildkite.BuildGetOptions{
+		IncludeTestEngine: true,
+		BuildsListOptions: buildkite.BuildsListOptions{
+			ExcludeJobs:     true,
+			ExcludePipeline: true,
+		},
+	})
 	expectTestSummary := buildErr == nil && buildWithTests.TestEngine != nil && len(buildWithTests.TestEngine.Runs) > 0
 
 	if buildErr != nil {

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -25,6 +25,10 @@ func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.
 			ListOptions: buildkite.ListOptions{
 				PerPage: 1,
 			},
+			// Only the build number is used from the response, so skip the
+			// heavyweight job and pipeline payloads (important for large builds).
+			ExcludeJobs:     true,
+			ExcludePipeline: true,
 		}
 		for _, opt := range listOpts {
 			err = opt(opts)

--- a/internal/build/watch/watch.go
+++ b/internal/build/watch/watch.go
@@ -86,13 +86,13 @@ func WatchBuild(
 		}
 
 		reqCtx, cancel := context.WithTimeout(ctx, DefaultRequestTimeout)
-		var getOpts *buildkite.BuildGetOptions
-		if cfg.includeRetriedJobs {
-			getOpts = &buildkite.BuildGetOptions{
-				BuildsListOptions: buildkite.BuildsListOptions{
-					IncludeRetriedJobs: true,
-				},
-			}
+		getOpts := &buildkite.BuildGetOptions{
+			BuildsListOptions: buildkite.BuildsListOptions{
+				IncludeRetriedJobs: cfg.includeRetriedJobs,
+				// Watchers render job progress but never use the pipeline
+				// payload, so exclude it to keep polling responses small.
+				ExcludePipeline: true,
+			},
 		}
 		b, _, err := client.Builds.Get(reqCtx, org, pipeline, fmt.Sprint(buildNumber), getOpts)
 		cancel()

--- a/internal/preflight/branch_build.go
+++ b/internal/preflight/branch_build.go
@@ -97,6 +97,10 @@ func ResolveBuilds(ctx context.Context, client *buildkite.Client, org, pipeline 
 		opts := &buildkite.BuildsListOptions{
 			Branch:      branchBatch,
 			ListOptions: buildkite.ListOptions{PerPage: resolveBuildsPerPage},
+			// Only build state/branch are used, so skip the heavyweight job and
+			// pipeline payloads (important for large builds).
+			ExcludeJobs:     true,
+			ExcludePipeline: true,
 		}
 
 		for page := 0; page < maxResolveBuildPages; page++ {


### PR DESCRIPTION
### Description

The Buildkite REST API supports `exclude_jobs` and `exclude_pipeline` query params to skip serializing the (potentially huge) jobs array and pipeline object in build responses. The [MCP server already uses this](https://github.com/buildkite/buildkite-mcp-server/blob/fdda11fad2ac7b9eb78b67a7dfb5af8b1efc53cd/pkg/buildkite/builds.go#L160-L166), and support exists in go-buildkite v5 (`BuildsListOptions.ExcludeJobs` / `ExcludePipeline`).

This PR applies these options everywhere the CLI fetches builds but never reads the jobs and/or pipeline payloads. No user-facing behaviour changes, just smaller, faster API responses, especially for builds with many jobs and for polling loops (`bk build watch`, `bk preflight`).

### Changes

Exclude **jobs + pipeline** (neither is read):
- `internal/build/resolver/with_options.go` - build resolution only uses the build number
- `internal/preflight/branch_build.go` - `ResolveBuilds` only uses build state/branch
- `cmd/preflight/preflight.go` (`loadFinalResult`) - only uses build ID + Test Engine data
- `cmd/build/list.go` - text output only; `-o json/yaml` keeps full payloads for compatibility

Exclude **pipeline** only (jobs still needed):
- `cmd/job/list.go` - jobs are extracted from builds; pipeline object unused
- `cmd/build/download.go` - needs jobs for log downloads
- `internal/build/watch/watch.go` - polling never reads the pipeline payload (now applied on every poll)

`bk build view` is intentionally untouched (renders jobs, and JSON output should stay complete)

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
