### PR TITLE
Respect organization environment variable in bk configure

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ConfigureCmd struct {
-	Org     string              `help:"Organization slug" optional:""`
+	Org     string              `help:"Organization slug" optional:"" env:"BUILDKITE_ORGANIZATION_SLUG"`
 	Token   string              `help:"API token" optional:""`
 	Force   bool                `help:"Force setting a new token" optional:""`
 	Default ConfigureDefaultCmd `cmd:"" optional:"" help:"Configure Buildkite API token" hidden:"" default:"1"`

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -1,13 +1,72 @@
 package configure
 
 import (
+	"os"
 	"testing"
 
+	"github.com/alecthomas/kong"
+	"github.com/buildkite/cli/v3/internal/cli"
 	"github.com/buildkite/cli/v3/internal/config"
 	"github.com/buildkite/cli/v3/pkg/cmd/factory"
 	"github.com/buildkite/cli/v3/pkg/keyring"
 	"github.com/spf13/afero"
 )
+
+func TestConfigureOrganizationEnvironment(t *testing.T) {
+	for _, command := range [][]string{{"configure"}, {"configure", "add"}} {
+		for _, override := range []string{"", "flag-org"} {
+			t.Run(command[len(command)-1]+"/"+override, func(t *testing.T) {
+				t.Chdir(t.TempDir())
+				t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+				t.Setenv("BUILDKITE_API_TOKEN", "")
+				t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "env-Org")
+				keyring.MockForTesting()
+
+				// An ignored organization must fail rather than wait for terminal input.
+				stdin, err := os.Open(os.DevNull)
+				if err != nil {
+					t.Fatal(err)
+				}
+				oldStdin := os.Stdin
+				os.Stdin = stdin
+				t.Cleanup(func() {
+					os.Stdin = oldStdin
+					stdin.Close()
+				})
+
+				var app struct {
+					Configure ConfigureCmd `cmd:""`
+				}
+				parser, err := kong.New(&app)
+				if err != nil {
+					t.Fatal(err)
+				}
+				args := append(append([]string{}, command...), "--token", "test-token")
+				wantOrg := "env-Org"
+				if override != "" {
+					args = append(args, "--org", override)
+					wantOrg = override
+				}
+				ctx, err := parser.Parse(args)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := app.Configure.Run(ctx, cli.Globals{}); err != nil {
+					t.Fatalf("configure failed: %v", err)
+				}
+				token, err := keyring.New().Get(wantOrg)
+				if err != nil || token != "test-token" {
+					t.Fatalf("token for %q = %q, %v; want test-token", wantOrg, token, err)
+				}
+				// Clear the env override to verify the persisted organization.
+				t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "")
+				if got := config.New(afero.NewOsFs(), nil).OrganizationSlug(); got != wantOrg {
+					t.Fatalf("persisted organization = %q, want %q", got, wantOrg)
+				}
+			})
+		}
+	}
+}
 
 func TestGetTokenForOrg(t *testing.T) {
 	t.Run("returns empty string when no token exists", func(t *testing.T) {


### PR DESCRIPTION
### Description

`BUILDKITE_ORGANIZATION_SLUG=sj26-new-1 bk configure` asks for an organization that was already supplied. Bind the organization flag to that environment variable so `configure` and `configure add` skip the redundant prompt. Explicit `--org` takes precedence; without either input, the organization prompt remains.

The binding also allows the environment-provided organization to be used with `--token`, and documents the variable in command help.

### Testing
- [x] Tests have run locally (`go test ./...`, with organization/token env cleared as in CI)
- [x] Code is formatted (`mise run format`)
- `mise run lint`: 0 issues.
- Regression tests fail before the fix and pass after it; verify both commands, flag precedence, credential storage, and persisted organization.
- Built CLI confirms env-only invocation reaches the token prompt and missing env still reaches the organization prompt.

### Disclosures / Credits

Amp implemented the fix, regression tests, and validation.