### PR TITLE
Add job step and group key filter flags

### DIFF
--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -31,6 +31,8 @@ const (
 type ListCmd struct {
 	Pipeline string   `help:"Filter by pipeline slug" short:"p"`
 	Build    string   `help:"Filter by build number (requires a resolvable pipeline)"`
+	StepKey  string   `help:"Filter by step key (requires --build)" name:"step-key"`
+	GroupKey string   `help:"Filter by group key (requires --build)" name:"group-key"`
 	Since    string   `help:"Filter jobs from builds created since this time (e.g. 1h, 30m)"`
 	Until    string   `help:"Filter jobs from builds created before this time (e.g. 1h, 30m)"`
 	Duration string   `help:"Filter by duration (e.g. >10m, <5m, 20m) - supports >, <, >=, <= operators"`
@@ -48,7 +50,7 @@ When a build number is known, use --build to fetch its jobs directly. The pipeli
 can be passed with --pipeline or resolved from the current repository or config.
 
 Client-side filters: --queue, --state, --duration
-Server-side filters: --pipeline, --build, --since, --until
+Server-side filters: --pipeline, --build, --step-key, --group-key, --since, --until
 
 With --build, --state is also applied by the server. Client-side filters and
 ordering are applied after all required cursor pages have been fetched.
@@ -73,6 +75,9 @@ Examples:
   # List failed jobs from a known build (recommended when the build is known)
   $ bk job list --pipeline my-app --build 429 --state failed
 
+  # List jobs for step and group keys from a known build
+  $ bk job list --pipeline my-app --build 429 --step-key test --group-key verification
+
   # List jobs that took longer than 10 minutes
   $ bk job list --duration ">10m"
 
@@ -96,6 +101,8 @@ Examples:
 type jobListOptions struct {
 	pipeline string
 	build    string
+	stepKey  string
+	groupKey string
 	since    string
 	until    string
 	duration string
@@ -136,6 +143,8 @@ func (c *ListCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 	opts := jobListOptions{
 		pipeline: c.Pipeline,
 		build:    c.Build,
+		stepKey:  c.StepKey,
+		groupKey: c.GroupKey,
 		since:    c.Since,
 		until:    c.Until,
 		duration: c.Duration,
@@ -263,6 +272,8 @@ func fetchJobsByBuild(ctx context.Context, client *buildkite.Client, org, pipeli
 	includeRetriedJobs := false
 	jobsListOpts := &buildkite.JobsListOptions{
 		State:              opts.state,
+		StepKey:            opts.stepKey,
+		GroupKey:           opts.groupKey,
 		IncludeRetriedJobs: &includeRetriedJobs,
 		PerPage:            pageSize,
 	}
@@ -290,6 +301,8 @@ func fetchJobsByBuild(ctx context.Context, client *buildkite.Client, org, pipeli
 			return nil, fmt.Errorf("invalid next jobs page: %w", err)
 		}
 		jobsListOpts.State = opts.state
+		jobsListOpts.StepKey = opts.stepKey
+		jobsListOpts.GroupKey = opts.groupKey
 		jobsListOpts.IncludeRetriedJobs = &includeRetriedJobs
 		jobsListOpts.PerPage = pageSize
 		if !fetchAll {
@@ -749,6 +762,9 @@ func mapGraphQLState(graphqlState, exitStatus string) string {
 }
 
 func jobListOptionsFromFlags(opts *jobListOptions) (*buildkite.BuildsListOptions, error) {
+	if opts.build == "" && (opts.stepKey != "" || opts.groupKey != "") {
+		return nil, fmt.Errorf("--step-key and --group-key require --build")
+	}
 	if opts.build != "" && (opts.since != "" || opts.until != "") {
 		return nil, fmt.Errorf("--since and --until cannot be used with --build")
 	}

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
+	"github.com/alecthomas/kong"
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/internal/pipeline"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
@@ -22,6 +23,29 @@ import (
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/spf13/afero"
 )
+
+func TestJobListKeyFilterFlags(t *testing.T) {
+	var cmd ListCmd
+	parser, err := kong.New(&cmd, kong.Vars{"output_default_format": ""})
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	if _, err := parser.Parse([]string{"--build", "429", "--step-key", "test", "--group-key", "verification"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if cmd.StepKey != "test" {
+		t.Fatalf("StepKey = %q, want test", cmd.StepKey)
+	}
+	if cmd.GroupKey != "verification" {
+		t.Fatalf("GroupKey = %q, want verification", cmd.GroupKey)
+	}
+	for _, want := range []string{"--step-key", "--group-key", "Server-side filters"} {
+		if !strings.Contains(cmd.Help(), want) {
+			t.Fatalf("Help() does not contain %q", want)
+		}
+	}
+}
 
 func TestFetchJobListByBuildUsesJobsEndpoint(t *testing.T) {
 	var requests int
@@ -39,6 +63,12 @@ func TestFetchJobListByBuildUsesJobsEndpoint(t *testing.T) {
 		if got := r.URL.Query().Get("include_retried_jobs"); got != "false" {
 			t.Fatalf("include_retried_jobs = %q, want false", got)
 		}
+		if got := r.URL.Query().Get("step_key"); got != "test" {
+			t.Fatalf("step_key = %q, want test", got)
+		}
+		if got := r.URL.Query().Get("group_key"); got != "verification" {
+			t.Fatalf("group_key = %q, want verification", got)
+		}
 		if got := r.URL.Query().Get("per_page"); got != "20" {
 			t.Fatalf("per_page = %q, want 20", got)
 		}
@@ -51,6 +81,8 @@ func TestFetchJobListByBuildUsesJobsEndpoint(t *testing.T) {
 	opts := jobListOptions{
 		pipeline: "my-app",
 		build:    "429",
+		stepKey:  "test",
+		groupKey: "verification",
 		state:    []string{"failed", "timed_out"},
 		limit:    20,
 	}
@@ -133,6 +165,12 @@ func TestFetchJobsByBuildCursorPaginationAndLimits(t *testing.T) {
 				}
 				pageSizes = append(pageSizes, perPage)
 				pageStarts = append(pageStarts, start)
+				if got := r.URL.Query().Get("step_key"); got != "test" {
+					t.Fatalf("step_key = %q, want test on every page", got)
+				}
+				if got := r.URL.Query().Get("group_key"); got != "verification" {
+					t.Fatalf("group_key = %q, want verification on every page", got)
+				}
 
 				end := min(start+perPage, tt.totalJobs)
 				jobs := make([]buildkite.Job, 0, end-start)
@@ -148,6 +186,8 @@ func TestFetchJobsByBuildCursorPaginationAndLimits(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			f := newJobListTestFactory(t, server.URL, nil)
+			tt.opts.stepKey = "test"
+			tt.opts.groupKey = "verification"
 			jobs, err := fetchJobsByBuild(context.Background(), f.RestAPIClient, "test-org", "my-app", "429", tt.opts, tt.fetchAll)
 			if err != nil {
 				t.Fatalf("fetchJobsByBuild() error = %v", err)
@@ -326,6 +366,21 @@ func TestJobListOptionsRejectBuildWithBuildTimeFilters(t *testing.T) {
 		_, err := jobListOptionsFromFlags(&opts)
 		if err == nil || !strings.Contains(err.Error(), "cannot be used with --build") {
 			t.Fatalf("jobListOptionsFromFlags(%+v) error = %v, want incompatible flags error", opts, err)
+		}
+	}
+}
+
+func TestJobListOptionsRequireBuildForKeyFilters(t *testing.T) {
+	tests := []jobListOptions{
+		{stepKey: "test"},
+		{groupKey: "verification"},
+		{stepKey: "test", groupKey: "verification"},
+	}
+
+	for _, opts := range tests {
+		_, err := jobListOptionsFromFlags(&opts)
+		if err == nil || !strings.Contains(err.Error(), "require --build") {
+			t.Fatalf("jobListOptionsFromFlags(%+v) error = %v, want build requirement", opts, err)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609
+	github.com/buildkite/go-buildkite/v5 v5.7.0
 	github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	github.com/buildkite/go-buildkite/v5 v5.4.0
+	github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609
 	github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v5 v5.4.0 h1:fCb3hEis/ecRcaDmRJSFKLfTLGd6ArWK+RF44jCCMw4=
-github.com/buildkite/go-buildkite/v5 v5.4.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609 h1:iJSBeqygwpKKCuQwYHbAP89kahfpUqlDFsirhV7Q6vA=
+github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1 h1:aaEl0QZURcwC+KOfFTzSp66xknw5eTmFZ1NgB87s2xk=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609 h1:iJSBeqygwpKKCuQwYHbAP89kahfpUqlDFsirhV7Q6vA=
-github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.7.0 h1:UY2vlF5AceV7zqWUN+uU7bjEXgEFdKrwayvZ8bZgcj0=
+github.com/buildkite/go-buildkite/v5 v5.7.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1 h1:aaEl0QZURcwC+KOfFTzSp66xknw5eTmFZ1NgB87s2xk=


### PR DESCRIPTION
### Description

Adds `--step-key` and `--group-key` server-side filters to `bk job list --build`. Both filters can be combined, require `--build`, and are preserved across cursor pages.

This PR uses the support from [go-buildkite #347](https://github.com/buildkite/go-buildkite/pull/347), released in [v5.7.0](https://github.com/buildkite/go-buildkite/releases/tag/v5.7.0).

Deployment order:
1. Confirm the server-side filters are deployed.
2. Merge this CLI change.

Dependent documentation should publish only after these CLI flags ship.

### Testing
- [x] Focused job command tests pass locally (`go test ./cmd/job`)
- [x] Code is formatted (`gofmt` via the pre-commit hook)
- [x] Lint passes (`golangci-lint` via the pre-commit hook)
- [ ] Full suite locally hit the unrelated `TestSnapshotContext_CancelsPush` timing flake; the test passed three isolated runs

### Rollback

Revert this PR. The flags are additive and do not change persisted data.

### Disclosures / Credits

Amp implemented the tests and CLI changes under human direction.
