### PR TITLE
Infer analytics endpoints by path

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -73,6 +73,9 @@ func buildFullEndpoint(endpoint, orgSlug string, isAnalytics bool) string {
 		endpoint = "/" + endpoint
 	}
 
+	// Analytics endpoints begin with /suites
+	isAnalytics = isAnalytics || strings.HasPrefix(endpoint, "/suites")
+
 	var endpointPrefix string
 	if isAnalytics {
 		endpointPrefix = fmt.Sprintf("v2/analytics/organizations/%s", orgSlug)

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -49,13 +49,13 @@ func TestBuildFullEndpoint(t *testing.T) {
 		"analytics endpoint with leading slash": {
 			endpoint:     "/suites",
 			orgSlug:      "test-org",
-			isAnalytics:  true,
+			isAnalytics:  false,
 			wantEndpoint: "v2/analytics/organizations/test-org/suites",
 		},
 		"analytics endpoint without leading slash": {
 			endpoint:     "suites",
 			orgSlug:      "test-org",
-			isAnalytics:  true,
+			isAnalytics:  false,
 			wantEndpoint: "v2/analytics/organizations/test-org/suites",
 		},
 		"pipeline endpoint without leading slash": {


### PR DESCRIPTION
### Description

Currently all analytics (AKA Test Engine) API calls must be made with `bk api --analytics`. Almost all Test Engine endpoints begin with `/suites` so in those cases we can infer `isAnalytics` from the path.

### Changes

This change sets `isAnalytics` to true when running `bk api` if the endpoint begins with `/suites`.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)


### Disclosures / Credits

I did not use AI tools at all