### PR TITLE
Support secure SSH access for Linux jobs

### DIFF
--- a/cmd/job/ssh.go
+++ b/cmd/job/ssh.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/alecthomas/kong"
@@ -27,27 +30,57 @@ type SSHCmd struct {
 
 type sshSession struct {
 	remoteSession
-	SSH sshSessionCredentials `json:"ssh"`
+	Transport sshTransport          `json:"transport"`
+	SSH       sshSessionCredentials `json:"ssh"`
 }
 
+type sshTransport string
+
+const (
+	sshTransportTCP              sshTransport = "tcp"
+	sshTransportNamespaceIngress sshTransport = "namespace_ingress"
+)
+
 type sshSessionCredentials struct {
-	Username   string `json:"username"`
-	PrivateKey string `json:"private_key"`
+	Username   string   `json:"username"`
+	PrivateKey string   `json:"private_key"`
+	HostKeys   []string `json:"host_keys"`
 }
 
 func (s sshSession) validate() error {
-	if err := s.remoteSession.validate(); err != nil {
-		return fmt.Errorf("buildkite API returned an SSH session %w", err)
+	if s.Endpoint == "" {
+		return errors.New("buildkite API returned an SSH session without an endpoint")
 	}
-	endpoint, err := url.Parse(s.Endpoint)
-	if err != nil {
-		return fmt.Errorf("buildkite API returned an SSH session with an invalid endpoint: %w", err)
+	if s.ExpiresAt.IsZero() {
+		return errors.New("buildkite API returned an SSH session without an expiry")
 	}
-	if endpoint.Scheme != "wss" {
-		return fmt.Errorf("buildkite API returned an SSH session endpoint that must use %q, got %q", "wss", endpoint.Scheme)
-	}
-	if endpoint.Hostname() == "" {
-		return errors.New("buildkite API returned an SSH session endpoint without a hostname")
+
+	switch s.Transport {
+	case "":
+		return errors.New("buildkite API returned an SSH session without a transport")
+	case sshTransportTCP:
+		if _, err := sshTCPEndpointAddress(s.Endpoint); err != nil {
+			return fmt.Errorf("buildkite API returned an SSH session with an invalid TCP endpoint: %w", err)
+		}
+		if len(s.SSH.HostKeys) == 0 {
+			return errors.New("buildkite API returned a TCP SSH session without SSH host keys")
+		}
+	case sshTransportNamespaceIngress:
+		if s.AccessToken == "" {
+			return errors.New("buildkite API returned an SSH session without an access token")
+		}
+		endpoint, err := url.Parse(s.Endpoint)
+		if err != nil {
+			return fmt.Errorf("buildkite API returned an SSH session with an invalid endpoint: %w", err)
+		}
+		if endpoint.Scheme != "wss" {
+			return fmt.Errorf("buildkite API returned an SSH session endpoint that must use %q, got %q", "wss", endpoint.Scheme)
+		}
+		if endpoint.Hostname() == "" {
+			return errors.New("buildkite API returned an SSH session endpoint without a hostname")
+		}
+	default:
+		return fmt.Errorf("buildkite API returned unsupported SSH transport %q", s.Transport)
 	}
 
 	if s.SSH.Username == "" {
@@ -56,6 +89,9 @@ func (s sshSession) validate() error {
 	if s.SSH.PrivateKey == "" {
 		return errors.New("buildkite API returned an SSH session without an SSH private key")
 	}
+	if _, err := parseSSHHostKeys(s.SSH.HostKeys); err != nil {
+		return fmt.Errorf("buildkite API returned an SSH session with invalid SSH host keys: %w", err)
+	}
 
 	return nil
 }
@@ -63,7 +99,7 @@ func (s sshSession) validate() error {
 func (c *SSHCmd) Help() string {
 	return `
 Examples:
-	# Open an interactive shell on a running hosted macOS job
+	# Open an interactive shell on a running hosted job
 	$ bk job ssh 0190046e-e199-453b-a302-a21a4d649d31
 `
 }
@@ -103,16 +139,27 @@ type sshStreams struct {
 }
 
 func (c *SSHCmd) run(ctx context.Context, streams sshStreams, client *buildkite.Client, organization string) error {
-	return c.runWithDialer(ctx, streams, client, organization, dialSSHEndpoint)
+	return c.runWithDialer(ctx, streams, client, organization, dialSSHSession)
 }
 
-type sshEndpointDialer func(context.Context, remoteAccessToken, string) (net.Conn, error)
+type sshSessionDialer func(context.Context, sshSession) (net.Conn, error)
 
-func dialSSHEndpoint(ctx context.Context, token remoteAccessToken, endpoint string) (net.Conn, error) {
-	return ingress.DialEndpoint(ctx, io.Discard, token, endpoint)
+func dialSSHSession(ctx context.Context, session sshSession) (net.Conn, error) {
+	switch session.Transport {
+	case sshTransportTCP:
+		address, err := sshTCPEndpointAddress(session.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return new(net.Dialer).DialContext(ctx, "tcp", address)
+	case sshTransportNamespaceIngress:
+		return ingress.DialEndpoint(ctx, io.Discard, remoteAccessToken(session.AccessToken), session.Endpoint)
+	default:
+		return nil, fmt.Errorf("unsupported SSH transport %q", session.Transport)
+	}
 }
 
-func (c *SSHCmd) runWithDialer(ctx context.Context, streams sshStreams, client *buildkite.Client, organization string, dialEndpoint sshEndpointDialer) error {
+func (c *SSHCmd) runWithDialer(ctx context.Context, streams sshStreams, client *buildkite.Client, organization string, dialSession sshSessionDialer) error {
 	session, err := createSSHSession(ctx, client, organization, c.JobID)
 	if err != nil {
 		return fmt.Errorf("create SSH session: %w", err)
@@ -123,7 +170,12 @@ func (c *SSHCmd) runWithDialer(ctx context.Context, streams sshStreams, client *
 		return fmt.Errorf("parse SSH private key: %w", err)
 	}
 
-	remote, err := dialEndpoint(ctx, remoteAccessToken(session.AccessToken), session.Endpoint)
+	hostKeyCallback, err := sshHostKeyCallback(session)
+	if err != nil {
+		return err
+	}
+
+	remote, err := dialSession(ctx, session)
 	if err != nil {
 		return fmt.Errorf("connect to the SSH service: %w", err)
 	}
@@ -134,11 +186,9 @@ func (c *SSHCmd) runWithDialer(ctx context.Context, streams sshStreams, client *
 	defer stopRemoteClose()
 
 	config := &ssh.ClientConfig{
-		User: session.SSH.Username,
-		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		// Namespace provides an ephemeral SSH server behind an authenticated WSS
-		// endpoint, so it has no stable host key to put in known_hosts.
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		User:            session.SSH.Username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: hostKeyCallback,
 	}
 
 	connection, channels, requests, err := ssh.NewClientConn(remote, remote.RemoteAddr().String(), config)
@@ -198,6 +248,87 @@ func (c *SSHCmd) runWithDialer(ctx context.Context, streams sshStreams, client *
 	}
 
 	return nil
+}
+
+func sshHostKeyCallback(session sshSession) (ssh.HostKeyCallback, error) {
+	if len(session.SSH.HostKeys) == 0 {
+		if session.Transport != sshTransportNamespaceIngress {
+			return nil, errors.New("refusing to connect without SSH host keys over an unauthenticated transport")
+		}
+		// Namespace ingress authenticates the endpoint using WebPKI and the
+		// instance-scoped bearer token before any SSH traffic is exchanged.
+		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec
+	}
+
+	hostKeys, err := parseSSHHostKeys(session.SSH.HostKeys)
+	if err != nil {
+		return nil, fmt.Errorf("parse SSH host keys: %w", err)
+	}
+
+	return func(_ string, _ net.Addr, presented ssh.PublicKey) error {
+		for _, expected := range hostKeys {
+			if bytes.Equal(presented.Marshal(), expected.Marshal()) {
+				return nil
+			}
+		}
+		return errors.New("SSH host key does not match any key provided by the Buildkite API")
+	}, nil
+}
+
+func parseSSHHostKeys(encoded []string) ([]ssh.PublicKey, error) {
+	hostKeys := make([]ssh.PublicKey, 0, len(encoded))
+	for index, encodedKey := range encoded {
+		hostKey, _, _, rest, err := ssh.ParseAuthorizedKey([]byte(encodedKey))
+		if err != nil {
+			return nil, fmt.Errorf("host key %d is not a valid OpenSSH public key", index+1)
+		}
+		if len(bytes.TrimSpace(rest)) != 0 {
+			return nil, fmt.Errorf("host key %d contains more than one public key", index+1)
+		}
+		hostKeys = append(hostKeys, hostKey)
+	}
+	return hostKeys, nil
+}
+
+func sshTCPEndpointAddress(endpoint string) (string, error) {
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil {
+		return "", errors.New("URL could not be parsed")
+	}
+	if parsedURL.Scheme != "tcp" {
+		return "", fmt.Errorf("scheme must be tcp, got %q", parsedURL.Scheme)
+	}
+	if parsedURL.User != nil {
+		return "", errors.New("userinfo is not allowed")
+	}
+	if parsedURL.Path != "" || parsedURL.RawPath != "" {
+		return "", errors.New("path is not allowed")
+	}
+	if parsedURL.RawQuery != "" || parsedURL.ForceQuery {
+		return "", errors.New("query is not allowed")
+	}
+	if parsedURL.Fragment != "" || strings.Contains(endpoint, "#") {
+		return "", errors.New("fragment is not allowed")
+	}
+
+	host, port, err := net.SplitHostPort(parsedURL.Host)
+	if err != nil {
+		return "", fmt.Errorf("host and port are required: %w", err)
+	}
+	if host == "" {
+		return "", errors.New("host is required")
+	}
+	if strings.IndexFunc(port, func(character rune) bool {
+		return character < '0' || character > '9'
+	}) != -1 {
+		return "", fmt.Errorf("port must be numeric, got %q", port)
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535, got %q", port)
+	}
+
+	return parsedURL.Host, nil
 }
 
 func isExpectedSSHExit(ctx context.Context, err error) bool {

--- a/cmd/job/ssh_test.go
+++ b/cmd/job/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +28,9 @@ import (
 
 func TestCreateSSHSession(t *testing.T) {
 	t.Parallel()
+
+	hostSigner, _ := newSSHTestKey(t)
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -49,7 +54,19 @@ func TestCreateSSHSession(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"endpoint":"wss://ssh.example.test/session","access_token":"namespace-access-token","expires_at":"2026-08-12T01:02:03Z","ssh":{"username":"root","private_key":"private-key"}}`)
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"endpoint":     "wss://ssh.example.test/session",
+			"access_token": "namespace-access-token",
+			"expires_at":   "2026-08-12T01:02:03Z",
+			"transport":    "namespace_ingress",
+			"ssh": map[string]any{
+				"username":    "root",
+				"private_key": "private-key",
+				"host_keys":   []string{hostKey},
+			},
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -72,21 +89,24 @@ func TestCreateSSHSession(t *testing.T) {
 			AccessToken: "namespace-access-token",
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   "root",
 			PrivateKey: "private-key",
+			HostKeys:   []string{hostKey},
 		},
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("createSSHSession() = %#v, want %#v", got, want)
 	}
 }
 
-func TestSSHCmdHelpMentionsMacOS(t *testing.T) {
+func TestSSHCmdHelpMentionsHostedJobs(t *testing.T) {
 	t.Parallel()
 
-	if help := new(SSHCmd).Help(); !strings.Contains(help, "hosted macOS job") {
-		t.Errorf("Help() = %q, want macOS scope", help)
+	help := new(SSHCmd).Help()
+	if !strings.Contains(help, "hosted job") || strings.Contains(help, "macOS") {
+		t.Errorf("Help() = %q, want platform-neutral hosted job scope", help)
 	}
 }
 
@@ -99,6 +119,7 @@ func TestSSHSessionValidation(t *testing.T) {
 			AccessToken: "namespace-access-token",
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   "root",
 			PrivateKey: "private-key",
@@ -113,12 +134,14 @@ func TestSSHSessionValidation(t *testing.T) {
 		{name: "missing endpoint", mutate: func(s *sshSession) { s.Endpoint = "" }, want: "without an endpoint"},
 		{name: "invalid endpoint", mutate: func(s *sshSession) { s.Endpoint = "://" }, want: "invalid endpoint"},
 		{name: "insecure websocket endpoint", mutate: func(s *sshSession) { s.Endpoint = "ws://ssh.example.test/session" }, want: `must use "wss"`},
-		{name: "TCP endpoint", mutate: func(s *sshSession) { s.Endpoint = "tcp://ssh.example.test:22" }, want: `must use "wss"`},
 		{name: "missing endpoint hostname", mutate: func(s *sshSession) { s.Endpoint = "wss:///session" }, want: "without a hostname"},
 		{name: "missing access token", mutate: func(s *sshSession) { s.AccessToken = "" }, want: "without an access token"},
 		{name: "missing expiry", mutate: func(s *sshSession) { s.ExpiresAt = time.Time{} }, want: "without an expiry"},
+		{name: "missing transport", mutate: func(s *sshSession) { s.Transport = "" }, want: "without a transport"},
+		{name: "unknown transport", mutate: func(s *sshSession) { s.Transport = "carrier_pigeon" }, want: `unsupported SSH transport "carrier_pigeon"`},
 		{name: "missing username", mutate: func(s *sshSession) { s.SSH.Username = "" }, want: "without an SSH username"},
 		{name: "missing private key", mutate: func(s *sshSession) { s.SSH.PrivateKey = "" }, want: "without an SSH private key"},
+		{name: "invalid host key", mutate: func(s *sshSession) { s.SSH.HostKeys = []string{"not-a-host-key"} }, want: "invalid SSH host keys"},
 	}
 
 	for _, test := range tests {
@@ -135,7 +158,91 @@ func TestSSHSessionValidation(t *testing.T) {
 	}
 }
 
-func TestSSHCmdRun(t *testing.T) {
+func TestSSHSessionTCPURLValidation(t *testing.T) {
+	t.Parallel()
+
+	hostSigner, _ := newSSHTestKey(t)
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())))
+	valid := sshSession{
+		remoteSession: remoteSession{
+			Endpoint:  "tcp://ssh.example.test:22",
+			ExpiresAt: time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
+		},
+		Transport: sshTransportTCP,
+		SSH: sshSessionCredentials{
+			Username:   "root",
+			PrivateKey: "private-key",
+			HostKeys:   []string{hostKey},
+		},
+	}
+
+	for _, endpoint := range []string{
+		"tcp://ssh.example.test:22",
+		"tcp://127.0.0.1:2222",
+		"tcp://[2001:db8::1]:22",
+	} {
+		t.Run("valid "+endpoint, func(t *testing.T) {
+			t.Parallel()
+
+			session := valid
+			session.Endpoint = endpoint
+			if err := session.validate(); err != nil {
+				t.Fatalf("validate() error = %v, want nil", err)
+			}
+		})
+	}
+
+	for _, endpoint := range []string{
+		"ssh.example.test:22",
+		"http://ssh.example.test:22",
+		"tcp://ssh.example.test",
+		"tcp://:22",
+		"tcp://ssh.example.test:not-a-port",
+		"tcp://ssh.example.test:+22",
+		"tcp://ssh.example.test:0",
+		"tcp://ssh.example.test:65536",
+		"tcp://user@ssh.example.test:22",
+		"tcp://ssh.example.test:22/",
+		"tcp://ssh.example.test:22/path",
+		"tcp://ssh.example.test:22?token=secret",
+		"tcp://ssh.example.test:22#fragment",
+		"tcp://ssh.example.test:22#",
+	} {
+		t.Run("invalid "+endpoint, func(t *testing.T) {
+			t.Parallel()
+
+			session := valid
+			session.Endpoint = endpoint
+			err := session.validate()
+			if err == nil || !strings.Contains(err.Error(), "invalid TCP endpoint") {
+				t.Fatalf("validate() error = %v, want invalid TCP endpoint error", err)
+			}
+		})
+	}
+}
+
+func TestSSHSessionTCPRequiresHostKeys(t *testing.T) {
+	t.Parallel()
+
+	session := sshSession{
+		remoteSession: remoteSession{
+			Endpoint:  "tcp://ssh.example.test:22",
+			ExpiresAt: time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
+		},
+		Transport: sshTransportTCP,
+		SSH: sshSessionCredentials{
+			Username:   "root",
+			PrivateKey: "private-key",
+		},
+	}
+
+	err := session.validate()
+	if err == nil || !strings.Contains(err.Error(), "without SSH host keys") {
+		t.Fatalf("validate() error = %v, want missing host keys error", err)
+	}
+}
+
+func TestSSHCmdRunNamespaceIngress(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -181,6 +288,7 @@ func TestSSHCmdRun(t *testing.T) {
 			AccessToken: accessToken,
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   username,
 			PrivateKey: privateKey,
@@ -196,7 +304,7 @@ func TestSSHCmdRun(t *testing.T) {
 		Stdin:  strings.NewReader(clientData),
 		Stdout: &stdout,
 		Stderr: &stderr,
-	}, client, "buildkite", dialInsecureTestSSHEndpoint); err != nil {
+	}, client, "buildkite", dialInsecureTestSSHSession); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
 	if ctx.Err() != nil {
@@ -219,6 +327,230 @@ func TestSSHCmdRun(t *testing.T) {
 	}
 }
 
+func TestSSHCmdRunTCPWithRotatingHostKeys(t *testing.T) {
+	t.Parallel()
+
+	const (
+		accessToken = "namespace-access-token-must-not-be-sent"
+		username    = "root"
+		clientData  = "from local terminal"
+		serverData  = "from hosted Linux container"
+	)
+
+	clientSigner, privateKey := newSSHTestKey(t)
+	previousHostSigner, _ := newSSHTestKey(t)
+	currentHostSigner, _ := newSSHTestKey(t)
+	serverConfig := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if !bytes.Equal(key.Marshal(), clientSigner.PublicKey().Marshal()) {
+				return nil, errors.New("unexpected SSH public key")
+			}
+			return nil, nil
+		},
+	}
+	serverConfig.AddHostKey(currentHostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SSH: %v", err)
+	}
+	defer listener.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- fmt.Errorf("accept TCP connection: %w", err)
+			return
+		}
+		defer conn.Close()
+
+		prefix := make([]byte, 4)
+		if _, err := io.ReadFull(conn, prefix); err != nil {
+			serverErr <- fmt.Errorf("read SSH identification prefix: %w", err)
+			return
+		}
+		if got := string(prefix); got != "SSH-" {
+			serverErr <- fmt.Errorf("TCP connection started with %q, want SSH identification without access token", got)
+			return
+		}
+
+		serverErr <- serveSSHTestConnection(&prefixedConn{Conn: conn, prefix: bytes.NewReader(prefix)}, serverConfig, username, clientData, serverData)
+	}()
+
+	client := newSSHSessionTestClient(t, sshSession{
+		remoteSession: remoteSession{
+			Endpoint:    "tcp://" + listener.Addr().String(),
+			AccessToken: accessToken,
+			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
+		},
+		Transport: sshTransportTCP,
+		SSH: sshSessionCredentials{
+			Username:   username,
+			PrivateKey: privateKey,
+			HostKeys: []string{
+				strings.TrimSpace(string(ssh.MarshalAuthorizedKey(previousHostSigner.PublicKey()))),
+				strings.TrimSpace(string(ssh.MarshalAuthorizedKey(currentHostSigner.PublicKey()))),
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	cmd := SSHCmd{JobID: "job-uuid"}
+	if err := cmd.run(ctx, sshStreams{
+		Stdin:  strings.NewReader(clientData),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}, client, "buildkite"); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Error(err)
+	}
+	if got := stdout.String(); got != serverData {
+		t.Errorf("stdout = %q, want %q", got, serverData)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+	for _, secret := range []string{accessToken, privateKey} {
+		if strings.Contains(stdout.String(), secret) || strings.Contains(stderr.String(), secret) {
+			t.Errorf("command output contains SSH session material")
+		}
+	}
+}
+
+func TestSSHCmdRunTCPRejectsMismatchedHostKey(t *testing.T) {
+	t.Parallel()
+
+	_, privateKey := newSSHTestKey(t)
+	serverHostSigner, _ := newSSHTestKey(t)
+	expectedHostSigner, _ := newSSHTestKey(t)
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(serverHostSigner)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SSH: %v", err)
+	}
+	defer listener.Close()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _, _, _ = ssh.NewServerConn(conn, serverConfig)
+	}()
+
+	client := newSSHSessionTestClient(t, sshSession{
+		remoteSession: remoteSession{
+			Endpoint:  "tcp://" + listener.Addr().String(),
+			ExpiresAt: time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
+		},
+		Transport: sshTransportTCP,
+		SSH: sshSessionCredentials{
+			Username:   "root",
+			PrivateKey: privateKey,
+			HostKeys: []string{
+				strings.TrimSpace(string(ssh.MarshalAuthorizedKey(expectedHostSigner.PublicKey()))),
+			},
+		},
+	})
+
+	cmd := SSHCmd{JobID: "job-uuid"}
+	err = cmd.run(context.Background(), sshStreams{
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}, client, "buildkite")
+	if err == nil || !strings.Contains(err.Error(), "SSH host key does not match") {
+		t.Fatalf("run() error = %v, want host key mismatch", err)
+	}
+
+	select {
+	case <-serverDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SSH server did not finish after host key rejection")
+	}
+}
+
+func TestSSHCmdRunTCPRejectsInvalidHostKeysBeforeDialing(t *testing.T) {
+	t.Parallel()
+
+	_, privateKey := newSSHTestKey(t)
+	hostSigner, _ := newSSHTestKey(t)
+	hostKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())))
+	tests := []struct {
+		name     string
+		hostKeys []string
+		want     string
+	}{
+		{name: "missing", want: "without SSH host keys"},
+		{name: "malformed", hostKeys: []string{"not-a-host-key"}, want: "invalid SSH host keys"},
+		{name: "multiple keys in one entry", hostKeys: []string{hostKey + "\n" + hostKey}, want: "contains more than one public key"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := newSSHSessionTestClient(t, sshSession{
+				remoteSession: remoteSession{
+					Endpoint:  "tcp://ssh.example.test:22",
+					ExpiresAt: time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
+				},
+				Transport: sshTransportTCP,
+				SSH: sshSessionCredentials{
+					Username:   "root",
+					PrivateKey: privateKey,
+					HostKeys:   test.hostKeys,
+				},
+			})
+
+			cmd := SSHCmd{JobID: "job-uuid"}
+			err := cmd.runWithDialer(context.Background(), sshStreams{
+				Stdout: io.Discard,
+				Stderr: io.Discard,
+			}, client, "buildkite", func(context.Context, sshSession) (net.Conn, error) {
+				t.Fatal("dialer called for an invalid SSH session")
+				return nil, nil
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("run() error = %v, want error containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSSHHostKeyCallbackVerifiesKeysForNamespaceIngress(t *testing.T) {
+	t.Parallel()
+
+	trustedHostSigner, _ := newSSHTestKey(t)
+	untrustedHostSigner, _ := newSSHTestKey(t)
+	callback, err := sshHostKeyCallback(sshSession{
+		Transport: sshTransportNamespaceIngress,
+		SSH: sshSessionCredentials{HostKeys: []string{
+			strings.TrimSpace(string(ssh.MarshalAuthorizedKey(trustedHostSigner.PublicKey()))),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("sshHostKeyCallback() error = %v", err)
+	}
+
+	if err := callback("ssh.example.test", nil, trustedHostSigner.PublicKey()); err != nil {
+		t.Errorf("callback rejected trusted host key: %v", err)
+	}
+	if err := callback("ssh.example.test", nil, untrustedHostSigner.PublicKey()); err == nil {
+		t.Fatal("callback accepted untrusted host key")
+	}
+}
+
 func TestSSHCmdRunInvalidPrivateKey(t *testing.T) {
 	t.Parallel()
 
@@ -228,6 +560,7 @@ func TestSSHCmdRunInvalidPrivateKey(t *testing.T) {
 			AccessToken: "namespace-access-token",
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   "root",
 			PrivateKey: "not-a-private-key",
@@ -286,6 +619,7 @@ func TestSSHCmdRunCancellation(t *testing.T) {
 			AccessToken: accessToken,
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   "root",
 			PrivateKey: privateKey,
@@ -304,7 +638,7 @@ func TestSSHCmdRunCancellation(t *testing.T) {
 			Stdin:  stdinReader,
 			Stdout: io.Discard,
 			Stderr: io.Discard,
-		}, client, "buildkite", dialInsecureTestSSHEndpoint)
+		}, client, "buildkite", dialInsecureTestSSHSession)
 	}()
 
 	select {
@@ -363,6 +697,7 @@ func TestSSHCmdRunCancellationDuringHandshake(t *testing.T) {
 			AccessToken: accessToken,
 			ExpiresAt:   time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC),
 		},
+		Transport: sshTransportNamespaceIngress,
 		SSH: sshSessionCredentials{
 			Username:   "root",
 			PrivateKey: privateKey,
@@ -376,7 +711,7 @@ func TestSSHCmdRunCancellationDuringHandshake(t *testing.T) {
 		runErr <- cmd.runWithDialer(ctx, sshStreams{
 			Stdout: io.Discard,
 			Stderr: io.Discard,
-		}, client, "buildkite", dialInsecureTestSSHEndpoint)
+		}, client, "buildkite", dialInsecureTestSSHSession)
 	}()
 
 	select {
@@ -490,7 +825,9 @@ func newSSHSessionTestClient(t *testing.T, session sshSession) *buildkite.Client
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"endpoint":%q,"access_token":%q,"expires_at":%q,"ssh":{"username":%q,"private_key":%q}}`, session.Endpoint, session.AccessToken, session.ExpiresAt.Format(time.RFC3339), session.SSH.Username, session.SSH.PrivateKey)
+		if err := json.NewEncoder(w).Encode(session); err != nil {
+			t.Errorf("encode SSH session response: %v", err)
+		}
 	}))
 	t.Cleanup(server.Close)
 
@@ -504,14 +841,36 @@ func newSSHSessionTestClient(t *testing.T, session sshSession) *buildkite.Client
 	return client
 }
 
-func dialInsecureTestSSHEndpoint(ctx context.Context, token remoteAccessToken, endpoint string) (net.Conn, error) {
-	if !strings.HasPrefix(endpoint, "wss://") {
-		return nil, fmt.Errorf("test SSH endpoint = %q, want wss:// endpoint", endpoint)
+type prefixedConn struct {
+	net.Conn
+	prefix io.Reader
+}
+
+func (c *prefixedConn) Read(p []byte) (int, error) {
+	if c.prefix != nil {
+		n, err := c.prefix.Read(p)
+		if !errors.Is(err, io.EOF) {
+			return n, err
+		}
+		c.prefix = nil
+		if n > 0 {
+			return n, nil
+		}
+	}
+	return c.Conn.Read(p)
+}
+
+func dialInsecureTestSSHSession(ctx context.Context, session sshSession) (net.Conn, error) {
+	if session.Transport != sshTransportNamespaceIngress {
+		return nil, fmt.Errorf("test SSH transport = %q, want namespace ingress", session.Transport)
+	}
+	if !strings.HasPrefix(session.Endpoint, "wss://") {
+		return nil, fmt.Errorf("test SSH endpoint = %q, want wss:// endpoint", session.Endpoint)
 	}
 	// The API fixture advertises wss:// so the production validation is exercised.
 	// Rewrite it to ws:// only when dialing the local test server, avoiding test
 	// certificate setup while keeping plaintext WebSockets out of production.
-	return ingress.DialEndpoint(ctx, io.Discard, token, "ws://"+strings.TrimPrefix(endpoint, "wss://"))
+	return ingress.DialEndpoint(ctx, io.Discard, remoteAccessToken(session.AccessToken), "ws://"+strings.TrimPrefix(session.Endpoint, "wss://"))
 }
 
 func newSSHTestKey(t *testing.T) (ssh.Signer, string) {

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ type (
 		Log          job.LogCmd          `cmd:"" help:"Get logs for a job."`
 		Reprioritize job.ReprioritizeCmd `cmd:"" help:"Reprioritize a job." aliases:"priority"`
 		Retry        job.RetryCmd        `cmd:"" help:"Retry a job."`
-		SSH          job.SSHCmd          `cmd:"" help:"Connect to a running hosted macOS job over SSH."`
+		SSH          job.SSHCmd          `cmd:"" help:"Connect to a running hosted job over SSH."`
 		Unblock      job.UnblockCmd      `cmd:"" help:"Unblock a job."`
 		VNC          job.VNCCmd          `cmd:"" help:"Connect to a running hosted macOS job over VNC."`
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -86,8 +86,8 @@ func TestSSHCommandRegistration(t *testing.T) {
 				if subcommand.Hidden {
 					t.Error("job ssh should be visible")
 				}
-				if !strings.Contains(subcommand.Help, "hosted macOS job") {
-					t.Errorf("job ssh help = %q, want macOS scope", subcommand.Help)
+				if !strings.Contains(subcommand.Help, "hosted job") || strings.Contains(subcommand.Help, "macOS") {
+					t.Errorf("job ssh help = %q, want platform-neutral hosted job scope", subcommand.Help)
 				}
 				return
 			}

--- a/pkg/cmd/factory/factory_test.go
+++ b/pkg/cmd/factory/factory_test.go
@@ -125,8 +125,8 @@ func TestRedactBody(t *testing.T) {
 		},
 		{
 			name:  "SSH session response",
-			input: `{"endpoint":"wss://ssh.example.test/session","access_token":"namespace-secret","ssh":{"username":"root","private_key": "private-key-secret"}}`,
-			want:  `{"endpoint":"wss://ssh.example.test/session","access_token":"[REDACTED]","ssh":{"username":"root","private_key": "[REDACTED]"}}`,
+			input: `{"endpoint":"tcp://ssh.example.test:22","access_token":"namespace-secret","transport":"tcp","ssh":{"username":"root","private_key": "private-key-secret","host_keys":["ssh-ed25519 public-host-key"]}}`,
+			want:  `{"endpoint":"tcp://ssh.example.test:22","access_token":"[REDACTED]","transport":"tcp","ssh":{"username":"root","private_key": "[REDACTED]","host_keys":["ssh-ed25519 public-host-key"]}}`,
 		},
 		{
 			name:  "truncated JSON string",


### PR DESCRIPTION
### Description

Add Linux hosted-job support to `bk job ssh` using Namespace's TCP container endpoint with SSH host-key verification.

The CLI consumes the `transport` and `ssh.host_keys` fields from the existing SSH session endpoint. Raw TCP sessions require at least one valid host key and fail closed if verification cannot be performed.

Existing macOS jobs continue using authenticated Namespace WSS ingress. If host keys are supplied for ingress sessions, the CLI verifies those too.

Context: [A-1682](https://linear.app/buildkite/issue/A-1682/support-secure-bk-job-ssh-access-for-linux-jobs)

### Changes

- Handle `tcp` and `namespace_ingress` SSH transports explicitly.
- Strictly validate TCP endpoint URLs.
- Accept multiple host keys to support key rotation.
- Verify the server's presented key against the API-provided keys.
- Reject TCP sessions with missing or malformed host keys before dialing.
- Keep the Namespace access token off raw TCP connections.
- Update command help to refer to hosted jobs rather than only macOS jobs.
- Add end-to-end coverage for TCP sessions, rotated keys, mismatches, malformed responses, and existing ingress behavior.

### Deployment

Deploy the corresponding Buildkite API changes before relying on Linux SSH sessions. The CLI will fail closed if a TCP response does not include valid host keys.

### Rollback

Reverting this change restores the previous WSS-only behavior. Linux TCP sessions will be rejected, while existing macOS SSH sessions remain supported.

### Testing

- [x] Tests have run locally (`go test ./...`)
- [x] Code is formatted
- [x] Focused tests pass with the race detector
- [x] SSH tests pass across 10 repeated runs
- [x] `golangci-lint` passes
- [x] The job package cross-compiles for Windows
- [x] `govulncheck ./...` reports no called vulnerabilities

### Disclosures / Credits

Implemented with Codex. Codex gathered the linked Linear, Slack, Notion, Namespace API, and prior PR context; implemented the CLI transport and host-key verification changes; and added and ran the automated coverage. Jamie reviewed the plan, API alignment, and resulting implementation.
