### PR TITLE
fix(http): set short timeout on posthog

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/posthog/posthog-go"
 )
@@ -43,9 +44,15 @@ func Init(version string, enabled bool) *Client {
 
 	once.Do(func() {
 		var err error
+		// Telemetry must never delay CLI exit: a single delivery attempt with
+		// a hard cap on the shutdown flush, dropping events on failure.
+		maxRetries := 0
 		client, err = posthog.NewWithConfig(key, posthog.Config{
-			Endpoint: apiHost,
-			Logger:   noopLogger{},
+			Endpoint:           apiHost,
+			Logger:             noopLogger{},
+			MaxRetries:         &maxRetries,
+			ShutdownTimeout:    500 * time.Millisecond,
+			BatchUploadTimeout: 500 * time.Millisecond,
 		})
 		if err != nil {
 			client = nil

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -15,11 +15,12 @@ func TestCloseIsBoundedWhenEndpointIsUnresponsive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
 
-	// Hold accepted connections open without ever responding.
+	// Hold accepted connections open without ever responding. The accept
+	// goroutine owns closing conns, once Accept fails after ln is closed.
 	conns := make(chan net.Conn, 16)
 	go func() {
+		defer close(conns)
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
@@ -29,7 +30,7 @@ func TestCloseIsBoundedWhenEndpointIsUnresponsive(t *testing.T) {
 		}
 	}()
 	defer func() {
-		close(conns)
+		ln.Close()
 		for conn := range conns {
 			conn.Close()
 		}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,56 @@
+package analytics
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// Telemetry must never delay CLI exit. This pins the shutdown bound by
+// pointing the client at a server that accepts connections but never
+// responds, and asserting Close returns promptly instead of blocking on
+// the flush.
+func TestCloseIsBoundedWhenEndpointIsUnresponsive(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Hold accepted connections open without ever responding.
+	conns := make(chan net.Conn, 16)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conns <- conn
+		}
+	}()
+	defer func() {
+		close(conns)
+		for conn := range conns {
+			conn.Close()
+		}
+	}()
+
+	t.Setenv("BK_ANALYTICS_KEY", "test-key")
+	t.Setenv("CI", "")
+
+	origHost := apiHost
+	apiHost = "http://" + ln.Addr().String()
+	t.Cleanup(func() { apiHost = origHost })
+
+	c := Init("test", true)
+	if c.disabled {
+		t.Fatal("expected client to be enabled")
+	}
+	c.TrackCommand("version", []string{"version"}, nil)
+
+	start := time.Now()
+	c.Close()
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Close took %v, want under 2s", elapsed)
+	}
+}


### PR DESCRIPTION
### Description

We currently default to a 10s shutdown for posthog calls, which is silly.

### Changes

- Implements a 500ms timeout on telemetry send
- if they take > 500ms we just drop them

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
