### PR TITLE
Add file and stdin input to bk secret create

### DIFF
--- a/cmd/secret/create.go
+++ b/cmd/secret/create.go
@@ -3,9 +3,11 @@ package secret
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
+	"unicode/utf8"
 
 	"github.com/alecthomas/kong"
 	"github.com/buildkite/cli/v3/internal/cli"
@@ -19,7 +21,8 @@ import (
 type CreateCmd struct {
 	ClusterUUID string `help:"The UUID of the cluster" required:"" name:"cluster-uuid"`
 	Key         string `help:"The key name for the secret (e.g. MY_SECRET)" required:""`
-	Value       string `help:"The secret value. If not provided, you will be prompted to enter it." optional:""`
+	Value       string `help:"The secret value. If neither value source is provided, you will be prompted to enter it." optional:"" xor:"value-source"`
+	ValueFile   string `help:"Read the secret value from a file, or from stdin with -. Content is preserved exactly." optional:"" name:"value-file" xor:"value-source"`
 	Description string `help:"A description of the secret" optional:""`
 	Policy      string `help:"The access policy for the secret (YAML format)" optional:""`
 	output.OutputFlags
@@ -29,8 +32,12 @@ func (c *CreateCmd) Help() string {
 	return `
 Create a new secret in a cluster.
 
-If --value is not provided, you will be prompted to enter the secret value
-interactively (input will be masked).
+Use --value-file to read the value exactly as stored, including multiline content
+and any trailing LF or CRLF. Use --value-file - to read the value from stdin.
+File and stdin values must be non-empty valid UTF-8.
+
+If neither --value nor --value-file is provided, you will be prompted to enter
+the secret value interactively (input will be masked).
 
 Examples:
   # Create a secret with interactive value input
@@ -38,6 +45,12 @@ Examples:
 
   # Create a secret with the value provided inline
   $ bk secret create --cluster-uuid my-cluster-uuid --key MY_SECRET --value "s3cr3t"
+
+  # Create a secret from a file, preserving its content exactly
+  $ bk secret create --cluster-uuid my-cluster-uuid --key MY_SECRET --value-file ./secret.txt
+
+  # Create a secret from stdin (including the trailing newline from printf)
+  $ printf 'line one\nline two\n' | bk secret create --no-input --cluster-uuid my-cluster-uuid --key MY_SECRET --value-file -
 
   # Create a secret with a description
   $ bk secret create --cluster-uuid my-cluster-uuid --key MY_SECRET --description "My secret description"
@@ -59,10 +72,13 @@ func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 		return err
 	}
 
-	value := c.Value
+	value, err := resolveSecretValue(c.Value, c.ValueFile, os.Stdin)
+	if err != nil {
+		return err
+	}
 	if value == "" {
 		if f.NoInput {
-			return fmt.Errorf("--value is required when --no-input is set")
+			return fmt.Errorf("--value or --value-file is required when --no-input is set")
 		}
 		fmt.Fprint(os.Stderr, "Enter secret value: ")
 		value, err = bkIO.ReadPassword()
@@ -107,4 +123,34 @@ func (c *CreateCmd) Run(kongCtx *kong.Context, globals cli.GlobalFlags) error {
 
 	fmt.Fprintf(os.Stdout, "Secret %s created successfully\n\n", secret.Key)
 	return output.Write(os.Stdout, secretView, format)
+}
+
+func resolveSecretValue(value, valueFile string, stdin io.Reader) (string, error) {
+	if valueFile == "" {
+		return value, nil
+	}
+
+	var (
+		contents []byte
+		err      error
+		source   string
+	)
+	if valueFile == "-" {
+		contents, err = io.ReadAll(stdin)
+		source = "stdin"
+	} else {
+		contents, err = os.ReadFile(valueFile)
+		source = fmt.Sprintf("file %q", valueFile)
+	}
+	if err != nil {
+		return "", fmt.Errorf("read secret value from %s: %w", source, err)
+	}
+	if len(contents) == 0 {
+		return "", fmt.Errorf("secret value from %s cannot be empty", source)
+	}
+	if !utf8.Valid(contents) {
+		return "", fmt.Errorf("secret value from %s is not valid UTF-8", source)
+	}
+
+	return string(contents), nil
 }

--- a/cmd/secret/create_test.go
+++ b/cmd/secret/create_test.go
@@ -1,0 +1,120 @@
+package secret
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+)
+
+func TestResolveSecretValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct value", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := resolveSecretValue("s3cr3t", "", strings.NewReader("ignored"))
+		if err != nil {
+			t.Fatalf("resolveSecretValue() error = %v", err)
+		}
+		if got != "s3cr3t" {
+			t.Errorf("resolveSecretValue() = %q, want %q", got, "s3cr3t")
+		}
+	})
+
+	t.Run("file preserves multiline content and trailing newline", func(t *testing.T) {
+		t.Parallel()
+
+		want := "line one\nline two\r\n"
+		path := t.TempDir() + "/secret.txt"
+		if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := resolveSecretValue("", path, strings.NewReader(""))
+		if err != nil {
+			t.Fatalf("resolveSecretValue() error = %v", err)
+		}
+		if got != want {
+			t.Errorf("resolveSecretValue() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("stdin preserves exact content", func(t *testing.T) {
+		t.Parallel()
+
+		want := "line one\nline two\r\n"
+		got, err := resolveSecretValue("", "-", strings.NewReader(want))
+		if err != nil {
+			t.Fatalf("resolveSecretValue() error = %v", err)
+		}
+		if got != want {
+			t.Errorf("resolveSecretValue() = %q, want %q", got, want)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		contents  []byte
+		wantError string
+	}{
+		{name: "empty file", contents: nil, wantError: "cannot be empty"},
+		{name: "invalid UTF-8", contents: []byte{0xff, 0xfe}, wantError: "not valid UTF-8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := t.TempDir() + "/secret.txt"
+			if err := os.WriteFile(path, tt.contents, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := resolveSecretValue("", path, strings.NewReader(""))
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("resolveSecretValue() error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run("stdin "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveSecretValue("", "-", strings.NewReader(string(tt.contents)))
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("resolveSecretValue() error = %v, want error containing %q", err, tt.wantError)
+			}
+		})
+	}
+
+	t.Run("unreadable path", func(t *testing.T) {
+		t.Parallel()
+
+		path := t.TempDir() + "/missing"
+		_, err := resolveSecretValue("", path, strings.NewReader(""))
+		if err == nil || !strings.Contains(err.Error(), "read secret value from file") {
+			t.Fatalf("resolveSecretValue() error = %v, want file read error", err)
+		}
+	})
+}
+
+func TestCreateCmdValueSourcesAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	var cmd CreateCmd
+	parser, err := kong.New(&cmd, kong.Vars{"output_default_format": ""})
+	if err != nil {
+		t.Fatalf("kong.New() error = %v", err)
+	}
+	_, err = parser.Parse([]string{
+		"--cluster-uuid", "cluster-123",
+		"--key", "MY_SECRET",
+		"--value", "s3cr3t",
+		"--value-file", "secret.txt",
+	})
+	if err == nil {
+		t.Fatal("Parse() expected an error for --value with --value-file, got nil")
+	}
+}


### PR DESCRIPTION
### Description

Secret values currently have to be passed inline or entered interactively. Inline values can be exposed in shell history, while interactive entry is not suitable for multiline values or automation.

Add `--value-file <path>` so callers can supply a secret from a file, or use `--value-file -` to read from stdin with `--no-input`:

```console
printf 'line one\nline two\n' | bk secret create --no-input --cluster-uuid "$CLUSTER_UUID" --key MY_SECRET --value-file -
```

### Changes

- Makes `--value` and `--value-file` mutually exclusive.
- Preserves file and stdin content exactly, including trailing LF or CRLF.
- Rejects empty and invalid UTF-8 file/stdin values while preserving existing inline and interactive behavior.
- Documents file and stdin usage in command help.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

Amp implemented the change and tests, ran the repository checks, and drafted this pull request description under human direction.
