### PR TITLE
Use List Jobs endpoint for build-specific job lists

### DIFF
--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -155,9 +155,10 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	org := f.Config.OrganizationSlug()
 	var jobs []buildkite.Job
 	var resolvedPipeline *pipeline.Pipeline
+	var queueIDs []string
 
 	if err = bkIO.SpinWhile(f, "Loading jobs", func() error {
-		jobs, resolvedPipeline, err = fetchJobList(ctx, f, org, opts, listOpts)
+		jobs, resolvedPipeline, queueIDs, err = fetchJobList(ctx, f, org, opts, listOpts)
 		return err
 	}); err != nil {
 		return fmt.Errorf("failed to list jobs: %w", err)
@@ -165,7 +166,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	shouldApplyFilters := opts.build != "" || opts.queue == ""
 	if shouldApplyFilters && (opts.queue != "" || len(opts.state) > 0 || opts.duration != "") {
-		jobs, err = applyClientSideFilters(jobs, opts)
+		jobs, err = applyClientSideFilters(jobs, opts, queueIDs)
 		if err != nil {
 			return fmt.Errorf("failed to apply filters: %w", err)
 		}
@@ -206,25 +207,33 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	return displayJobs(jobs, format, os.Stdout)
 }
 
-func fetchJobList(ctx context.Context, f *factory.Factory, org string, opts jobListOptions, listOpts *buildkite.BuildsListOptions) ([]buildkite.Job, *pipeline.Pipeline, error) {
+func fetchJobList(ctx context.Context, f *factory.Factory, org string, opts jobListOptions, listOpts *buildkite.BuildsListOptions) ([]buildkite.Job, *pipeline.Pipeline, []string, error) {
 	if opts.build != "" {
 		resolvedPipeline, err := resolveJobListPipeline(ctx, f, opts.pipeline)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
+		}
+
+		var queueIDs []string
+		if opts.queue != "" {
+			queueIDs, err = lookupQueueIDs(ctx, f, resolvedPipeline.Org, opts.queue)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		}
 
 		fetchAll := opts.noLimit || opts.queue != "" || opts.duration != "" || opts.orderBy != ""
 		jobs, err := fetchJobsByBuild(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, opts.build, opts, fetchAll)
-		return jobs, resolvedPipeline, err
+		return jobs, resolvedPipeline, queueIDs, err
 	}
 
 	if opts.queue != "" {
 		jobs, err := fetchJobsWithQueueFilter(ctx, f, org, opts)
-		return jobs, nil, err
+		return jobs, nil, nil, err
 	}
 
 	jobs, err := fetchJobs(ctx, f, org, opts, listOpts)
-	return jobs, nil, err
+	return jobs, nil, nil, err
 }
 
 func resolveJobListPipeline(ctx context.Context, f *factory.Factory, pipelineFlag string) (*pipeline.Pipeline, error) {
@@ -377,7 +386,7 @@ func listJobsWithPagination(ctx context.Context, f *factory.Factory, org string,
 
 		// Apply client-side filters if needed
 		if len(noQueueOpts.state) > 0 || noQueueOpts.duration != "" {
-			jobBatch, err = applyClientSideFilters(jobBatch, noQueueOpts)
+			jobBatch, err = applyClientSideFilters(jobBatch, noQueueOpts, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply filters: %w", err)
 			}
@@ -740,6 +749,10 @@ func mapGraphQLState(graphqlState, exitStatus string) string {
 }
 
 func jobListOptionsFromFlags(opts *jobListOptions) (*buildkite.BuildsListOptions, error) {
+	if opts.build != "" && (opts.since != "" || opts.until != "") {
+		return nil, fmt.Errorf("--since and --until cannot be used with --build")
+	}
+
 	listOpts := &buildkite.BuildsListOptions{
 		ListOptions: buildkite.ListOptions{
 			PerPage: pageSize,
@@ -784,7 +797,7 @@ func getBuildsByPipeline(ctx context.Context, f *factory.Factory, org, pipelineF
 	return builds, err
 }
 
-func applyClientSideFilters(jobs []buildkite.Job, opts jobListOptions) ([]buildkite.Job, error) {
+func applyClientSideFilters(jobs []buildkite.Job, opts jobListOptions, queueIDs []string) ([]buildkite.Job, error) {
 	if opts.queue == "" && len(opts.state) == 0 && opts.duration == "" {
 		return jobs, nil
 	}
@@ -826,7 +839,7 @@ func applyClientSideFilters(jobs []buildkite.Job, opts jobListOptions) ([]buildk
 		job := &jobs[i]
 
 		if opts.queue != "" {
-			if !matchesQueue(*job, opts.queue) {
+			if !matchesQueue(*job, opts.queue, queueIDs) {
 				continue
 			}
 		}
@@ -871,7 +884,11 @@ func applyClientSideFilters(jobs []buildkite.Job, opts jobListOptions) ([]buildk
 	return result, nil
 }
 
-func matchesQueue(job buildkite.Job, queueFilter string) bool {
+func matchesQueue(job buildkite.Job, queueFilter string, queueIDs []string) bool {
+	if len(queueIDs) > 0 {
+		return containsString(queueIDs, job.ClusterQueueID)
+	}
+
 	for _, rule := range job.AgentQueryRules {
 		if strings.Contains(strings.ToLower(rule), "queue="+strings.ToLower(queueFilter)) {
 			return true

--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/cli/v3/internal/cli"
 	bkGraphQL "github.com/buildkite/cli/v3/internal/graphql"
 	bkIO "github.com/buildkite/cli/v3/internal/io"
+	"github.com/buildkite/cli/v3/internal/pipeline"
 	pipelineResolver "github.com/buildkite/cli/v3/internal/pipeline/resolver"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/cmd/validation"
@@ -29,6 +30,7 @@ const (
 
 type ListCmd struct {
 	Pipeline string   `help:"Filter by pipeline slug" short:"p"`
+	Build    string   `help:"Filter by build number (requires a resolvable pipeline)"`
 	Since    string   `help:"Filter jobs from builds created since this time (e.g. 1h, 30m)"`
 	Until    string   `help:"Filter jobs from builds created before this time (e.g. 1h, 30m)"`
 	Duration string   `help:"Filter by duration (e.g. >10m, <5m, 20m) - supports >, <, >=, <= operators"`
@@ -42,14 +44,17 @@ type ListCmd struct {
 
 func (c *ListCmd) Help() string {
 	return `This command supports both server-side filtering (fast) and client-side filtering.
-Server-side filters are applied when fetching builds, while client-side filters
-are applied after extracting jobs from builds.
+When a build number is known, use --build to fetch its jobs directly. The pipeline
+can be passed with --pipeline or resolved from the current repository or config.
 
 Client-side filters: --queue, --state, --duration
-Server-side filters: --pipeline, --since, --until
+Server-side filters: --pipeline, --build, --since, --until
 
-By default, fetches up to 200 builds for filtering. Use --no-limit if you need to
-search across more builds to find all matching jobs.
+With --build, --state is also applied by the server. Client-side filters and
+ordering are applied after all required cursor pages have been fetched.
+
+Without --build, the command fetches up to 200 builds for filtering by default.
+Use --no-limit if you need to search across more builds to find all matching jobs.
 
 Jobs can be filtered by queue, state, duration, and other attributes.
 When filtering by duration, you can use operators like >, <, >=, and <= to specify your criteria.
@@ -64,6 +69,9 @@ Examples:
 
   # List running jobs
   $ bk job list --state running
+
+  # List failed jobs from a known build (recommended when the build is known)
+  $ bk job list --pipeline my-app --build 429 --state failed
 
   # List jobs that took longer than 10 minutes
   $ bk job list --duration ">10m"
@@ -87,6 +95,7 @@ Examples:
 
 type jobListOptions struct {
 	pipeline string
+	build    string
 	since    string
 	until    string
 	duration string
@@ -126,6 +135,7 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	opts := jobListOptions{
 		pipeline: c.Pipeline,
+		build:    c.Build,
 		since:    c.Since,
 		until:    c.Until,
 		duration: c.Duration,
@@ -144,19 +154,17 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	ctx := context.Background()
 	org := f.Config.OrganizationSlug()
 	var jobs []buildkite.Job
+	var resolvedPipeline *pipeline.Pipeline
 
 	if err = bkIO.SpinWhile(f, "Loading jobs", func() error {
-		if opts.queue != "" {
-			jobs, err = fetchJobsWithQueueFilter(ctx, f, org, opts)
-		} else {
-			jobs, err = fetchJobs(ctx, f, org, opts, listOpts)
-		}
+		jobs, resolvedPipeline, err = fetchJobList(ctx, f, org, opts, listOpts)
 		return err
 	}); err != nil {
 		return fmt.Errorf("failed to list jobs: %w", err)
 	}
 
-	if opts.queue == "" && (len(opts.state) > 0 || opts.duration != "") {
+	shouldApplyFilters := opts.build != "" || opts.queue == ""
+	if shouldApplyFilters && (opts.queue != "" || len(opts.state) > 0 || opts.duration != "") {
 		jobs, err = applyClientSideFilters(jobs, opts)
 		if err != nil {
 			return fmt.Errorf("failed to apply filters: %w", err)
@@ -185,7 +193,9 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		defer func() { _ = cleanup() }()
 
 		target := org
-		if c.Pipeline != "" {
+		if resolvedPipeline != nil {
+			target = fmt.Sprintf("%s/%s", resolvedPipeline.Org, resolvedPipeline.Name)
+		} else if c.Pipeline != "" {
 			target = fmt.Sprintf("%s/%s", org, c.Pipeline)
 		}
 
@@ -194,6 +204,89 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	}
 
 	return displayJobs(jobs, format, os.Stdout)
+}
+
+func fetchJobList(ctx context.Context, f *factory.Factory, org string, opts jobListOptions, listOpts *buildkite.BuildsListOptions) ([]buildkite.Job, *pipeline.Pipeline, error) {
+	if opts.build != "" {
+		resolvedPipeline, err := resolveJobListPipeline(ctx, f, opts.pipeline)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		fetchAll := opts.noLimit || opts.queue != "" || opts.duration != "" || opts.orderBy != ""
+		jobs, err := fetchJobsByBuild(ctx, f.RestAPIClient, resolvedPipeline.Org, resolvedPipeline.Name, opts.build, opts, fetchAll)
+		return jobs, resolvedPipeline, err
+	}
+
+	if opts.queue != "" {
+		jobs, err := fetchJobsWithQueueFilter(ctx, f, org, opts)
+		return jobs, nil, err
+	}
+
+	jobs, err := fetchJobs(ctx, f, org, opts, listOpts)
+	return jobs, nil, err
+}
+
+func resolveJobListPipeline(ctx context.Context, f *factory.Factory, pipelineFlag string) (*pipeline.Pipeline, error) {
+	resolvers := pipelineResolver.AggregateResolver{
+		pipelineResolver.ResolveFromFlag(pipelineFlag, f.Config),
+		pipelineResolver.ResolveFromConfig(f.Config, pipelineResolver.PickOneWithFactory(f)),
+		pipelineResolver.ResolveFromRepository(f, pipelineResolver.CachedPicker(f.Config, pipelineResolver.PickOneWithFactory(f))),
+	}
+
+	resolvedPipeline, err := resolvers.Resolve(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("--build requires a pipeline; specify one with --pipeline or run from a linked repository: %w", err)
+	}
+	if resolvedPipeline == nil {
+		return nil, fmt.Errorf("--build requires a pipeline; specify one with --pipeline or run from a linked repository")
+	}
+
+	return resolvedPipeline, nil
+}
+
+func fetchJobsByBuild(ctx context.Context, client *buildkite.Client, org, pipeline, build string, opts jobListOptions, fetchAll bool) ([]buildkite.Job, error) {
+	fetchAll = fetchAll || opts.noLimit
+	if !fetchAll && opts.limit <= 0 {
+		return []buildkite.Job{}, nil
+	}
+
+	includeRetriedJobs := false
+	jobsListOpts := &buildkite.JobsListOptions{
+		State:              opts.state,
+		IncludeRetriedJobs: &includeRetriedJobs,
+		PerPage:            pageSize,
+	}
+	if !fetchAll {
+		jobsListOpts.PerPage = min(opts.limit, pageSize)
+	}
+
+	var jobs []buildkite.Job
+	for {
+		page, _, err := client.Jobs.ListByBuild(ctx, org, pipeline, build, jobsListOpts)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, page.Items...)
+
+		if !fetchAll && len(jobs) >= opts.limit {
+			return jobs[:opts.limit], nil
+		}
+		if page.Links.Next == "" {
+			return jobs, nil
+		}
+
+		jobsListOpts, err = page.Links.Next.ToOptions()
+		if err != nil {
+			return nil, fmt.Errorf("invalid next jobs page: %w", err)
+		}
+		jobsListOpts.State = opts.state
+		jobsListOpts.IncludeRetriedJobs = &includeRetriedJobs
+		jobsListOpts.PerPage = pageSize
+		if !fetchAll {
+			jobsListOpts.PerPage = min(opts.limit-len(jobs), pageSize)
+		}
+	}
 }
 
 func fetchJobs(ctx context.Context, f *factory.Factory, org string, opts jobListOptions, listOpts *buildkite.BuildsListOptions) ([]buildkite.Job, error) {

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -2,13 +2,368 @@ package job
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildkite/cli/v3/internal/config"
+	"github.com/buildkite/cli/v3/internal/pipeline"
+	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/output"
 	buildkite "github.com/buildkite/go-buildkite/v5"
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/spf13/afero"
 )
+
+func TestFetchJobListByBuildUsesJobsEndpoint(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v2/organizations/test-org/pipelines/my-app/builds/429/jobs" {
+			t.Fatalf("path = %s, want dedicated jobs endpoint", r.URL.Path)
+		}
+		if got := r.URL.Query()["state[]"]; fmt.Sprint(got) != "[failed timed_out]" {
+			t.Fatalf("state[] = %v, want repeated failed and timed_out values", got)
+		}
+		if got := r.URL.Query().Get("include_retried_jobs"); got != "false" {
+			t.Fatalf("include_retried_jobs = %q, want false", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "20" {
+			t.Fatalf("per_page = %q, want 20", got)
+		}
+
+		writeJobsPage(t, w, []buildkite.Job{{ID: "job-1", State: "failed"}}, "")
+	}))
+	t.Cleanup(server.Close)
+
+	f := newJobListTestFactory(t, server.URL, nil)
+	opts := jobListOptions{
+		pipeline: "my-app",
+		build:    "429",
+		state:    []string{"failed", "timed_out"},
+		limit:    20,
+	}
+	listOpts, err := jobListOptionsFromFlags(&opts)
+	if err != nil {
+		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
+	}
+
+	jobs, resolvedPipeline, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	if err != nil {
+		t.Fatalf("fetchJobList() error = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if resolvedPipeline == nil || resolvedPipeline.Org != "test-org" || resolvedPipeline.Name != "my-app" {
+		t.Fatalf("resolved pipeline = %#v", resolvedPipeline)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "job-1" {
+		t.Fatalf("jobs = %#v", jobs)
+	}
+}
+
+func TestFetchJobsByBuildCursorPaginationAndLimits(t *testing.T) {
+	tests := []struct {
+		name           string
+		totalJobs      int
+		opts           jobListOptions
+		fetchAll       bool
+		wantJobs       int
+		wantPageSizes  []int
+		wantPageStarts []int
+	}{
+		{
+			name:           "limit 20 requests and emits at most 20",
+			totalJobs:      250,
+			opts:           jobListOptions{limit: 20},
+			wantJobs:       20,
+			wantPageSizes:  []int{20},
+			wantPageStarts: []int{0},
+		},
+		{
+			name:           "limit 150 follows the next cursor",
+			totalJobs:      250,
+			opts:           jobListOptions{limit: 150},
+			wantJobs:       150,
+			wantPageSizes:  []int{100, 50},
+			wantPageStarts: []int{0, 100},
+		},
+		{
+			name:           "no limit follows every cursor",
+			totalJobs:      205,
+			opts:           jobListOptions{noLimit: true},
+			fetchAll:       true,
+			wantJobs:       205,
+			wantPageSizes:  []int{100, 100, 100},
+			wantPageStarts: []int{0, 100, 200},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pageSizes []int
+			var pageStarts []int
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				perPage, err := strconv.Atoi(r.URL.Query().Get("per_page"))
+				if err != nil {
+					t.Fatalf("invalid per_page: %v", err)
+				}
+				if perPage > pageSize {
+					t.Fatalf("per_page = %d, exceeds %d", perPage, pageSize)
+				}
+				start := 0
+				if after := r.URL.Query().Get("after"); after != "" {
+					start, err = strconv.Atoi(after)
+					if err != nil {
+						t.Fatalf("invalid after cursor: %v", err)
+					}
+				}
+				pageSizes = append(pageSizes, perPage)
+				pageStarts = append(pageStarts, start)
+
+				end := min(start+perPage, tt.totalJobs)
+				jobs := make([]buildkite.Job, 0, end-start)
+				for i := start; i < end; i++ {
+					jobs = append(jobs, buildkite.Job{ID: fmt.Sprintf("job-%03d", i)})
+				}
+				next := ""
+				if end < tt.totalJobs {
+					next = fmt.Sprintf("%s%s?after=%d&per_page=%d", server.URL, r.URL.Path, end, perPage)
+				}
+				writeJobsPage(t, w, jobs, next)
+			}))
+			t.Cleanup(server.Close)
+
+			f := newJobListTestFactory(t, server.URL, nil)
+			jobs, err := fetchJobsByBuild(context.Background(), f.RestAPIClient, "test-org", "my-app", "429", tt.opts, tt.fetchAll)
+			if err != nil {
+				t.Fatalf("fetchJobsByBuild() error = %v", err)
+			}
+			if len(jobs) != tt.wantJobs {
+				t.Fatalf("jobs = %d, want %d", len(jobs), tt.wantJobs)
+			}
+			if fmt.Sprint(pageSizes) != fmt.Sprint(tt.wantPageSizes) {
+				t.Fatalf("page sizes = %v, want %v", pageSizes, tt.wantPageSizes)
+			}
+			if fmt.Sprint(pageStarts) != fmt.Sprint(tt.wantPageStarts) {
+				t.Fatalf("page starts = %v, want %v", pageStarts, tt.wantPageStarts)
+			}
+		})
+	}
+}
+
+func TestBuildJobListFetchesAllPagesBeforeClientFilteringAndOrdering(t *testing.T) {
+	started := time.Now().Add(-30 * time.Minute)
+	firstPage := []buildkite.Job{
+		{ID: "wrong-queue", State: "failed", AgentQueryRules: []string{"queue=other"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(20 * time.Minute)}},
+	}
+	secondPage := []buildkite.Job{
+		{ID: "short", State: "failed", AgentQueryRules: []string{"queue=test"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(2 * time.Minute)}},
+		{ID: "long", State: "failed", AgentQueryRules: []string{"queue=test"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(15 * time.Minute)}},
+	}
+
+	var requests int
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			writeJobsPage(t, w, firstPage, server.URL+r.URL.Path+"?after=next&per_page=100")
+			return
+		}
+		writeJobsPage(t, w, secondPage, "")
+	}))
+	t.Cleanup(server.Close)
+
+	f := newJobListTestFactory(t, server.URL, nil)
+	opts := jobListOptions{pipeline: "my-app", build: "429", queue: "test", duration: ">1m", orderBy: "duration", limit: 1}
+	listOpts, err := jobListOptionsFromFlags(&opts)
+	if err != nil {
+		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
+	}
+	jobs, _, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	if err != nil {
+		t.Fatalf("fetchJobList() error = %v", err)
+	}
+	jobs, err = applyClientSideFilters(jobs, opts)
+	if err != nil {
+		t.Fatalf("applyClientSideFilters() error = %v", err)
+	}
+	jobs = sortJobs(jobs, opts.orderBy)
+	if len(jobs) > opts.limit {
+		jobs = jobs[:opts.limit]
+	}
+
+	if requests != 2 {
+		t.Fatalf("requests = %d, want all 2 pages", requests)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "long" {
+		t.Fatalf("jobs = %#v, want longest matching job", jobs)
+	}
+}
+
+func TestResolveJobListPipeline(t *testing.T) {
+	t.Run("from pipeline flag", func(t *testing.T) {
+		f := newJobListTestFactory(t, "http://127.0.0.1", nil)
+		got, err := resolveJobListPipeline(context.Background(), f, "other-org/my-app")
+		if err != nil {
+			t.Fatalf("resolveJobListPipeline() error = %v", err)
+		}
+		if got.Org != "other-org" || got.Name != "my-app" {
+			t.Fatalf("pipeline = %#v", got)
+		}
+	})
+
+	t.Run("from config", func(t *testing.T) {
+		f := newJobListTestFactory(t, "http://127.0.0.1", nil)
+		if err := f.Config.SetPreferredPipelines([]pipeline.Pipeline{{Org: "test-org", Name: "configured-app"}}); err != nil {
+			t.Fatalf("SetPreferredPipelines() error = %v", err)
+		}
+		got, err := resolveJobListPipeline(context.Background(), f, "")
+		if err != nil {
+			t.Fatalf("resolveJobListPipeline() error = %v", err)
+		}
+		if got.Org != "test-org" || got.Name != "configured-app" {
+			t.Fatalf("pipeline = %#v", got)
+		}
+	})
+
+	t.Run("from repository", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v2/organizations/test-org/pipelines" {
+				t.Fatalf("path = %s, want pipelines endpoint", r.URL.Path)
+			}
+			_, _ = w.Write([]byte(`[{"slug":"repo-app","repository":"git@github.com:buildkite/cli.git"}]`))
+		}))
+		t.Cleanup(server.Close)
+
+		f := newJobListTestFactory(t, server.URL, jobListTestRepository(t, "https://github.com/buildkite/cli.git"))
+		got, err := resolveJobListPipeline(context.Background(), f, "")
+		if err != nil {
+			t.Fatalf("resolveJobListPipeline() error = %v", err)
+		}
+		if got.Org != "test-org" || got.Name != "repo-app" {
+			t.Fatalf("pipeline = %#v", got)
+		}
+	})
+
+	t.Run("missing pipeline context", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		f := newJobListTestFactory(t, "http://127.0.0.1", nil)
+		_, err := resolveJobListPipeline(context.Background(), f, "")
+		if err == nil || !strings.Contains(err.Error(), "--build requires a pipeline") || !strings.Contains(err.Error(), "--pipeline") {
+			t.Fatalf("error = %v, want useful pipeline guidance", err)
+		}
+	})
+}
+
+func TestFetchJobListWithoutBuildRetainsCrossBuildEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/organizations/test-org/builds" {
+			t.Fatalf("path = %s, want cross-build endpoint", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[{"jobs":[{"id":"cross-build-job"}]}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	f := newJobListTestFactory(t, server.URL, nil)
+	opts := jobListOptions{limit: 100}
+	listOpts, err := jobListOptionsFromFlags(&opts)
+	if err != nil {
+		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
+	}
+	jobs, resolvedPipeline, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	if err != nil {
+		t.Fatalf("fetchJobList() error = %v", err)
+	}
+	if resolvedPipeline != nil {
+		t.Fatalf("resolved pipeline = %#v, want nil for cross-build path", resolvedPipeline)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "cross-build-job" {
+		t.Fatalf("jobs = %#v", jobs)
+	}
+}
+
+func TestDisplayJobsOutputCompatibility(t *testing.T) {
+	job := buildkite.Job{ID: "job-1", State: "failed", Label: "Test", WebURL: "https://buildkite.com/example#job-1"}
+
+	tests := []struct {
+		name   string
+		format output.Format
+		want   []string
+	}{
+		{name: "text", format: output.FormatText, want: []string{"STATE", "failed", "Test", job.WebURL}},
+		{name: "json", format: output.FormatJSON, want: []string{`"id": "job-1"`, `"state": "failed"`}},
+		{name: "yaml", format: output.FormatYAML, want: []string{"id: job-1", "state: failed"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := displayJobs([]buildkite.Job{job}, tt.format, &buf); err != nil {
+				t.Fatalf("displayJobs() error = %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(buf.String(), want) {
+					t.Fatalf("output does not contain %q:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+func newJobListTestFactory(t *testing.T, serverURL string, repo *git.Repository) *factory.Factory {
+	t.Helper()
+	client, err := buildkite.NewOpts(buildkite.WithBaseURL(serverURL))
+	if err != nil {
+		t.Fatalf("new Buildkite client: %v", err)
+	}
+	conf := config.New(afero.NewMemMapFs(), nil)
+	if err := conf.SelectOrganization("test-org", true); err != nil {
+		t.Fatalf("SelectOrganization() error = %v", err)
+	}
+	return &factory.Factory{
+		Config:        conf,
+		GitRepository: repo,
+		RestAPIClient: client,
+		Quiet:         true,
+		NoInput:       true,
+	}
+}
+
+func jobListTestRepository(t *testing.T, remoteURL string) *git.Repository {
+	t.Helper()
+	repo, err := git.PlainInit(t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("init repository: %v", err)
+	}
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{remoteURL}}); err != nil {
+		t.Fatalf("create remote: %v", err)
+	}
+	return repo
+}
+
+func writeJobsPage(t *testing.T, w http.ResponseWriter, jobs []buildkite.Job, next string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(buildkite.JobsList{
+		Items: jobs,
+		Links: buildkite.JobsListLinks{Next: buildkite.JobsListLink(next)},
+	}); err != nil {
+		t.Fatalf("encode jobs page: %v", err)
+	}
+}
 
 func TestDisplayJobs_EmptyJSON(t *testing.T) {
 	var buf bytes.Buffer

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
@@ -58,7 +59,7 @@ func TestFetchJobListByBuildUsesJobsEndpoint(t *testing.T) {
 		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
 	}
 
-	jobs, resolvedPipeline, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	jobs, resolvedPipeline, _, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
 	if err != nil {
 		t.Fatalf("fetchJobList() error = %v", err)
 	}
@@ -167,18 +168,37 @@ func TestFetchJobsByBuildCursorPaginationAndLimits(t *testing.T) {
 func TestBuildJobListFetchesAllPagesBeforeClientFilteringAndOrdering(t *testing.T) {
 	started := time.Now().Add(-30 * time.Minute)
 	firstPage := []buildkite.Job{
-		{ID: "wrong-queue", State: "failed", AgentQueryRules: []string{"queue=other"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(20 * time.Minute)}},
+		{ID: "wrong-queue", State: "failed", ClusterQueueID: "other-queue-id", StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(20 * time.Minute)}},
 	}
 	secondPage := []buildkite.Job{
-		{ID: "short", State: "failed", AgentQueryRules: []string{"queue=test"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(2 * time.Minute)}},
-		{ID: "long", State: "failed", AgentQueryRules: []string{"queue=test"}, StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(15 * time.Minute)}},
+		{ID: "short", State: "failed", ClusterQueueID: "test-queue-id", StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(2 * time.Minute)}},
+		{ID: "long", State: "failed", ClusterQueueID: "test-queue-id", StartedAt: &buildkite.Timestamp{Time: started}, FinishedAt: &buildkite.Timestamp{Time: started.Add(15 * time.Minute)}},
 	}
 
-	var requests int
+	var restRequests int
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		if requests == 1 {
+		if r.Method == http.MethodPost {
+			var request struct {
+				OperationName string `json:"operationName"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode GraphQL request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			switch request.OperationName {
+			case "FindClusters":
+				_, _ = w.Write([]byte(`{"data":{"organization":{"clusters":{"edges":[{"node":{"id":"cluster-id","name":"Test"}}],"pageInfo":{"hasNextPage":false}}}}}`))
+			case "FindQueuesForCluster":
+				_, _ = w.Write([]byte(`{"data":{"node":{"__typename":"Cluster","id":"cluster-id","name":"Test","queues":{"edges":[{"node":{"id":"test-queue-id","key":"test"}}],"pageInfo":{"hasNextPage":false}}}}}`))
+			default:
+				t.Fatalf("unexpected GraphQL operation %q", request.OperationName)
+			}
+			return
+		}
+
+		restRequests++
+		if restRequests == 1 {
 			writeJobsPage(t, w, firstPage, server.URL+r.URL.Path+"?after=next&per_page=100")
 			return
 		}
@@ -187,16 +207,17 @@ func TestBuildJobListFetchesAllPagesBeforeClientFilteringAndOrdering(t *testing.
 	t.Cleanup(server.Close)
 
 	f := newJobListTestFactory(t, server.URL, nil)
+	f.GraphQLClient = graphql.NewClient(server.URL, server.Client())
 	opts := jobListOptions{pipeline: "my-app", build: "429", queue: "test", duration: ">1m", orderBy: "duration", limit: 1}
 	listOpts, err := jobListOptionsFromFlags(&opts)
 	if err != nil {
 		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
 	}
-	jobs, _, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	jobs, _, queueIDs, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
 	if err != nil {
 		t.Fatalf("fetchJobList() error = %v", err)
 	}
-	jobs, err = applyClientSideFilters(jobs, opts)
+	jobs, err = applyClientSideFilters(jobs, opts, queueIDs)
 	if err != nil {
 		t.Fatalf("applyClientSideFilters() error = %v", err)
 	}
@@ -205,8 +226,8 @@ func TestBuildJobListFetchesAllPagesBeforeClientFilteringAndOrdering(t *testing.
 		jobs = jobs[:opts.limit]
 	}
 
-	if requests != 2 {
-		t.Fatalf("requests = %d, want all 2 pages", requests)
+	if restRequests != 2 {
+		t.Fatalf("REST requests = %d, want all 2 pages", restRequests)
 	}
 	if len(jobs) != 1 || jobs[0].ID != "long" {
 		t.Fatalf("jobs = %#v, want longest matching job", jobs)
@@ -283,7 +304,7 @@ func TestFetchJobListWithoutBuildRetainsCrossBuildEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("jobListOptionsFromFlags() error = %v", err)
 	}
-	jobs, resolvedPipeline, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
+	jobs, resolvedPipeline, _, err := fetchJobList(context.Background(), f, "test-org", opts, listOpts)
 	if err != nil {
 		t.Fatalf("fetchJobList() error = %v", err)
 	}
@@ -292,6 +313,20 @@ func TestFetchJobListWithoutBuildRetainsCrossBuildEndpoint(t *testing.T) {
 	}
 	if len(jobs) != 1 || jobs[0].ID != "cross-build-job" {
 		t.Fatalf("jobs = %#v", jobs)
+	}
+}
+
+func TestJobListOptionsRejectBuildWithBuildTimeFilters(t *testing.T) {
+	tests := []jobListOptions{
+		{build: "429", since: "1h"},
+		{build: "429", until: "30m"},
+	}
+
+	for _, opts := range tests {
+		_, err := jobListOptionsFromFlags(&opts)
+		if err == nil || !strings.Contains(err.Error(), "cannot be used with --build") {
+			t.Fatalf("jobListOptionsFromFlags(%+v) error = %v, want incompatible flags error", opts, err)
+		}
 	}
 }
 
@@ -411,7 +446,7 @@ func TestFilterJobs(t *testing.T) {
 	}
 
 	opts := jobListOptions{duration: ">10m"}
-	filtered, err := applyClientSideFilters(jobs, opts)
+	filtered, err := applyClientSideFilters(jobs, opts, nil)
 	if err != nil {
 		t.Fatalf("applyClientSideFilters failed: %v", err)
 	}
@@ -421,7 +456,7 @@ func TestFilterJobs(t *testing.T) {
 	}
 
 	opts = jobListOptions{queue: "test-queue"}
-	filtered, err = applyClientSideFilters(jobs, opts)
+	filtered, err = applyClientSideFilters(jobs, opts, nil)
 	if err != nil {
 		t.Fatalf("applyClientSideFilters failed: %v", err)
 	}


### PR DESCRIPTION
### Description

The Buildkite REST API now has a dedicated [**List Jobs for a Build**](https://buildkite.com/docs/apis/rest-api/jobs#list-jobs) endpoint:

```http
GET /v2/organizations/{org}/pipelines/{pipeline}/builds/{number}/jobs
```

This PR makes `bk job list --build` use that endpoint through go-buildkite's `Jobs.ListByBuild`. Previously, `bk job list` called a Builds list endpoint and flattened the jobs embedded in every returned build, even when the pipeline and build number were already known. Using the build-specific Jobs endpoint avoids those larger build-list responses and retrieves only the requested build's jobs.

```console
bk job list --pipeline my-app --build 429 --state failed
```

The new endpoint returns cursor-paginated `items` with `links.next`. The CLI follows those links internally, sends `--state` values as server-side `state[]` filters, and explicitly sets `include_retried_jobs=false`. Existing total `--limit` and `--no-limit` semantics, client-side filtering, ordering, and output formats remain unchanged.

Pipelines are resolved from `--pipeline`, configuration, or the current repository. The existing cross-build `bk job list` path remains unchanged when `--build` is absent.

Follow-up to [buildkite/cli#911](https://github.com/buildkite/cli/pull/911).

Part of PB-2339

### Testing

- [x] `go test ./cmd/job` — passed
- [x] `mise run format` — passed
- [x] `mise run lint` — passed with 0 issues
- [x] `mise run test` — passed (`go test ./...`)

### Deployment

Low risk. The new endpoint is used only when `--build` is supplied. There are no dependency, migration, or configuration changes.

### Rollback

Revert this PR. The existing cross-build path remains available and no persisted state requires cleanup.

### Disclosures / Credits

Amp wrote the tests and implementation from human-authored requirements.