### PR TITLE
fix(slugs): normalise pipeline slugs

### DIFF
--- a/internal/pipeline/resolver/cli.go
+++ b/internal/pipeline/resolver/cli.go
@@ -63,5 +63,13 @@ func parsePipelineArg(arg string, conf *config.Config) (org, pipeline string) {
 		org = conf.OrganizationSlug()
 		pipeline = arg
 	}
-	return org, pipeline
+	return normalizeSlug(org), normalizeSlug(pipeline)
+}
+
+// normalizeSlug converts user input to a valid Buildkite slug. Slugs may only contain
+// lowercase letters, numbers and dashes, so this is a no-op on anything already valid.
+// It allows passing a name like "my_pipeline" (eg. from a repository directory name)
+// and matching the "my-pipeline" slug Buildkite derives from it.
+func normalizeSlug(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
 }

--- a/internal/pipeline/resolver/cli_test.go
+++ b/internal/pipeline/resolver/cli_test.go
@@ -30,6 +30,16 @@ func TestParsePipelineArg(t *testing.T) {
 			org:      "buildkite",
 			pipeline: "buildkite-cli",
 		},
+		"underscores_normalized_to_dashes": {
+			url:      "shared_gem",
+			org:      "testing",
+			pipeline: "shared-gem",
+		},
+		"uppercase_normalized_to_lowercase": {
+			url:      "My_Org/Shared_Gem",
+			org:      "my-org",
+			pipeline: "shared-gem",
+		},
 	}
 
 	for name, testcase := range testcases {

--- a/internal/pipeline/resolver/flag_test.go
+++ b/internal/pipeline/resolver/flag_test.go
@@ -45,6 +45,21 @@ func TestResolveFromFlag(t *testing.T) {
 		}
 	})
 
+	t.Run("underscores in pipeline name are normalized to dashes", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New(afero.NewMemMapFs(), nil)
+		conf.SelectOrganization("testing", true)
+		f := resolver.ResolveFromFlag("my_pipeline", conf)
+		pipeline, err := f(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if pipeline.Name != "my-pipeline" {
+			t.Errorf("expected pipeline 'my-pipeline', got '%s'", pipeline.Name)
+		}
+	})
+
 	t.Run("org/pipeline slug extracts org", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/pipeline/resolver/resolver.go
+++ b/internal/pipeline/resolver/resolver.go
@@ -57,7 +57,7 @@ func WithOrg(org string, resolve PipelineResolverFn) PipelineResolverFn {
 			return p, err
 		}
 
-		p.Org = org
+		p.Org = normalizeSlug(org)
 		return p, nil
 	}
 }

--- a/internal/pipeline/resolver/resolver_test.go
+++ b/internal/pipeline/resolver/resolver_test.go
@@ -76,4 +76,20 @@ func TestWithOrg(t *testing.T) {
 			t.Fatalf("expected org override-org, got %s", p.Org)
 		}
 	})
+
+	t.Run("normalizes the org override to a valid slug", func(t *testing.T) {
+		t.Parallel()
+
+		resolve := resolver.WithOrg("Override_Org", func(context.Context) (*pipeline.Pipeline, error) {
+			return &pipeline.Pipeline{Org: "config-org", Name: "pipeline"}, nil
+		})
+
+		p, err := resolve(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.Org != "override-org" {
+			t.Fatalf("expected org override-org, got %s", p.Org)
+		}
+	})
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/buildkite/cli/issues/930

### Changes

- normalises pipeline slugs so that `_` becomes `-`
- ensures `[a-z]`, `[0-9]` and `-` are allowed in pipelines slugs

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)
