### PR TITLE
Fix preflight build with go-buildkite v5.13

### DIFF
--- a/cmd/preflight/event.go
+++ b/cmd/preflight/event.go
@@ -22,7 +22,6 @@ const (
 	// early (promised) failure, ahead of reaching a terminal state.
 	EventJobPromisedFailure EventType = "job_promised_failure"
 	EventBuildSummary       EventType = "build_summary"
-	EventTestFailure        EventType = "test_failure"
 )
 
 // Event is the single data model emitted by a preflight run.
@@ -66,9 +65,6 @@ type Event struct {
 
 	// Duration is set for build_summary events. Total elapsed time of the preflight run.
 	Duration time.Duration `json:"duration_ns,omitempty"`
-
-	// TestFailures is set for test_failure events.
-	TestFailures []buildkite.BuildTest `json:"test_failures,omitempty"`
 
 	// Tests is set for build_summary events when aggregated test summary data is available.
 	Tests internalpreflight.SummaryTests `json:"tests,omitempty"`
@@ -145,8 +141,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 
 		Duration time.Duration `json:"duration_ns,omitempty"`
 
-		TestFailures []buildkite.BuildTest           `json:"test_failures,omitempty"`
-		Tests        *internalpreflight.SummaryTests `json:"tests,omitempty"`
+		Tests *internalpreflight.SummaryTests `json:"tests,omitempty"`
 	}
 
 	var job *jsonJob
@@ -178,7 +173,6 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		FailedJobs:    newJSONJobs(e.FailedJobs),
 		PassedJobs:    newJSONJobs(e.PassedJobs),
 		Duration:      e.Duration,
-		TestFailures:  e.TestFailures,
 		Tests:         tests,
 	})
 }

--- a/cmd/preflight/preflight_test.go
+++ b/cmd/preflight/preflight_test.go
@@ -211,10 +211,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				json.NewEncoder(w).Encode(build)
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
-
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/analytics/organizations/test-org/builds/build-id-123/preflight/v1":
 				summaryRequests.Add(1)
 				if r.URL.Query().Get("include") == "latest_fail" {
@@ -614,10 +610,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				json.NewEncoder(w).Encode(build)
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
-
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/analytics/organizations/test-org/builds/build-id-123/preflight/v1":
 				summaryRequests.Add(1)
 				w.WriteHeader(http.StatusNotFound)
@@ -740,9 +732,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
 			}
 
 			http.NotFound(w, r)
@@ -849,9 +838,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				json.NewEncoder(w).Encode(build)
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
 			}
 
 			http.NotFound(w, r)
@@ -969,10 +955,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 						State: "failed",
 					}},
 				})
-				return
-
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
 				return
 
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
@@ -1105,10 +1087,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				_, _ = w.Write([]byte(`{"message":"temporary failure"}`))
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
-
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
 				json.NewEncoder(w).Encode([]buildkite.Build{{
 					ID:     "build-id-123",
@@ -1200,10 +1178,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 						State: "failed",
 					}},
 				})
-				return
-
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
 				return
 
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
@@ -1352,10 +1326,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 				})
 				return
 
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
-				return
-
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":
 				json.NewEncoder(w).Encode([]buildkite.Build{{
 					ID:     "build-id-123",
@@ -1452,10 +1422,6 @@ func TestPreflightCmd_Run(t *testing.T) {
 						State: "failed",
 					}},
 				})
-				return
-
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tests"):
-				json.NewEncoder(w).Encode([]buildkite.BuildTest{})
 				return
 
 			case r.Method == http.MethodGet && r.URL.Path == "/v2/organizations/test-org/builds":

--- a/cmd/preflight/render.go
+++ b/cmd/preflight/render.go
@@ -110,15 +110,6 @@ func (r *plainRenderer) Render(e Event) error {
 			return err
 		}
 
-	case EventTestFailure:
-		if e.TestFailures != nil {
-			presenter := testPresenter{}
-			for _, t := range e.TestFailures {
-				if _, err := fmt.Fprintf(r.stdout, "%s\n", formatTimestampedBlock(presenter.Line(t), e.Time)); err != nil {
-					return err
-				}
-			}
-		}
 	}
 	return nil
 }

--- a/cmd/preflight/render_test.go
+++ b/cmd/preflight/render_test.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"bytes"
 	"encoding/json"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -12,8 +11,6 @@ import (
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	buildkite "github.com/buildkite/go-buildkite/v5"
 )
-
-var ansiCodesPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func TestPlainRenderer_Render_Operation(t *testing.T) {
 	var out bytes.Buffer
@@ -250,44 +247,6 @@ func TestJSONRenderer_Render_JobRetryPassed(t *testing.T) {
 	}
 }
 
