### PR TITLE
fix(pipeline): preserve casing when normalizing org/pipeline slugs

### DIFF
--- a/internal/pipeline/resolver/cli.go
+++ b/internal/pipeline/resolver/cli.go
@@ -66,10 +66,11 @@ func parsePipelineArg(arg string, conf *config.Config) (org, pipeline string) {
 	return normalizeSlug(org), normalizeSlug(pipeline)
 }
 
-// normalizeSlug converts user input to a valid Buildkite slug. Slugs may only contain
-// lowercase letters, numbers and dashes, so this is a no-op on anything already valid.
-// It allows passing a name like "my_pipeline" (eg. from a repository directory name)
-// and matching the "my-pipeline" slug Buildkite derives from it.
+// normalizeSlug converts user input to a valid Buildkite slug. Slugs may contain
+// letters (of any case), numbers and dashes, so this is a no-op on anything already
+// valid. It allows passing a name like "my_pipeline" (eg. from a repository directory
+// name) and matching the "my-pipeline" slug Buildkite derives from it. Casing is
+// preserved since Buildkite organization and pipeline slugs may be mixed case.
 func normalizeSlug(s string) string {
-	return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+	return strings.ReplaceAll(s, "_", "-")
 }

--- a/internal/pipeline/resolver/cli_test.go
+++ b/internal/pipeline/resolver/cli_test.go
@@ -35,10 +35,10 @@ func TestParsePipelineArg(t *testing.T) {
 			org:      "testing",
 			pipeline: "shared-gem",
 		},
-		"uppercase_normalized_to_lowercase": {
+		"casing_preserved": {
 			url:      "My_Org/Shared_Gem",
-			org:      "my-org",
-			pipeline: "shared-gem",
+			org:      "My-Org",
+			pipeline: "Shared-Gem",
 		},
 	}
 

--- a/internal/pipeline/resolver/resolver_test.go
+++ b/internal/pipeline/resolver/resolver_test.go
@@ -88,8 +88,8 @@ func TestWithOrg(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if p.Org != "override-org" {
-			t.Fatalf("expected org override-org, got %s", p.Org)
+		if p.Org != "Override-Org" {
+			t.Fatalf("expected org Override-Org, got %s", p.Org)
 		}
 	})
 }


### PR DESCRIPTION
### Description

`bk pipeline view`, `bk pipeline copy`, `bk job list --pipeline`, and `bk artifacts list --pipeline` all fail with `404 No organization found` for organizations with mixed-case slugs (e.g. `AcmeCorp`), because `normalizeSlug` in `internal/pipeline/resolver/cli.go` lowercases org and pipeline slugs parsed from `org/pipeline` args, `--pipeline`, and `--org`.

This is a resurgence of #424 / #685. #686 only fixed the validation regex that rejected mixed-case slugs — it didn't touch `normalizeSlug`, which still forces lowercase.

Fixes #985

### Changes

- `normalizeSlug` no longer lowercases input; it still converts underscores to hyphens (for repo-directory-derived names like `my_pipeline`).
- Updated the existing `cli_test.go` and `resolver_test.go` cases that asserted lowercasing, since mixed-case slugs are valid on Buildkite and should now be preserved.

### Testing
- [x] Tests have run locally (with `go test ./...`)
- [x] Code is formatted (with `go fmt ./...`)

### Disclosures / Credits

I used an AI coding assistant (Claude, via the Pi agent harness) to investigate the bug, trace it to `normalizeSlug`, and implement this fix and the corresponding test updates. I reviewed and directed the change.
