### PR TITLE
Prevent PostHog telemetry from delaying commands

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -5,9 +5,12 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/posthog/posthog-go"
 )
+
+const shutdownTimeout = 500 * time.Millisecond
 
 var (
 	// Set via -ldflags at build time: -X github.com/buildkite/cli/v3/pkg/analytics.apiKey=...
@@ -44,8 +47,9 @@ func Init(version string, enabled bool) *Client {
 	once.Do(func() {
 		var err error
 		client, err = posthog.NewWithConfig(key, posthog.Config{
-			Endpoint: apiHost,
-			Logger:   noopLogger{},
+			Endpoint:        apiHost,
+			Logger:          noopLogger{},
+			ShutdownTimeout: shutdownTimeout,
 		})
 		if err != nil {
 			client = nil

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,54 @@
+package analytics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/posthog/posthog-go"
+)
+
+func TestCloseDoesNotWaitForPostHogUploadTimeout(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var signalRequestStarted sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		signalRequestStarted.Do(func() { close(requestStarted) })
+		<-releaseRequest
+	}))
+	defer server.Close()
+
+	originalAPIHost := apiHost
+	apiHost = server.URL
+	client = nil
+	once = sync.Once{}
+	t.Cleanup(func() {
+		apiHost = originalAPIHost
+		client = nil
+		once = sync.Once{}
+	})
+	t.Setenv("BK_ANALYTICS_KEY", "test-key")
+	t.Setenv("CI", "")
+
+	tracker := Init("test", true)
+	defer tracker.Close()
+	defer close(releaseRequest)
+
+	for range posthog.DefaultBatchSize {
+		tracker.TrackCommand("build list", []string{"build", "list"}, nil)
+	}
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected queued telemetry to start uploading")
+	}
+
+	start := time.Now()
+	tracker.Close()
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("Close waited %s for unavailable telemetry; expected less than 2s", elapsed)
+	}
+}


### PR DESCRIPTION
### Description

PostHog's Go client can wait for its 10-second upload timeout when the telemetry endpoint is unreachable. Because `bk` flushes telemetry during process shutdown, this can add approximately 10 seconds to normal CLI commands; disabling telemetry reduced an affected command to approximately 0.1 seconds.

Configure a 500 ms PostHog shutdown deadline so telemetry remains best-effort without materially delaying command exit. Healthy uploads still complete normally, while stalled uploads are cancelled when the deadline expires.

Context: [PB-2556](https://linear.app/buildkite/issue/PB-2556)

### Changes

- Bound PostHog client shutdown to 500 ms.
- Add regression coverage using an upload that starts but never responds.
- Verify the regression test fails at the previous 10-second timeout and completes in approximately 500 ms with the fix.

### Testing

- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `gofumpt`)
- [x] Focused regression test passes 10 times under the race detector
- [x] `golangci-lint` reports no issues for `pkg/analytics`

### Rollback

Revert this pull request to restore the PostHog SDK's default shutdown behavior. There are no migrations or persisted-data changes.

### Disclosures / Credits

Amp investigated the telemetry lifecycle, implemented the timeout and regression test, ran validation, and performed an iterative independent review. Sorcha Abel provided the real-world reproduction and product context.