-func TestPlainRenderer_Render_TestFailure(t *testing.T) {
-	var out bytes.Buffer
-	r := newPlainRenderer(&out)
-
-	now := time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)
-	executionTime := buildkite.Timestamp{Time: now}
-	r.Render(Event{
-		Type: EventTestFailure,
-		Time: now,
-		TestFailures: []buildkite.BuildTest{{
-			Name:            "Test A",
-			ExecutionsCount: 1,
-			ExecutionsCountByResult: buildkite.BuildTestExecutionsCount{
-				Failed: 1,
-			},
-			Executions: []buildkite.BuildTestExecution{{
-				Status:        "failed",
-				Location:      "./spec/example_spec.rb:10",
-				FailureReason: "Failure/Error: expect(false).to eq(true)",
-				Timestamp:     &executionTime,
-			}},
-		}},
-	})
-
-	got := out.String()
-	if ansiCodesPattern.MatchString(got) {
-		t.Fatalf("expected plain output without ANSI codes, got %q", got)
-	}
-
-	indent := strings.Repeat(" ", len("10:31:00 "))
-	expected := "10:31:00 ✗ Test A\n" +
-		indent + "    1 attempt (0 passed, 1 failed) — ./spec/example_spec.rb:10\n" +
-		indent + "    Failure/Error: expect(false).to eq(true)\n"
-	if got != expected {
-		t.Fatalf("expected:\n%s\ngot:\n%s", expected, got)
-	}
-}
-
 func TestJSONRenderer_Render_Operation(t *testing.T) {
 	var out bytes.Buffer
 	r := newJSONRenderer(&out)
@@ -431,203 +390,6 @@ func TestJSONRenderer_Render_MultipleEvents_JSONL(t *testing.T) {
 			t.Fatalf("line %d: invalid JSON: %v", i, err)
 		}
 	}
