### PR TITLE
fix(deps): update golang.org/x/crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ go run main.go --help
 ```
 
 `mise.toml` pins the shared toolchain, including the release helpers used in
-CI. The module itself remains compatible with Go `1.25.0` as declared in
+CI. The module itself remains compatible with Go `1.26.0` as declared in
 `go.mod`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/cli/v3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.16.1
@@ -92,7 +92,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/suessflorian/gqlfetch v0.7.0
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cma
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=


### PR DESCRIPTION
### Description

Updates `golang.org/x/crypto` to v0.56.0 to remediate [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) and [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355), which affect the CLI's SSH client path. Because v0.56.0 requires Go 1.26, this also aligns the module minimum with the repository's existing Go 1.26.6 toolchain.

Go 1.25 was EOL'd 19th August 2026.

### Changes

- Upgrade `golang.org/x/crypto` from v0.55.0 to v0.56.0.
- Raise the module's minimum Go version from 1.25 to 1.26.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

`mise run vulncheck`, `mise run lint`, and `go mod verify` also pass.

### Disclosures / Credits

Amp diagnosed the linked Buildkite failure, prepared the dependency update, and ran the verification commands under Ash McKenzie's direction.
