### PR TITLE
Add summary-only output for build list and view

### DIFF
--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -501,19 +501,12 @@ func displayBuilds(builds []buildkite.Build, format output.Format, writer io.Wri
 		return output.Write(writer, builds, format)
 	}
 
-	const (
-		maxMessageLength = 22
-		truncatedLength  = 19
-		timeFormat       = "2006-01-02T15:04:05Z"
-	)
+	const timeFormat = "2006-01-02T15:04:05Z"
 
 	var rows [][]string
 
 	for _, build := range builds {
-		message := build.Message
-		if len(message) > maxMessageLength {
-			message = message[:truncatedLength] + "..."
-		}
+		message := truncateBuildMessage(build.Message)
 
 		startedAt := "-"
 		if build.StartedAt != nil {
@@ -561,10 +554,11 @@ func displayBuilds(builds []buildkite.Build, format output.Format, writer io.Wri
 func displaySummaryTable(builds []buildkite.Build, writer io.Writer) error {
 	var rows [][]string
 	for _, build := range builds {
+		message, _, _ := strings.Cut(build.Message, "\n")
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", build.Number),
 			build.State,
-			build.Message,
+			truncateBuildMessage(message),
 			build.Branch,
 			build.Commit,
 			build.WebURL,
@@ -578,6 +572,17 @@ func displaySummaryTable(builds []buildkite.Build, writer io.Writer) error {
 	)
 	_, err := fmt.Fprint(writer, table)
 	return err
+}
+
+func truncateBuildMessage(message string) string {
+	const (
+		maxMessageLength = 22
+		truncatedLength  = 19
+	)
+	if len(message) > maxMessageLength {
+		return message[:truncatedLength] + "..."
+	}
+	return message
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -39,6 +39,7 @@ type ListCmd struct {
 	MetaData map[string]string `help:"Filter by build meta-data (key=value format, can be specified multiple times)"`
 	Limit    int               `help:"Maximum number of builds to return" default:"50"`
 	NoLimit  bool              `help:"Fetch all builds (overrides --limit)"`
+	Summary  bool              `help:"Return metadata only for fast state checks, polling, scripts, and LLM agents."`
 	output.OutputFlags
 }
 
@@ -59,6 +60,9 @@ Supported duration units are seconds (s), minutes (m), and hours (h).
 Examples:
   # List recent builds (50 by default)
   $ bk build list
+
+  # Check build states without downloading jobs or pipeline details
+  $ bk build list --summary
 
   # Get more builds (automatically paginates)
   $ bk build list --limit 500
@@ -174,6 +178,9 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return output.Write(os.Stdout, []buildkite.Build{}, format)
 	}
 
+	if c.Summary {
+		return displayBuildSummaries(builds, format, os.Stdout)
+	}
 	return displayBuilds(builds, format, os.Stdout)
 }
 
@@ -182,6 +189,10 @@ func (c *ListCmd) buildListOptions() (*buildkite.BuildsListOptions, error) {
 		ListOptions: buildkite.ListOptions{
 			PerPage: pageSize,
 		},
+	}
+	if c.Summary {
+		listOpts.ExcludeJobs = true
+		listOpts.ExcludePipeline = true
 	}
 
 	now := time.Now()
@@ -339,7 +350,11 @@ func (c *ListCmd) fetchBuilds(ctx context.Context, f *factory.Factory, org strin
 
 		// Stream only the builds we are about to add; header only once we actually print something
 		if format == output.FormatText && len(buildsToAdd) > 0 && writer != nil {
-			_ = displayBuilds(buildsToAdd, format, writer)
+			if c.Summary {
+				_ = displayBuildSummaries(buildsToAdd, format, writer)
+			} else {
+				_ = displayBuilds(buildsToAdd, format, writer)
+			}
 			if !printedAny {
 				fmt.Fprintln(writer)
 			}
@@ -541,6 +556,28 @@ func displayBuilds(builds []buildkite.Build, format output.Format, writer io.Wri
 	})
 	fmt.Fprint(writer, table)
 	return nil
+}
+
+func displaySummaryTable(builds []buildkite.Build, writer io.Writer) error {
+	var rows [][]string
+	for _, build := range builds {
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", build.Number),
+			build.State,
+			build.Message,
+			build.Branch,
+			build.Commit,
+			build.WebURL,
+		})
+	}
+
+	table := output.Table(
+		[]string{"Number", "State", "Message", "Branch", "Commit", "URL"},
+		rows,
+		map[string]string{"number": "bold", "state": "bold", "message": "italic", "url": "dim"},
+	)
+	_, err := fmt.Fprint(writer, table)
+	return err
 }
 
 func formatDuration(d time.Duration) string {

--- a/cmd/build/list.go
+++ b/cmd/build/list.go
@@ -143,6 +143,14 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	org := f.Config.OrganizationSlug()
+	summaryPipeline := ""
+	if c.Summary && c.Pipeline != "" {
+		pipeline, err := pipelineResolver.ResolveFromFlag(c.Pipeline, f.Config)(ctx)
+		if err != nil {
+			return err
+		}
+		summaryPipeline = pipeline.Name
+	}
 
 	format := output.ResolveFormat(c.Output, f.Config.OutputFormat())
 
@@ -179,7 +187,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	if c.Summary {
-		return displayBuildSummaries(builds, format, os.Stdout)
+		return displayBuildSummaries(builds, org, summaryPipeline, format, os.Stdout)
 	}
 	return displayBuilds(builds, format, os.Stdout)
 }
@@ -351,7 +359,7 @@ func (c *ListCmd) fetchBuilds(ctx context.Context, f *factory.Factory, org strin
 		// Stream only the builds we are about to add; header only once we actually print something
 		if format == output.FormatText && len(buildsToAdd) > 0 && writer != nil {
 			if c.Summary {
-				_ = displayBuildSummaries(buildsToAdd, format, writer)
+				_ = displayBuildSummaries(buildsToAdd, "", "", format, writer)
 			} else {
 				_ = displayBuilds(buildsToAdd, format, writer)
 			}
@@ -554,11 +562,10 @@ func displayBuilds(builds []buildkite.Build, format output.Format, writer io.Wri
 func displaySummaryTable(builds []buildkite.Build, writer io.Writer) error {
 	var rows [][]string
 	for _, build := range builds {
-		message, _, _ := strings.Cut(build.Message, "\n")
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", build.Number),
 			build.State,
-			truncateBuildMessage(message),
+			truncateBuildMessage(singleLineBuildMessage(build.Message)),
 			build.Branch,
 			build.Commit,
 			build.WebURL,

--- a/cmd/build/list_test.go
+++ b/cmd/build/list_test.go
@@ -95,7 +95,7 @@ func TestDisplayBuildSummaries_StructuredShape(t *testing.T) {
 	for _, format := range []output.Format{output.FormatJSON, output.FormatYAML} {
 		t.Run(string(format), func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := displayBuildSummaries(builds, format, &buf); err != nil {
+			if err := displayBuildSummaries(builds, "acme", "widgets", format, &buf); err != nil {
 				t.Fatalf("displayBuildSummaries failed: %v", err)
 			}
 
@@ -115,7 +115,10 @@ func TestDisplayBuildSummaries_StructuredShape(t *testing.T) {
 			if len(got) != 1 || got[0]["number"] != float64(42) || got[0]["state"] != "passed" {
 				t.Fatalf("unexpected summary: %#v", got)
 			}
-			for _, excluded := range []string{"jobs", "pipeline", "artifacts", "annotations"} {
+			if got[0]["organization"] != "acme" || got[0]["pipeline"] != "widgets" {
+				t.Errorf("summary target = %v/%v, want acme/widgets", got[0]["organization"], got[0]["pipeline"])
+			}
+			for _, excluded := range []string{"jobs", "artifacts", "annotations"} {
 				if _, ok := got[0][excluded]; ok {
 					t.Errorf("summary unexpectedly contains %q: %#v", excluded, got[0])
 				}
@@ -128,7 +131,7 @@ func TestDisplayBuildSummaries_Text(t *testing.T) {
 	var buf bytes.Buffer
 	builds := []buildkite.Build{{Number: 42, State: "failed", Message: "Deploy\nwith a detailed commit body", Branch: "main", WebURL: "https://example.test/42"}}
 
-	if err := displayBuildSummaries(builds, output.FormatText, &buf); err != nil {
+	if err := displayBuildSummaries(builds, "", "", output.FormatText, &buf); err != nil {
 		t.Fatalf("displayBuildSummaries failed: %v", err)
 	}
 

--- a/cmd/build/list_test.go
+++ b/cmd/build/list_test.go
@@ -126,7 +126,7 @@ func TestDisplayBuildSummaries_StructuredShape(t *testing.T) {
 
 func TestDisplayBuildSummaries_Text(t *testing.T) {
 	var buf bytes.Buffer
-	builds := []buildkite.Build{{Number: 42, State: "failed", Message: "Deploy", Branch: "main", WebURL: "https://example.test/42"}}
+	builds := []buildkite.Build{{Number: 42, State: "failed", Message: "Deploy\nwith a detailed commit body", Branch: "main", WebURL: "https://example.test/42"}}
 
 	if err := displayBuildSummaries(builds, output.FormatText, &buf); err != nil {
 		t.Fatalf("displayBuildSummaries failed: %v", err)
@@ -136,6 +136,9 @@ func TestDisplayBuildSummaries_Text(t *testing.T) {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("summary text %q does not contain %q", buf.String(), want)
 		}
+	}
+	if strings.Contains(buf.String(), "detailed commit body") {
+		t.Errorf("summary text includes the multi-line commit body: %q", buf.String())
 	}
 }
 

--- a/cmd/build/list_test.go
+++ b/cmd/build/list_test.go
@@ -2,12 +2,14 @@ package build
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/buildkite/cli/v3/pkg/output"
 	buildkite "github.com/buildkite/go-buildkite/v5"
+	"github.com/goccy/go-yaml"
 )
 
 type buildListOptions struct {
@@ -59,6 +61,81 @@ func TestBuildListOptions_EmptyMetaData(t *testing.T) {
 
 	if len(opts.MetaData.MetaData) != 0 {
 		t.Errorf("Expected empty meta-data, got %d entries", len(opts.MetaData.MetaData))
+	}
+}
+
+func TestBuildListOptions_Summary(t *testing.T) {
+	cmd := &ListCmd{Summary: true}
+
+	opts, err := cmd.buildListOptions()
+	if err != nil {
+		t.Fatalf("buildListOptions failed: %v", err)
+	}
+
+	if !opts.ExcludeJobs || !opts.ExcludePipeline {
+		t.Fatalf("summary options = %+v, want jobs and pipeline excluded", opts)
+	}
+}
+
+func TestDisplayBuildSummaries_StructuredShape(t *testing.T) {
+	builds := []buildkite.Build{{
+		ID:      "build-id",
+		Number:  42,
+		State:   "passed",
+		Message: "Ship it",
+		Branch:  "main",
+		Commit:  "abcdef",
+		WebURL:  "https://buildkite.com/acme/widgets/builds/42",
+		Jobs:    []buildkite.Job{{ID: "job-id"}},
+		Pipeline: &buildkite.Pipeline{
+			ID: "pipeline-id",
+		},
+	}}
+
+	for _, format := range []output.Format{output.FormatJSON, output.FormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := displayBuildSummaries(builds, format, &buf); err != nil {
+				t.Fatalf("displayBuildSummaries failed: %v", err)
+			}
+
+			jsonData := buf.Bytes()
+			if format == output.FormatYAML {
+				var err error
+				jsonData, err = yaml.YAMLToJSON(jsonData)
+				if err != nil {
+					t.Fatalf("convert YAML to JSON: %v", err)
+				}
+			}
+
+			var got []map[string]any
+			if err := json.Unmarshal(jsonData, &got); err != nil {
+				t.Fatalf("decode output: %v", err)
+			}
+			if len(got) != 1 || got[0]["number"] != float64(42) || got[0]["state"] != "passed" {
+				t.Fatalf("unexpected summary: %#v", got)
+			}
+			for _, excluded := range []string{"jobs", "pipeline", "artifacts", "annotations"} {
+				if _, ok := got[0][excluded]; ok {
+					t.Errorf("summary unexpectedly contains %q: %#v", excluded, got[0])
+				}
+			}
+		})
+	}
+}
+
+func TestDisplayBuildSummaries_Text(t *testing.T) {
+	var buf bytes.Buffer
+	builds := []buildkite.Build{{Number: 42, State: "failed", Message: "Deploy", Branch: "main", WebURL: "https://example.test/42"}}
+
+	if err := displayBuildSummaries(builds, output.FormatText, &buf); err != nil {
+		t.Fatalf("displayBuildSummaries failed: %v", err)
+	}
+
+	for _, want := range []string{"42", "failed", "Deploy", "main", "https://example.test/42"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("summary text %q does not contain %q", buf.String(), want)
+		}
 	}
 }
 

--- a/cmd/build/summary.go
+++ b/cmd/build/summary.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"io"
+	"strings"
 
 	"github.com/buildkite/cli/v3/internal/build/view"
 	"github.com/buildkite/cli/v3/pkg/output"
@@ -43,22 +44,29 @@ func newBuildSummary(build buildkite.Build, organization, pipeline string) build
 }
 
 func newBuildSummaryOutput(build buildkite.Build, organization, pipeline string) output.Viewable[buildSummary] {
+	textBuild := build
+	textBuild.Message = singleLineBuildMessage(build.Message)
 	return output.Viewable[buildSummary]{
 		Data: newBuildSummary(build, organization, pipeline),
 		Render: func(buildSummary) string {
-			return view.BuildSummary(&build, organization, pipeline)
+			return view.BuildSummary(&textBuild, organization, pipeline)
 		},
 	}
 }
 
-func displayBuildSummaries(builds []buildkite.Build, format output.Format, writer io.Writer) error {
+func displayBuildSummaries(builds []buildkite.Build, organization, pipeline string, format output.Format, writer io.Writer) error {
 	if format == output.FormatText {
 		return displaySummaryTable(builds, writer)
 	}
 
 	summaries := make([]buildSummary, len(builds))
 	for i, build := range builds {
-		summaries[i] = newBuildSummary(build, "", "")
+		summaries[i] = newBuildSummary(build, organization, pipeline)
 	}
 	return output.Write(writer, summaries, format)
+}
+
+func singleLineBuildMessage(message string) string {
+	firstLine, _, _ := strings.Cut(message, "\n")
+	return firstLine
 }

--- a/cmd/build/summary.go
+++ b/cmd/build/summary.go
@@ -1,0 +1,64 @@
+package build
+
+import (
+	"io"
+
+	"github.com/buildkite/cli/v3/internal/build/view"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v5"
+)
+
+type buildSummary struct {
+	ID           string               `json:"id" yaml:"id"`
+	Number       int                  `json:"number" yaml:"number"`
+	State        string               `json:"state" yaml:"state"`
+	Message      string               `json:"message" yaml:"message"`
+	Branch       string               `json:"branch" yaml:"branch"`
+	Commit       string               `json:"commit" yaml:"commit"`
+	WebURL       string               `json:"web_url" yaml:"web_url"`
+	CreatedAt    *buildkite.Timestamp `json:"created_at" yaml:"created_at"`
+	StartedAt    *buildkite.Timestamp `json:"started_at" yaml:"started_at"`
+	FinishedAt   *buildkite.Timestamp `json:"finished_at" yaml:"finished_at"`
+	Source       string               `json:"source" yaml:"source"`
+	Organization string               `json:"organization,omitempty" yaml:"organization,omitempty"`
+	Pipeline     string               `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
+}
+
+func newBuildSummary(build buildkite.Build, organization, pipeline string) buildSummary {
+	return buildSummary{
+		ID:           build.ID,
+		Number:       build.Number,
+		State:        build.State,
+		Message:      build.Message,
+		Branch:       build.Branch,
+		Commit:       build.Commit,
+		WebURL:       build.WebURL,
+		CreatedAt:    build.CreatedAt,
+		StartedAt:    build.StartedAt,
+		FinishedAt:   build.FinishedAt,
+		Source:       build.Source,
+		Organization: organization,
+		Pipeline:     pipeline,
+	}
+}
+
+func newBuildSummaryOutput(build buildkite.Build, organization, pipeline string) output.Viewable[buildSummary] {
+	return output.Viewable[buildSummary]{
+		Data: newBuildSummary(build, organization, pipeline),
+		Render: func(buildSummary) string {
+			return view.BuildSummary(&build, organization, pipeline)
+		},
+	}
+}
+
+func displayBuildSummaries(builds []buildkite.Build, format output.Format, writer io.Writer) error {
+	if format == output.FormatText {
+		return displaySummaryTable(builds, writer)
+	}
+
+	summaries := make([]buildSummary, len(builds))
+	for i, build := range builds {
+		summaries[i] = newBuildSummary(build, "", "")
+	}
+	return output.Write(writer, summaries, format)
+}

--- a/cmd/build/view.go
+++ b/cmd/build/view.go
@@ -27,7 +27,8 @@ type ViewCmd struct {
 	User        string   `help:"Filter builds to this user. You can use name or email." short:"u" xor:"userfilter"`
 	Mine        bool     `help:"Filter builds to only my user." xor:"userfilter"`
 	JobStates   []string `help:"Filter jobs by state. Valid states: running, scheduled, passed, failed, canceled, skipped, not_run, broken." short:"s" sep:","`
-	Web         bool     `help:"Open the build in a web browser." short:"w"`
+	Web         bool     `help:"Open the build in a web browser." short:"w" xor:"viewmode"`
+	Summary     bool     `help:"Return metadata only for fast state checks, polling, scripts, and LLM agents." xor:"viewmode"`
 	output.OutputFlags
 }
 
@@ -43,6 +44,9 @@ Examples:
 
   # To view a specific build
   $ bk build view 429
+
+  # Check build state without downloading jobs, artifacts, annotations, or pipeline details
+  $ bk build view 429 --summary
 
   # Add -w to any command to open the build in your web browser instead
   $ bk build view -w 429
@@ -65,8 +69,14 @@ Examples:
 }
 
 func (c *ViewCmd) buildGetOptions() *buildkite.BuildGetOptions {
-	if len(c.JobStates) > 0 {
-		return &buildkite.BuildGetOptions{JobStates: c.JobStates}
+	if len(c.JobStates) > 0 || c.Summary {
+		return &buildkite.BuildGetOptions{
+			BuildsListOptions: buildkite.BuildsListOptions{
+				ExcludeJobs:     c.Summary,
+				ExcludePipeline: c.Summary,
+			},
+			JobStates: c.JobStates,
+		}
 	}
 	return nil
 }
@@ -148,67 +158,15 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	var build buildkite.Build
 	var artifacts []buildkite.Artifact
 	var annotations []buildkite.Annotation
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-
 	if err = bkIO.SpinWhile(f, "Loading build information", func() error {
-		var fetchErr error
-		wg.Add(3)
-		go func() {
-			defer wg.Done()
-			var apiErr error
-			build, _, apiErr = f.RestAPIClient.Builds.Get(
-				ctx,
-				opts.Organization,
-				opts.Pipeline,
-				fmt.Sprint(opts.BuildNumber),
-				c.buildGetOptions(),
-			)
-			if apiErr != nil {
-				mu.Lock()
-				fetchErr = apiErr
-				mu.Unlock()
-			}
-		}()
-
-		go func() {
-			defer wg.Done()
-			var apiErr error
-			artifacts, _, apiErr = f.RestAPIClient.Artifacts.ListByBuild(
-				ctx,
-				opts.Organization,
-				opts.Pipeline,
-				fmt.Sprint(opts.BuildNumber),
-				nil,
-			)
-			if apiErr != nil {
-				mu.Lock()
-				fetchErr = apiErr
-				mu.Unlock()
-			}
-		}()
-
-		go func() {
-			defer wg.Done()
-			var apiErr error
-			annotations, _, apiErr = f.RestAPIClient.Annotations.ListByBuild(
-				ctx,
-				opts.Organization,
-				opts.Pipeline,
-				fmt.Sprint(opts.BuildNumber),
-				nil,
-			)
-			if apiErr != nil {
-				mu.Lock()
-				fetchErr = apiErr
-				mu.Unlock()
-			}
-		}()
-
-		wg.Wait()
-		return fetchErr
+		build, artifacts, annotations, err = c.fetchBuildDetails(ctx, f, opts)
+		return err
 	}); err != nil {
 		return err
+	}
+
+	if c.Summary {
+		return output.Write(os.Stdout, newBuildSummaryOutput(build, opts.Organization, opts.Pipeline), format)
 	}
 
 	// Create a combined view for JSON/YAML output
@@ -238,4 +196,53 @@ func (c *ViewCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	return output.Write(os.Stdout, buildOutput, format)
+}
+
+func (c *ViewCmd) fetchBuildDetails(ctx context.Context, f *factory.Factory, opts view.ViewOptions) (buildkite.Build, []buildkite.Artifact, []buildkite.Annotation, error) {
+	if c.Summary {
+		build, _, err := f.RestAPIClient.Builds.Get(ctx, opts.Organization, opts.Pipeline, fmt.Sprint(opts.BuildNumber), c.buildGetOptions())
+		return build, nil, nil, err
+	}
+
+	var build buildkite.Build
+	var artifacts []buildkite.Artifact
+	var annotations []buildkite.Annotation
+	var fetchErr error
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		var apiErr error
+		build, _, apiErr = f.RestAPIClient.Builds.Get(ctx, opts.Organization, opts.Pipeline, fmt.Sprint(opts.BuildNumber), c.buildGetOptions())
+		if apiErr != nil {
+			mu.Lock()
+			fetchErr = apiErr
+			mu.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var apiErr error
+		artifacts, _, apiErr = f.RestAPIClient.Artifacts.ListByBuild(ctx, opts.Organization, opts.Pipeline, fmt.Sprint(opts.BuildNumber), nil)
+		if apiErr != nil {
+			mu.Lock()
+			fetchErr = apiErr
+			mu.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var apiErr error
+		annotations, _, apiErr = f.RestAPIClient.Annotations.ListByBuild(ctx, opts.Organization, opts.Pipeline, fmt.Sprint(opts.BuildNumber), nil)
+		if apiErr != nil {
+			mu.Lock()
+			fetchErr = apiErr
+			mu.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	return build, artifacts, annotations, fetchErr
 }

--- a/cmd/build/view_test.go
+++ b/cmd/build/view_test.go
@@ -125,7 +125,7 @@ func TestBuildSummaryOutput_StructuredAndText(t *testing.T) {
 		ID:      "build-id",
 		Number:  42,
 		State:   "passed",
-		Message: "Ship it",
+		Message: "Ship it\nwith a detailed commit body",
 		Branch:  "main",
 		Commit:  "abcdef",
 		WebURL:  "https://example.test/42",
@@ -156,5 +156,8 @@ func TestBuildSummaryOutput_StructuredAndText(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Errorf("summary text %q does not contain %q", text, want)
 		}
+	}
+	if strings.Contains(text, "detailed commit body") {
+		t.Errorf("summary text includes the multi-line commit body: %q", text)
 	}
 }

--- a/cmd/build/view_test.go
+++ b/cmd/build/view_test.go
@@ -1,7 +1,18 @@
 package build
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/build/view"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	"github.com/buildkite/cli/v3/pkg/output"
+	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 func TestViewCmd_BuildGetOptions_WithJobStates(t *testing.T) {
@@ -54,5 +65,96 @@ func TestViewCmd_BuildGetOptions_SingleState(t *testing.T) {
 
 	if opts.JobStates[0] != "running" {
 		t.Errorf("Expected state to be 'running', got %q", opts.JobStates[0])
+	}
+}
+
+func TestViewCmd_BuildGetOptions_Summary(t *testing.T) {
+	opts := (&ViewCmd{Summary: true}).buildGetOptions()
+	if opts == nil || !opts.ExcludeJobs || !opts.ExcludePipeline {
+		t.Fatalf("summary options = %+v, want jobs and pipeline excluded", opts)
+	}
+}
+
+func TestViewCmd_SummaryAndWebAreIncompatible(t *testing.T) {
+	var cli struct {
+		View ViewCmd `cmd:""`
+	}
+	parser := kong.Must(&cli, kong.Vars{"output_default_format": ""})
+
+	if _, err := parser.Parse([]string{"view", "--summary", "--web"}); err == nil {
+		t.Fatal("expected --summary --web to be rejected")
+	}
+}
+
+func TestFetchBuildDetails_SummarySkipsArtifactsAndAnnotations(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Query().Get("exclude_jobs") != "true" || r.URL.Query().Get("exclude_pipeline") != "true" {
+			t.Errorf("summary request query = %q", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode(buildkite.Build{Number: 42, State: "passed"})
+	}))
+	defer server.Close()
+
+	client, err := buildkite.NewOpts(buildkite.WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &factory.Factory{RestAPIClient: client}
+	cmd := &ViewCmd{Summary: true}
+
+	build, artifacts, annotations, err := cmd.fetchBuildDetails(context.Background(), f, view.ViewOptions{
+		Organization: "acme",
+		Pipeline:     "widgets",
+		BuildNumber:  42,
+	})
+	if err != nil {
+		t.Fatalf("fetchBuildDetails failed: %v", err)
+	}
+	if build.Number != 42 || len(artifacts) != 0 || len(annotations) != 0 {
+		t.Fatalf("unexpected details: build=%+v artifacts=%+v annotations=%+v", build, artifacts, annotations)
+	}
+	if len(paths) != 1 || strings.Contains(paths[0], "artifacts") || strings.Contains(paths[0], "annotations") {
+		t.Fatalf("summary requested unexpected paths: %v", paths)
+	}
+}
+
+func TestBuildSummaryOutput_StructuredAndText(t *testing.T) {
+	build := buildkite.Build{
+		ID:      "build-id",
+		Number:  42,
+		State:   "passed",
+		Message: "Ship it",
+		Branch:  "main",
+		Commit:  "abcdef",
+		WebURL:  "https://example.test/42",
+		Jobs:    []buildkite.Job{{ID: "job-id"}},
+		Pipeline: &buildkite.Pipeline{
+			ID: "pipeline-id",
+		},
+	}
+	summary := newBuildSummaryOutput(build, "acme", "widgets")
+
+	for _, format := range []output.Format{output.FormatJSON, output.FormatYAML} {
+		var buf strings.Builder
+		if err := output.Write(&buf, summary, format); err != nil {
+			t.Fatalf("write %s: %v", format, err)
+		}
+		for _, excluded := range []string{"jobs", "artifacts", "annotations"} {
+			if strings.Contains(buf.String(), excluded) {
+				t.Errorf("%s summary unexpectedly contains %q: %s", format, excluded, buf.String())
+			}
+		}
+		if !strings.Contains(buf.String(), "widgets") || strings.Contains(buf.String(), "pipeline-id") {
+			t.Errorf("%s summary should contain only the pipeline slug: %s", format, buf.String())
+		}
+	}
+
+	text := summary.TextOutput()
+	for _, want := range []string{"acme/widgets", "#42", "passed", "Ship it", "main", "https://example.test/42"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("summary text %q does not contain %q", text, want)
+		}
 	}
 }

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -22,8 +22,6 @@ func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.
 		}
 
 		opts := &buildkite.BuildsListOptions{
-			ExcludeJobs:     true,
-			ExcludePipeline: true,
 			ListOptions: buildkite.ListOptions{
 				PerPage: 1,
 			},

--- a/internal/build/resolver/with_options.go
+++ b/internal/build/resolver/with_options.go
@@ -22,6 +22,8 @@ func ResolveBuildWithOpts(f *factory.Factory, pipelineResolver pipelineResolver.
 		}
 
 		opts := &buildkite.BuildsListOptions{
+			ExcludeJobs:     true,
+			ExcludePipeline: true,
 			ListOptions: buildkite.ListOptions{
 				PerPage: 1,
 			},

--- a/internal/build/resolver/with_options_test.go
+++ b/internal/build/resolver/with_options_test.go
@@ -1,0 +1,44 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/pipeline"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
+	buildkite "github.com/buildkite/go-buildkite/v5"
+	"github.com/spf13/afero"
+)
+
+func TestResolveBuildWithOptsExcludesJobsAndPipeline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("exclude_jobs") != "true" || r.URL.Query().Get("exclude_pipeline") != "true" {
+			t.Errorf("resolver request query = %q, want jobs and pipeline excluded", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode([]buildkite.Build{{Number: 42}})
+	}))
+	defer server.Close()
+
+	client, err := buildkite.NewOpts(buildkite.WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf := config.New(afero.NewMemMapFs(), nil)
+	conf.SelectOrganization("acme", true)
+	f := &factory.Factory{Config: conf, RestAPIClient: client}
+	resolvePipeline := func(context.Context) (*pipeline.Pipeline, error) {
+		return &pipeline.Pipeline{Name: "widgets", Org: "acme"}, nil
+	}
+
+	build, err := ResolveBuildWithOpts(f, resolvePipeline)(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveBuildWithOpts failed: %v", err)
+	}
+	if build.BuildNumber != 42 {
+		t.Fatalf("resolved build = %+v, want build 42", build)
+	}
+}


### PR DESCRIPTION
### Description

Build state checks currently download jobs, expanded pipeline details, artifacts, and annotations that polling loops and automation do not use. Add `--summary` to `bk build list` and `bk build view` so humans, scripts, and LLM agents can request a stable metadata-only representation while avoiding those API payloads and requests.

Existing invocations keep their current output and request behavior. Summary JSON/YAML contains build identity, state, message, source-control metadata, timestamps, URL, and—when known—organization and pipeline slugs; it never embeds jobs, expanded pipeline objects, artifacts, or annotations.

### Deployment

Low risk: this is opt-in CLI behavior with no migration or dependency change. The latest-build resolver now requests less data but retains the build number it needs.

### Rollback

Revert this PR. No persisted data or server-side state requires cleanup.

### Disclosures / Credits

Amp implemented the tests and code under human-authored requirements; the contributor reviewed the resulting diff and local checks.