-}
-
-func TestTestPresenter_Line_FailedAttemptIncludesSummaryAndFailureDetails(t *testing.T) {
-	t.Parallel()
-	older := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)}
-	newer := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)}
-
-	line := testPresenter{}.Line(buildkite.BuildTest{
-		Name:            "Pipelines::ShardMigration::DeleteOrganizationFromShardWorker with more than BATCH_SIZE records for a shard that needs cleaning",
-		Location:        "./spec/workers/pipelines/shard_migration/delete_organization_from_shard_worker_spec.rb:181",
-		ExecutionsCount: 2,
-		ExecutionsCountByResult: buildkite.BuildTestExecutionsCount{
-			Failed: 2,
-		},
-		Executions: []buildkite.BuildTestExecution{
-			{
-				Status:        "failed",
-				Location:      "./spec/workers/pipelines/shard_migration/delete_organization_from_shard_worker_spec.rb:181",
-				FailureReason: "Failure/Error: expect(empty_tables).to eq({})",
-				Timestamp:     &newer,
-			},
-			{
-				Status:        "failed",
-				Location:      "./spec/workers/pipelines/shard_migration/delete_organization_from_shard_worker_spec.rb:182",
-				FailureReason: "Failure/Error: expect(empty_tables).to eq({})",
-				Timestamp:     &older,
-			},
-		},
-	})
-
-	if ansiCodesPattern.MatchString(line) {
-		t.Fatalf("expected plain line without ANSI codes, got %q", line)
-	}
-
-	got := line
-
-	if !strings.Contains(got, "✗ Pipelines::ShardMigration::DeleteOrgan...records for a shard that needs cleaning") {
-		t.Fatalf("expected long name to preserve the start and end, got %q", got)
-	}
-	if !strings.Contains(got, "2 attempts (0 passed, 2 failed) — ./spec/workers/pipelines/shard_migration/delete_organization_from_shard_worker_spec.rb:181") {
-		t.Fatalf("expected location detail, got %q", got)
-	}
-	if !strings.Contains(got, "Failure/Error: expect(empty_tables).to eq({})") {
-		t.Fatalf("expected failure reason, got %q", got)
-	}
-	if strings.Contains(got, "BATCH_SIZE records for a shard that needs cleaning") {
-		t.Fatalf("expected long name to be truncated, got %q", got)
-	}
-}
-
-func TestFormatTestStatusIcon_UsesLatestExecution(t *testing.T) {
-	t.Parallel()
-	newest := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)}
-
-	execution := &buildkite.BuildTestExecution{Status: "passed", Timestamp: &newest}
-	icon := formatTestStatusIcon(execution, false)
-
-	if got, want := icon, "✓"; got != want {
-		t.Fatalf("icon = %q, want %q", got, want)
-	}
-}
-
-func TestFormatTestStatusIcon_NilExecution(t *testing.T) {
-	t.Parallel()
-
-	icon := formatTestStatusIcon(nil, false)
-
-	if got, want := icon, "?"; got != want {
-		t.Fatalf("icon = %q, want %q", got, want)
-	}
-}
-
-func TestTestAttemptCounts_FormatsCorrectly(t *testing.T) {
-	t.Parallel()
-
-	counts := testAttemptCounts(buildkite.BuildTest{
-		ExecutionsCount: 5,
-		ExecutionsCountByResult: buildkite.BuildTestExecutionsCount{
-			Passed: 3,
-			Failed: 2,
-		},
-		Executions: []buildkite.BuildTestExecution{{Status: "failed"}},
-	})
-
-	if got, want := counts, "5 attempts (3 passed, 2 failed)"; got != want {
-		t.Fatalf("counts = %q, want %q", got, want)
-	}
-}
-
-func TestTestPresenter_Line_PassedLatestAttemptOnlyShowsSummaryLine(t *testing.T) {
-	t.Parallel()
-	oldest := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 29, 0, 0, time.UTC)}
-	middle := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)}
-	newest := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)}
-
-	line := testPresenter{}.Line(buildkite.BuildTest{
-		Name:            "Test A",
-		Location:        "./spec/example_spec.rb:10",
-		ExecutionsCount: 3,
-		ExecutionsCountByResult: buildkite.BuildTestExecutionsCount{
-			Passed: 1,
-			Failed: 2,
-		},
-		Executions: []buildkite.BuildTestExecution{
-			{Status: "passed", Location: "./spec/example_spec.rb:10", Timestamp: &newest},
-			{Status: "failed", FailureReason: "Failure/Error: expect(false).to eq(true)", Location: "./spec/example_spec.rb:10", Timestamp: &oldest},
-			{Status: "failed", FailureReason: "Failure/Error: expect(false).to eq(true)", Location: "./spec/example_spec.rb:10", Timestamp: &middle},
-		},
-	})
-
-	if ansiCodesPattern.MatchString(line) {
-		t.Fatalf("expected plain line without ANSI codes, got %q", line)
-	}
-
-	got := line
-
-	if strings.Contains(got, "./spec/example_spec.rb:10") {
-		t.Fatalf("expected passed attempt to omit location detail, got %q", got)
-	}
-	if strings.Contains(got, "Failure/Error:") {
-		t.Fatalf("expected passed attempt to omit failure detail, got %q", got)
-	}
-}
-
-func TestLatestTestExecution_PicksNewestTimestamp(t *testing.T) {
-	t.Parallel()
-	older := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)}
-	newer := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)}
-
-	execution := latestTestExecution(buildkite.BuildTest{
-		Executions: []buildkite.BuildTestExecution{
-			{Status: "failed", Location: "./spec/example_spec.rb:11", Timestamp: &older},
-			{Status: "passed", Location: "./spec/example_spec.rb:12", Timestamp: &newer},
-			{Status: "failed", Location: "./spec/example_spec.rb:10"},
-		},
-	})
-
-	if execution == nil {
-		t.Fatal("expected execution to be present")
-		return
-	}
-	if got, want := execution.Status, "passed"; got != want {
-		t.Fatalf("status = %q, want %q", got, want)
-	}
-	if got, want := execution.Location, "./spec/example_spec.rb:12"; got != want {
-		t.Fatalf("location = %q, want %q", got, want)
-	}
-}
-
-func TestLatestTestExecution_IgnoresExecutionsWithoutTimestamps(t *testing.T) {
-	t.Parallel()
-
-	execution := latestTestExecution(buildkite.BuildTest{
-		Executions: []buildkite.BuildTestExecution{
-			{Status: "failed", Location: "./spec/example_spec.rb:10"},
-			{Status: "passed", Location: "./spec/example_spec.rb:11"},
-		},
-	})
-
-	if execution != nil {
-		t.Fatalf("expected nil execution, got %#v", execution)
-	}
-}
-
-func TestTestPresenter_ColoredLine_AddsANSIStyles(t *testing.T) {
-	t.Parallel()
-	executionTime := buildkite.Timestamp{Time: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC)}
-
-	line := testPresenter{}.ColoredLine(buildkite.BuildTest{
-		Name:            "Test A",
-		ExecutionsCount: 1,
-		ExecutionsCountByResult: buildkite.BuildTestExecutionsCount{
-			Failed: 1,
-		},
-		Executions: []buildkite.BuildTestExecution{{
-			Status:        "failed",
-			Location:      "./spec/example_spec.rb:10",
-			FailureReason: "Failure/Error: expect(false).to eq(true)",
-			Timestamp:     &executionTime,
-		}},
-	})
-
-	if !ansiCodesPattern.MatchString(line) {
-		t.Fatalf("expected colored line with ANSI codes, got %q", line)
-	}
-
-	got := stripANSI(line)
-	if !strings.Contains(got, "✗ Test A") {
-		t.Fatalf("expected colored line to preserve headline text content, got %q", got)
-	}
-	if !strings.Contains(got, "1 attempt (0 passed, 1 failed) — ./spec/example_spec.rb:10") {
-		t.Fatalf("expected colored line to preserve text content, got %q", got)
-	}
-}
-
-func stripANSI(s string) string {
-	return ansiCodesPattern.ReplaceAllString(s, "")
 }
 
 func TestNewRenderer_NonFileWriterDefaultsToPlain(t *testing.T) {

--- a/cmd/preflight/test_presenter.go
+++ b/cmd/preflight/test_presenter.go
@@ -2,14 +2,11 @@ package preflight
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	internalpreflight "github.com/buildkite/cli/v3/internal/preflight"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
-
-	buildkite "github.com/buildkite/go-buildkite/v5"
 )
 
 type testPresenter struct{}
@@ -19,14 +16,6 @@ type summarySuiteColumnWidths struct {
 	Failed  int
 	Passed  int
 	Skipped int
-}
-
-func (p testPresenter) Line(t buildkite.BuildTest) string {
-	return p.line(t, false)
-}
-
-func (p testPresenter) ColoredLine(t buildkite.BuildTest) string {
-	return p.line(t, true)
 }
 
 func (p testPresenter) SummarySuiteLine(summary internalpreflight.SummaryTestRun, widths summarySuiteColumnWidths) string {
@@ -89,131 +78,6 @@ func (p testPresenter) SummaryFailureLine(failure internalpreflight.SummaryTestF
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-func (p testPresenter) line(t buildkite.BuildTest, colored bool) string {
-	name := t.Name
-	if t.Scope != "" {
-		name = t.Scope + " " + name
-	}
-	name = truncateToWidth(name, 80)
-
-	latestExecution := latestTestExecution(t)
-
-	statusIcon := formatTestStatusIcon(latestExecution, colored)
-	line := fmt.Sprintf("%s %s", statusIcon, name)
-
-	if !isFailedTestExecution(latestExecution) {
-		return line
-	}
-
-	detailParts := make([]string, 0, 2)
-	if attemptSummary := testAttemptCounts(t); attemptSummary != "" {
-		detailParts = append(detailParts, attemptSummary)
-	}
-	if location := latestExecution.Location; location != "" {
-		detailParts = append(detailParts, location)
-	} else if t.Location != "" {
-		detailParts = append(detailParts, t.Location)
-	}
-	if len(detailParts) > 0 {
-		line += fmt.Sprintf("\n    %s", formatTestDetail(strings.Join(detailParts, " — "), colored))
-	}
-
-	if latestExecution.FailureReason != "" {
-		line += fmt.Sprintf("\n    %s", formatTestDetail(latestExecution.FailureReason, colored))
-	}
-
-	return line
-}
-
-func testAttemptCounts(t buildkite.BuildTest) string {
-	attempts := t.ExecutionsCount
-	if attempts == 0 {
-		return ""
-	}
-
-	passed := t.ExecutionsCountByResult.Passed
-	failed := t.ExecutionsCountByResult.Failed
-	return fmt.Sprintf("%d %s (%d passed, %d failed)", attempts, plural(attempts, "attempt"), passed, failed)
-}
-
-func latestTestExecution(t buildkite.BuildTest) *buildkite.BuildTestExecution {
-	executions := testExecutionsInTimestampOrder(t.Executions)
-	if len(executions) == 0 {
-		return nil
-	}
-
-	latest := executions[len(executions)-1]
-	if latest.Timestamp == nil {
-		return nil
-	}
-
-	return &latest
-}
-
-func testExecutionsInTimestampOrder(executions []buildkite.BuildTestExecution) []buildkite.BuildTestExecution {
-	ordered := append([]buildkite.BuildTestExecution(nil), executions...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		left := ordered[i]
-		right := ordered[j]
-
-		switch {
-		case left.Timestamp == nil && right.Timestamp == nil:
-			return false
-		case left.Timestamp == nil:
-			return true
-		case right.Timestamp == nil:
-			return false
-		default:
-			return left.Timestamp.Before(right.Timestamp.Time)
-		}
-	})
-
-	return ordered
-}
-
-func isFailedTestExecution(execution *buildkite.BuildTestExecution) bool {
-	if execution == nil {
-		return false
-	}
-
-	return strings.EqualFold(execution.Status, "failed")
-}
-
-func formatTestDetail(text string, colored bool) string {
-	if !colored {
-		return text
-	}
-
-	return "\033[2m" + text + "\033[0m"
-}
-
-func formatTestStatusIcon(execution *buildkite.BuildTestExecution, colored bool) string {
-	status := ""
-	if execution != nil {
-		status = execution.Status
-	}
-
-	if !colored {
-		switch {
-		case strings.EqualFold(status, "passed"):
-			return "✓"
-		case strings.EqualFold(status, "failed"):
-			return "✗"
-		default:
-			return "?"
-		}
-	}
-
-	switch {
-	case strings.EqualFold(status, "passed"):
-		return "\033[32m✓\033[0m"
-	case strings.EqualFold(status, "failed"):
-		return "\033[31m✗\033[0m"
-	default:
-		return "\033[2m?\033[0m"
-	}
 }
 
 func truncateToWidth(s string, width int) string {

--- a/cmd/preflight/tty.go
+++ b/cmd/preflight/tty.go
@@ -98,16 +98,6 @@ func (m ttyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tea.Quit,
 			)
 
-		case EventTestFailure:
-			if len(msg.TestFailures) > 0 {
-				presenter := testPresenter{}
-				var cmds []tea.Cmd
-				for _, t := range msg.TestFailures {
-					line := formatTimestampedBlock(presenter.ColoredLine(t), msg.Time)
-					cmds = append(cmds, tea.Printf("%s", m.hardwrapLine(line)))
-				}
-				return m, tea.Batch(cmds...)
-			}
 		}
 
 	case tea.WindowSizeMsg:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	github.com/buildkite/go-buildkite/v5 v5.12.0
+	github.com/buildkite/go-buildkite/v5 v5.13.0
 	github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -15,7 +15,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jpillora/chisel v1.11.8
+	github.com/jpillora/chisel v1.12.0
 	github.com/mcncl/terminal-to-llm v0.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/posthog/posthog-go v1.24.3
@@ -43,6 +43,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildkite/go-buildkite/v5 v5.12.0 h1:Ly+F5Yu3pEyjerCu6S5PGhc3irhOJXVVpewMBKN0QBk=
-github.com/buildkite/go-buildkite/v5 v5.12.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.13.0 h1:4vdLuZLW/hhP5RgM0FJO+p0dZKOtKA8CjNAFKU6uDFI=
+github.com/buildkite/go-buildkite/v5 v5.13.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/buildkite/termoji v0.0.0-20260330080310-c0aa4ebee0d1 h1:aaEl0QZURcwC+KOfFTzSp66xknw5eTmFZ1NgB87s2xk=
@@ -78,6 +78,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
@@ -113,8 +115,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jpillora/chisel v1.11.8 h1:pf2ufs2kfytmSWkZoeEgSs5pGrn9ODL2UaZRiR/meyk=
-github.com/jpillora/chisel v1.11.8/go.mod h1:efqW+iikEM4E7CxQSR1LW1oyErlZtWXC/R81C/Fzk2w=
+github.com/jpillora/chisel v1.12.0 h1:dSbh+gzYF8PWj7aWIRDB48ntSIkrFAWEYNhbsl/XOCg=
+github.com/jpillora/chisel v1.12.0/go.mod h1:HbVSQorRhEvKNesMuOT51r+REHn6Zp6V4XQc2AJrEvA=
 github.com/jpillora/sizestr v1.0.0 h1:4tr0FLxs1Mtq3TnsLDV+GYUWG7Q26a6s+tV5Zfw2ygw=
 github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mzD+MZ33f0=
 github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=


### PR DESCRIPTION
### Description

The go-buildkite v5.13 upgrade removes the `BuildTest` execution-detail types, causing the preflight package to stop compiling. The only remaining users belonged to the in-progress test-failure event path, which has not been emitted since preflight switched to its final test summary.

### Changes

Remove the unreachable test-failure event rendering path, its obsolete API mocks, and its tests. The active final preflight test summary remains unchanged.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `mise run format`)
- [x] `mise run lint`
- [x] `mise run vulncheck`

### Disclosures / Credits

Amp diagnosed and implemented the fix, ran the verification checks, and used Amp's Oracle to review the complete change set.

Related: https://github.com/buildkite/cli/pull/973
